### PR TITLE
Changing objectToClassnames to return array

### DIFF
--- a/packages/ui-components/src/utils/README.md
+++ b/packages/ui-components/src/utils/README.md
@@ -2,7 +2,7 @@
 
 ## `objectToClassnames(object, delimiter?)`
 
-`objectToClassnames` takes an object of strings and joins its keys and values using a provided delimiter (`-` by default) returning a single joined string. The base case here is to take a config object for creating CSS classnames.
+`objectToClassnames` takes an object of strings and joins its keys and values using a provided delimiter (`-` by default) returning an array of strings; The base case here is to take a config object for creating CSS classnames.
 
 ```javascript
 import { objectToClassnames } from "utils";
@@ -13,7 +13,7 @@ const properties = {
 };
 
 const classnames = objectToClassnames(properties);
-// classnames = "tint-exubrant size-medium"
+// classnames = ["tint-exubrant", "size-medium"]
 ```
 
 ## Params
@@ -35,7 +35,7 @@ const obj = {
 };
 
 const classnames = objectToClassnames(obj, "(ಠ_ಠ)");
-// classnames is "foo(ಠ_ಠ)bar baz(ಠ_ಠ)bim"
+// classnames is ["foo(ಠ_ಠ)bar", "baz(ಠ_ಠ)bim"]
 ```
 
 This prop is **optional**.

--- a/packages/ui-components/src/utils/objectToClassnames.test.ts
+++ b/packages/ui-components/src/utils/objectToClassnames.test.ts
@@ -5,9 +5,18 @@ describe("objectToClassnames", () => {
     expect(typeof objectToClassnames).toBe("function");
   });
 
-  test("should return a className string for a given prop", () => {
+  test("should return an array", () => {
+    const className = objectToClassnames({
+      foo: "bar",
+      baz: "bim",
+      boof: "boof",
+    });
+    expect(Array.isArray(className)).toBe(true);
+  });
+
+  test("should return a className array for a given prop", () => {
     const className = objectToClassnames({ foo: "bar" });
-    expect(className).toBe("foo-bar");
+    expect(className).toStrictEqual(["foo-bar"]);
   });
 
   test("should return a className string for several props", () => {

--- a/packages/ui-components/src/utils/objectToClassnames.ts
+++ b/packages/ui-components/src/utils/objectToClassnames.ts
@@ -4,9 +4,10 @@
 const objectToClassNames = (
   obj: { [key: string]: string },
   delimiter = "-",
-): string =>
-  Object.keys(obj)
-    .reduce((acc, key) => [`${key}${delimiter}${obj[key]}`, ...acc], [])
-    .join(" ");
+): string[] =>
+  Object.keys(obj).reduce(
+    (acc, key) => [`${key}${delimiter}${obj[key]}`, ...acc],
+    [],
+  );
 
 export default objectToClassNames;


### PR DESCRIPTION
Due to the fact that we are using the bind version of classnames
(https://github.com/JedWatson/classnames#alternate-bind-version-for-css-modules)
a array of strings is required rather than a concatinated string of
classnames.