### PR TITLE
Add publishConfig so publishing scoped packages doesn't fail

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -30,5 +30,8 @@
     "eslint-plugin-react": "^7.16.0",
     "eslint-plugin-react-hooks": "^2.3.0",
     "typescript": ">=2.8.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
In order to publish scoped packages, access must be set to public.

See https://github.com/lerna/lerna/tree/master/commands/publish#per-package-configuration for more details.