### PR TITLE
Override ts lint rule to allow empty arrow functions

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -37,6 +37,10 @@ module.exports = {
         "react/prop-types": "off",
         "@typescript-eslint/explicit-function-return-type": "off",
         "react/display-name": "off",
+        "@typescript-eslint/no-empty-function": [
+          "error",
+          { allow: ["arrowFunctions"] },
+        ],
       },
     },
   ],


### PR DESCRIPTION
Allow `() => {}` which is commonly used in tests.

I think this behavior changed in:
https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/CHANGELOG.md#2100-2019-12-02

Fixes: https://teamcity.cockroachdb.com/buildConfiguration/Internal_ManagedService_GitHubCiLint/1760914?buildTab=log&focusLine=3&linesState=352