### PR TITLE
Incorrect yarn install switch

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "lerna": "^3.20.2"
   },
   "scripts": {
-    "init": "yarn install --no-lockfile && lerna bootstrap --force-local && lerna link",
+    "init": "yarn install --pure-lockfile && lerna bootstrap --force-local && lerna link",
     "start": "lerna run start --parallel"
   }
 }


### PR DESCRIPTION
I had previously used `--no-lockfile` thinking that it would install but
not generate a new lockfile, but the correct switch for that behavior is
`--pure-lockfile`. This switch will read from the lockfile without
generating updates.