### PR TITLE
ui-components: Publish to NPM registry with Github actions

### DIFF
--- a/.github/workflows/publish-ui-components.yml
+++ b/.github/workflows/publish-ui-components.yml
@@ -1,0 +1,51 @@
+name: Publish ui-components to NPM Registry
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'packages/ui-components/**'
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Install dependencies
+        run: yarn install
+        working-directory: ./packages/ui-components
+      - name: Test
+        run: yarn ci
+        working-directory: ./packages/ui-components
+  publish:
+    runs-on: ubuntu-latest
+    needs: test
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install dependencies
+        run: yarn install
+        working-directory: ./packages/ui-components
+      - name: Configure Git User
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "<>"
+      - name: Bump version (prerelease)
+        run: |
+          yarn version --prerelease
+          git push --all
+        working-directory: ./packages/ui-components
+      - name: Publish ui-components
+        run: yarn publish --access public
+        working-directory: ./packages/ui-components
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.YARN_TOKEN }}


### PR DESCRIPTION
Publishing to NPM registry is a multistep action with the following steps:
- run tests to ensure build is healthy;
- bump package with a new version, it creates a new commit in "master" branch and a tag for the new version
- push these changes (in "master" branch and tag)
- and finally publish to NPM

This action requires NPM Access Token to publish packages.
Token has to be set in secrets as YARN_TOKEN.

Note:
- extra commit is pushed to "master" branch in order to increment the version.
- commit is created under user name (who initiated this action) and with
empty ("<>") email because action context doesn't provide such information.