### PR TITLE
ui-components // FuzzyTime Component

### DIFF
--- a/packages/storybook-ui-components/layout/Label.tsx
+++ b/packages/storybook-ui-components/layout/Label.tsx
@@ -1,0 +1,9 @@
+import React, { FunctionComponent } from "react";
+
+const Label: FunctionComponent<{ children: string }> = ({ children }) => (
+  <div style={{ marginBottom: "1rem" }}>
+    <code>{children}</code>
+  </div>
+);
+
+export default Label;

--- a/packages/storybook-ui-components/layout/Sample.tsx
+++ b/packages/storybook-ui-components/layout/Sample.tsx
@@ -1,0 +1,7 @@
+import React, { FunctionComponent, ReactNode } from "react";
+
+const Sample: FunctionComponent<{ children: ReactNode }> = ({ children }) => (
+  <div style={{ margin: "0rem 1rem", textAlign: "center" }}>{children}</div>
+);
+
+export default Sample;

--- a/packages/storybook-ui-components/layout/index.ts
+++ b/packages/storybook-ui-components/layout/index.ts
@@ -1,2 +1,4 @@
 export { default as StoryContainer } from "./StoryContainer";
 export { default as StoryDescription } from "./StoryDescription";
+export { default as Sample } from "./Sample";
+export { default as Label } from "./Label";

--- a/packages/storybook-ui-components/stories/FuzzyTime.stories.tsx
+++ b/packages/storybook-ui-components/stories/FuzzyTime.stories.tsx
@@ -1,0 +1,107 @@
+import React, { FunctionComponent, ReactNode } from "react";
+import { withKnobs, text } from "@storybook/addon-knobs";
+import { FuzzyTime } from "@cockroachlabs/ui-components";
+import { StoryContainer, StoryDescription, Label, Sample } from "../layout";
+
+export default {
+  title: "FuzzyTime",
+  components: FuzzyTime,
+  decorators: [withKnobs],
+};
+
+// timestamp samples
+const aFewSecondsAgo = new Date(Date.now() - 3000);
+const aCoupleMinutesAgo = new Date(Date.now() - 1000 * 60 * 2);
+const someHoursAgo = new Date(Date.now() - 1000 * 60 * 60 * 6);
+const manyDaysAgo = new Date(Date.now() - 1000 * 60 * 60 * 24 * 17);
+const monthsAgo = new Date(Date.now() - 1000 * 60 * 60 * 24 * 30 * 5);
+const now = new Date();
+const theFuture = new Date(Date.now() + 31104000000);
+
+const FuzzySample: FunctionComponent<{
+  children: ReactNode;
+}> = ({ children }) => (
+  <section
+    style={{
+      display: "flex",
+      justifyContent: "flex-start",
+      marginBottom: "2rem",
+    }}
+  >
+    {children}
+  </section>
+);
+
+export const Example = () => (
+  <StoryContainer>
+    <h1>FuzzyTime</h1>
+
+    <StoryDescription>
+      Fuzzy time takes a date string as a prop and renders and human readable
+      time difference
+    </StoryDescription>
+
+    <section>
+      <h3>TimeStamp</h3>
+      <FuzzySample>
+        <Sample>
+          <Label>
+            {`${aFewSecondsAgo.toDateString()}
+              ${aFewSecondsAgo.toLocaleTimeString()}`}
+          </Label>
+          <FuzzyTime timestamp={aFewSecondsAgo.toLocaleString()} />
+        </Sample>
+        <Sample>
+          <Label>
+            {`${aCoupleMinutesAgo.toDateString()}
+              ${aCoupleMinutesAgo.toLocaleTimeString()}`}
+          </Label>
+          <FuzzyTime timestamp={aCoupleMinutesAgo.toLocaleTimeString()} />
+        </Sample>
+        <Sample>
+          <Label>
+            {`${someHoursAgo.toDateString()}
+              ${someHoursAgo.toLocaleTimeString()}`}
+          </Label>
+          <FuzzyTime timestamp={someHoursAgo.toLocaleTimeString()} />
+        </Sample>
+        <Sample>
+          <Label>
+            {`${manyDaysAgo.toDateString()}
+              ${manyDaysAgo.toLocaleTimeString()}`}
+          </Label>
+          <FuzzyTime timestamp={manyDaysAgo} />
+        </Sample>
+        <Sample>
+          <Label>
+            {`${monthsAgo.toDateString()}
+              ${monthsAgo.toLocaleTimeString()}`}
+          </Label>
+          <FuzzyTime timestamp={monthsAgo} />
+        </Sample>
+      </FuzzySample>
+      <FuzzySample>
+        <Sample>
+          <Label>
+            {`${now.toDateString()}
+              ${now.toLocaleTimeString()}`}
+          </Label>
+          <FuzzyTime timestamp={now} />
+        </Sample>
+        <Sample>
+          <Label>
+            {`${theFuture.toDateString()}
+              ${theFuture.toLocaleTimeString()}`}
+          </Label>
+          <FuzzyTime timestamp={theFuture} />
+        </Sample>
+      </FuzzySample>
+    </section>
+  </StoryContainer>
+);
+
+export const Demo = () => (
+  <StoryContainer>
+    <FuzzyTime timestamp={text("Timestamp", "15 MAR 2020 00:00:00")} />
+  </StoryContainer>
+);

--- a/packages/ui-components/src/FuzzyTime/FuzzyTime.module.scss
+++ b/packages/ui-components/src/FuzzyTime/FuzzyTime.module.scss
@@ -1,0 +1,7 @@
+@import "../styles/tokens.scss";
+
+.fuzzy-time {
+  font-size: 0.75rem;
+  line-height: 1.25rem;
+  letter-spacing: 0.01875rem;
+}

--- a/packages/ui-components/src/FuzzyTime/FuzzyTime.test.ts
+++ b/packages/ui-components/src/FuzzyTime/FuzzyTime.test.ts
@@ -1,0 +1,3 @@
+test("stub", () => {
+  expect(true).toBe(true);
+});

--- a/packages/ui-components/src/FuzzyTime/FuzzyTime.tsx
+++ b/packages/ui-components/src/FuzzyTime/FuzzyTime.tsx
@@ -1,0 +1,20 @@
+import React, { FunctionComponent } from "React";
+import classnames from "classnames/bind";
+
+import { fuzzy } from "./util";
+import styles from "./FuzzyTime.module.scss";
+
+export interface FuzzyTimeProps {
+  timestamp: string | Date;
+}
+
+const cx = classnames.bind(styles);
+
+export const FuzzyTime: FunctionComponent<FuzzyTimeProps> = ({ timestamp }) => {
+  const timeago = fuzzy(new Date(timestamp));
+  const classnames = cx("fuzzy-time");
+
+  return <span className={classnames}>{timeago}</span>;
+};
+
+export default FuzzyTime;

--- a/packages/ui-components/src/FuzzyTime/constants.ts
+++ b/packages/ui-components/src/FuzzyTime/constants.ts
@@ -1,0 +1,6 @@
+export const aSecond = 1000;
+export const aMinute = aSecond * 60;
+export const anHour = aMinute * 60;
+export const aDay = anHour * 24;
+export const aMonth = aDay * 30;
+export const aYear = aDay * 365;

--- a/packages/ui-components/src/FuzzyTime/util.ts
+++ b/packages/ui-components/src/FuzzyTime/util.ts
@@ -1,0 +1,76 @@
+import { aYear, aMonth, aDay, anHour, aMinute, aSecond } from "./constants";
+
+export type TimeUnit = {
+  amount: number;
+  comparator: (x: number) => boolean;
+  template: (d: number) => string;
+};
+
+export const gteq = (x: number, y: number): boolean => x >= y;
+export const lt = (x: number, y: number): boolean => x < y;
+export const compare = (fn: Function) => (y: number) => (x: number) => fn(x, y);
+export const gteqUnit = compare(gteq);
+export const gteqZero = compare(gteq)(0);
+export const ltZero = compare(lt)(0);
+
+export const pastTemplate = (duration: number, label: string) =>
+  `${duration} ${label}${duration > 1 ? "s" : ""} ago`;
+
+export const TimeUnits = [
+  {
+    amount: aYear,
+    comparator: gteqUnit(aYear),
+    template: (d: number) => pastTemplate(d, "year"),
+  },
+  {
+    amount: aMonth,
+    comparator: gteqUnit(aMonth),
+    template: (d: number) => pastTemplate(d, "month"),
+  },
+  {
+    amount: aDay,
+    comparator: gteqUnit(aDay),
+    template: (d: number) => pastTemplate(d, "day"),
+  },
+  {
+    amount: anHour,
+    comparator: gteqUnit(anHour),
+    template: (d: number) => pastTemplate(d, "hour"),
+  },
+  {
+    amount: aMinute,
+    comparator: gteqUnit(aMinute),
+    template: (d: number) => pastTemplate(d, "min"),
+  },
+  {
+    amount: aSecond,
+    comparator: gteqUnit(aSecond),
+    template: (d: number) => pastTemplate(d, "sec"),
+  },
+  {
+    amount: 1,
+    comparator: (x: number) => x >= 0,
+    template: () => "just now",
+  },
+  {
+    label: "the future",
+    amount: 1,
+    comparator: (x: number) => x < 0,
+    template: () => "the future",
+  },
+];
+
+export const fuzzyFormatter = (offset: number) => (unit: TimeUnit) => {
+  const duration = Math.floor(offset / unit.amount);
+  return unit.template(duration);
+};
+
+export const setFuzzy = (now: Date) => (timedate: Date) => {
+  const diff = now.getTime() - timedate.getTime();
+  const format = fuzzyFormatter(diff);
+  const unit = TimeUnits.find(t => t.comparator(diff));
+
+  return format(unit);
+};
+
+export const fuzzy = (d: Date) => setFuzzy(new Date())(d);

--- a/packages/ui-components/src/FuzzyTime/util.ts
+++ b/packages/ui-components/src/FuzzyTime/util.ts
@@ -49,13 +49,13 @@ export const TimeUnits = [
   },
   {
     amount: 1,
-    comparator: (x: number) => x >= 0,
+    comparator: gteqZero,
     template: () => "just now",
   },
   {
     label: "the future",
     amount: 1,
-    comparator: (x: number) => x < 0,
+    comparator: ltZero,
     template: () => "the future",
   },
 ];

--- a/packages/ui-components/src/FuzzyTime/utils.test.ts
+++ b/packages/ui-components/src/FuzzyTime/utils.test.ts
@@ -1,0 +1,110 @@
+import {
+  gteq,
+  lt,
+  compare,
+  gteqZero,
+  ltZero,
+  pastTemplate,
+  fuzzyFormatter,
+  setFuzzy,
+  fuzzy,
+} from "./util";
+
+describe("comparison", () => {
+  describe("gteq (greater than equal)", () => {
+    test("comparing two  numbers", () => {
+      expect(gteq(2, 1)).toBe(true);
+      expect(gteq(1, 1)).toBe(true);
+      expect(gteq(1, 2)).toBe(false);
+    });
+  });
+
+  describe("lt (less than)", () => {
+    test("comparing two  numbers", () => {
+      expect(lt(2, 1)).toBe(false);
+      expect(lt(1, 1)).toBe(false);
+      expect(lt(1, 2)).toBe(true);
+    });
+  });
+
+  describe("compare function", () => {
+    const gt = (x: number, y: number): boolean => x > y;
+
+    test("creates comparison functions", () => {
+      const compareGT = compare(gt);
+      const greaterThanTwo = compareGT(2);
+      expect(greaterThanTwo(3)).toBe(true);
+    });
+  });
+
+  describe("gteqZero (greater than equal to zero)", () => {
+    test("compares to 0", () => {
+      expect(gteqZero(1)).toBe(true);
+      expect(gteqZero(0)).toBe(true);
+      expect(gteqZero(-1)).toBe(false);
+    });
+  });
+
+  describe("ltZero (less than to zero)", () => {
+    test("compares to 0", () => {
+      expect(ltZero(1)).toBe(false);
+      expect(ltZero(0)).toBe(false);
+      expect(ltZero(-1)).toBe(true);
+    });
+  });
+});
+
+describe("pastTemplate", () => {
+  test("renders singular durations", () => {
+    expect(pastTemplate(1, "second")).toBe("1 second ago");
+    expect(pastTemplate(1, "jiffy")).toBe("1 jiffy ago");
+    expect(pastTemplate(1, "year")).toBe("1 year ago");
+    expect(pastTemplate(1, "microcentury")).toBe("1 microcentury ago");
+  });
+  test("renders plural durations", () => {
+    expect(pastTemplate(3, "parsec")).toBe("3 parsecs ago");
+    expect(pastTemplate(25, "second")).toBe("25 seconds ago");
+  });
+});
+
+describe("fuzzyFormatter", () => {
+  const fizzywiggUnit = {
+    amount: 3000,
+    template: (d: number) => `about ${d} fizzywiggs ago`,
+    comparator: (x: number) => x >= 3000,
+  };
+
+  test("formats given a diff", () => {
+    const f = fuzzyFormatter(3000000);
+    const result = f(fizzywiggUnit);
+    const expected = "about 1000 fizzywiggs ago";
+    expect(result).toBe(expected);
+  });
+
+  describe("fuzzy", () => {
+    const fiveMonthsAgo = new Date(Date.now() - 1000 * 60 * 60 * 24 * 30 * 5);
+    const now = new Date();
+    const theFuture = new Date(Date.now() + 31104000000);
+
+    test("formats a time in the past", () => {
+      const result = fuzzy(fiveMonthsAgo);
+      const expected = "5 months ago";
+      expect(result).toBe(expected);
+    });
+
+    test("formats a time as now", () => {
+      // doing this just to ensure that we are comparing the same time instead
+      // of the time between when I create a variable and the function is run
+      const f = setFuzzy(now);
+      const result = f(now);
+      const expected = "just now";
+      expect(result).toBe(expected);
+    });
+
+    test("formats a time as the future", () => {
+      const result = fuzzy(theFuture);
+      const expected = "the future";
+      expect(result).toBe(expected);
+    });
+  });
+});

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -4,3 +4,4 @@ export * from "./Button/Button";
 export * from "./Input/";
 export * from "./Tooltip/Tooltip";
 export * from "./Icon/Icon";
+export * from "./FuzzyTime/FuzzyTime";


### PR DESCRIPTION
# FuzzyTime

For the Notifications work being done by the Observability team, I needed to render _fuzzy times_ given timestamps (something like _"5 sec ago", "10 min ago"_,  etc). I felt like this is something we are likely to see again in designs and so I'm skipping ahead and adding it here.

<img width="225" alt="Screen Shot 2020-07-29 at 14 34 41" src="https://user-images.githubusercontent.com/397448/88839246-ccdd7d80-d1a8-11ea-84c3-bb565ed33604.png">
<img width="389" alt="Screen Shot 2020-07-29 at 14 35 14" src="https://user-images.githubusercontent.com/397448/88839255-cea74100-d1a8-11ea-920f-849cce6a9990.png">


#### Checklist
- [X] I have written or updated test for the changes I made
- [ ] ~I have updated the README of the package I'm working in to reflect my changes~ (I don't think we do this anymore
- [X] I have added or updated Storybook if appropriate for my changes