### PR TITLE
ui-components // Adding info intent to Badge

### DIFF
--- a/packages/storybook-ui-components/stories/Badge.stories.tsx
+++ b/packages/storybook-ui-components/stories/Badge.stories.tsx
@@ -109,7 +109,7 @@ export const Demo = () => (
     <Badge
       intent={select(
         "Intent",
-        ["neutral", "success", "warning", "danger"],
+        ["neutral", "success", "warning", "danger", "info"],
         "neutral",
       )}
       transformCase={select(

--- a/packages/storybook-ui-components/stories/Badge.stories.tsx
+++ b/packages/storybook-ui-components/stories/Badge.stories.tsx
@@ -55,6 +55,10 @@ export const Example = () => (
           {" "}
           <strong>Danger:</strong> Use to indicate a failed state.{" "}
         </li>
+        <li>
+          {" "}
+          <strong>Info:</strong> Use to indicate useful information.{" "}
+        </li>
       </ul>
     </StoryDescription>
 
@@ -76,6 +80,10 @@ export const Example = () => (
         <BadgeDisplay>
           <Label>danger</Label>
           <Badge intent="danger">Error</Badge>
+        </BadgeDisplay>
+        <BadgeDisplay>
+          <Label>info</Label>
+          <Badge intent="info">Info</Badge>
         </BadgeDisplay>
       </BadgeDisplaySection>
     </section>

--- a/packages/ui-components/src/Badge/Badge.module.scss
+++ b/packages/ui-components/src/Badge/Badge.module.scss
@@ -5,7 +5,7 @@
   display: inline-block;
   font-size: 12px;
   line-height: 14px;
-  padding: crl-gutters(0.25) crl-gutters(0.75);
+  padding: crl-gutters(0.625) crl-gutters(1);
   vertical-align: crl-gutters(0.5);
   text-align: center;
   white-space: nowrap;

--- a/packages/ui-components/src/Badge/Badge.module.scss
+++ b/packages/ui-components/src/Badge/Badge.module.scss
@@ -32,6 +32,11 @@
   color: $color-font-badge-danger;
 }
 
+.intent-info {
+  background: $color-background-badge-info;
+  color: $color-font-badge-info;
+}
+
 .noTransform {
   text-transform: none;
 }

--- a/packages/ui-components/src/Badge/Badge.test.tsx
+++ b/packages/ui-components/src/Badge/Badge.test.tsx
@@ -40,6 +40,10 @@ describe("Badge Intent prop", () => {
     // neutral
     wrapper.setProps({ intent: "neutral" });
     expect(wrapper.prop("className")).toContain("intent-neutral");
+
+    // neutral
+    wrapper.setProps({ intent: "info" });
+    expect(wrapper.prop("className")).toContain("intent-info");
   });
 });
 

--- a/packages/ui-components/src/Badge/Badge.tsx
+++ b/packages/ui-components/src/Badge/Badge.tsx
@@ -6,7 +6,7 @@ import objectToClassnames from "../utils/objectToClassnames";
 import styles from "./Badge.module.scss";
 
 export type BadgeCase = "none" | "uppercase";
-export type BadgeIntent = "neutral" | "success" | "warning" | "danger";
+export type BadgeIntent = "neutral" | "success" | "warning" | "danger" | "info";
 
 export interface BadgeProps {
   intent?: BadgeIntent;

--- a/packages/ui-components/src/Badge/Badge.tsx
+++ b/packages/ui-components/src/Badge/Badge.tsx
@@ -8,10 +8,16 @@ import styles from "./Badge.module.scss";
 export type BadgeCase = "none" | "uppercase";
 export type BadgeIntent = "neutral" | "success" | "warning" | "danger" | "info";
 
-export interface BadgeProps {
+interface OwnBadgeProps {
   intent?: BadgeIntent;
   transformCase?: BadgeCase;
 }
+type NativeDivProps = Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  keyof OwnBadgeProps
+>;
+
+export type BadgeProps = NativeDivProps & OwnBadgeProps;
 
 const cx = classNames.bind(styles);
 
@@ -19,9 +25,14 @@ export const Badge: FunctionComponent<BadgeProps> = ({
   intent = "neutral",
   transformCase = "uppercase",
   children,
+  className,
   ...props
 }) => {
-  const classnames = cx("badge", objectToClassnames({ intent, transformCase }));
+  const classnames = cx(
+    "badge",
+    objectToClassnames({ intent, transformCase }),
+    className,
+  );
 
   if (children !== undefined) {
     return (


### PR DESCRIPTION
Adding a "blue" intent called "info" to Badge component

fixes #110

Also in this PR,
- Adjusting padding to match mocks
- Extending `BadgeProps` with `HTMLDivElement` attributes. This is immediately for the purpose of adding a `className` prop to Badge during implementation.

#### Checklist
- [X] I have written or updated test for the changes I made
- [X] I have added or updated Storybook if appropriate for my changes