### PR TITLE
ui-components: Extending Avatar props

### DIFF
--- a/packages/storybook-ui-components/stories/Avatar.stories.tsx
+++ b/packages/storybook-ui-components/stories/Avatar.stories.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent, ReactElement } from "react";
 import { withKnobs, text, boolean, select } from "@storybook/addon-knobs";
 import { action } from "@storybook/addon-actions";
-import { Avatar, AvatarProps } from "@cockroachlabs/ui-components";
+import { Avatar, AvatarProps, Icon } from "@cockroachlabs/ui-components";
 import { StoryContainer, StoryDescription } from "../layout";
 
 interface AvatarDisplay {
@@ -99,6 +99,27 @@ export const example = () => (
       place of an image. Avatar can be used on its own or in conjunction with
       the full username.
     </StoryDescription>
+    {/* Component API */}
+    <div>
+      <h2>Props</h2>
+      <pre
+        style={{
+          backgroundColor: "#eee",
+          padding: "1rem",
+          marginRight: "3rem",
+        }}
+      >
+        <code>
+          {`  size?: "default" | "small";
+  intent?: "default" | "active" | "pending" | "invalid";
+  disabled?: boolean;
+  selectable?: boolean;
+  onClick?: () => void;
+  transformCase?: "none" | "uppercase";
+`}
+        </code>
+      </pre>
+    </div>
     <h4>Default size</h4>
     <Container>
       {withIntentNotSelectable.map(({ description, ...props }, idx) => (
@@ -123,6 +144,59 @@ export const example = () => (
           <Avatar {...props} />
         </ItemWrapper>
       ))}
+    </Container>
+
+    <h4>Icon as content</h4>
+    <Container>
+      <Avatar>
+        <Icon iconName="Time" />
+      </Avatar>
+      <Avatar>
+        <Icon iconName="Backup" />
+      </Avatar>
+      <Avatar>
+        <Icon iconName="LockFilled" />
+      </Avatar>
+      <Avatar>
+        <Icon iconName="Terminal" />
+      </Avatar>
+      <Avatar>
+        <Icon iconName="User" />
+      </Avatar>
+    </Container>
+
+    <h4>Image as content</h4>
+    <Container>
+      <Avatar>
+        <img
+          src="https://assets.nathanstilwell.com/nathans/nathan_1-64.png"
+          alt="little image of Nathan's face"
+        />
+      </Avatar>
+      <Avatar>
+        <img
+          src="https://avatars0.githubusercontent.com/u/3106437"
+          alt="little image of Andrii's face"
+        />
+      </Avatar>
+      <Avatar>
+        <img
+          src="https://avatars1.githubusercontent.com/u/7131985"
+          alt="little image of Lauren's face"
+        />
+      </Avatar>
+      <Avatar>
+        <img
+          src="https://avatars0.githubusercontent.com/u/51920721"
+          alt="little image of Anne's face"
+        />
+      </Avatar>
+      <Avatar>
+        <img
+          src="https://avatars0.githubusercontent.com/u/6320333"
+          alt="little image of Joe's face"
+        />
+      </Avatar>
     </Container>
   </StoryContainer>
 );

--- a/packages/ui-components/src/Avatar/Avatar.module.scss
+++ b/packages/ui-components/src/Avatar/Avatar.module.scss
@@ -1,6 +1,5 @@
 @import "../styles/tokens.scss";
 
-// TODO (koorosh): Probably has to be extracted to tokens.
 @mixin selectable-border($color) {
   box-sizing: border-box;
   border: 2px solid $color;
@@ -19,6 +18,10 @@
   border-radius: 50%;
   overflow: hidden;
   user-select: none;
+}
+
+.avatar img {
+  height: 100%;
 }
 
 .intent-default {

--- a/packages/ui-components/src/Avatar/Avatar.test.tsx
+++ b/packages/ui-components/src/Avatar/Avatar.test.tsx
@@ -16,6 +16,16 @@ describe("Avatar", () => {
     });
   });
 
+  describe("User provided className", () => {
+    it("appends user provided className", () => {
+      const testClass = "nathan-test-stuff";
+      const wrapper = shallow(<Avatar className={testClass}>NS</Avatar>);
+      const className = wrapper.prop("className");
+      expect(className).toContain(testClass);
+      expect(className).toContain("intent-default");
+    });
+  });
+
   describe("Handle onClick prop", () => {
     it("calls callback function on element click", () => {
       const onClickSpy = jasmine.createSpy();
@@ -43,6 +53,16 @@ describe("Avatar", () => {
 
     it("renders with empty content", () => {
       expect(shallow(<Avatar />).text()).toEqual("");
+    });
+
+    it("renders with svg passed as children", () => {
+      const svg = <svg />;
+      expect(shallow(<Avatar>{svg}</Avatar>).find("svg")).toHaveLength(1);
+    });
+
+    it("renders with svg passed as children", () => {
+      const img = <img />;
+      expect(shallow(<Avatar>{img}</Avatar>).find("img")).toHaveLength(1);
     });
   });
 

--- a/packages/ui-components/src/Avatar/Avatar.test.tsx
+++ b/packages/ui-components/src/Avatar/Avatar.test.tsx
@@ -16,13 +16,20 @@ describe("Avatar", () => {
     });
   });
 
-  describe("User provided className", () => {
+  describe("Native element props", () => {
     it("appends user provided className", () => {
       const testClass = "nathan-test-stuff";
       const wrapper = shallow(<Avatar className={testClass}>NS</Avatar>);
       const className = wrapper.prop("className");
       expect(className).toContain(testClass);
       expect(className).toContain("intent-default");
+    });
+
+    it("accepts data attributes", () => {
+      const datatest = "nathan-data";
+      const wrapper = shallow(<Avatar data-test={datatest}>NS</Avatar>);
+      const result = wrapper.prop("data-test");
+      expect(result).toBe(datatest);
     });
   });
 

--- a/packages/ui-components/src/Avatar/Avatar.tsx
+++ b/packages/ui-components/src/Avatar/Avatar.tsx
@@ -35,6 +35,7 @@ export const Avatar: React.FC<AvatarProps> = ({
   selectable = false,
   onClick,
   transformCase = "uppercase",
+  ...rest
 }) => {
   const classnames = useMemo(
     () =>
@@ -58,7 +59,7 @@ export const Avatar: React.FC<AvatarProps> = ({
   }, [onClick, disabled]);
 
   return (
-    <div className={classnames} onClick={onClickHandler}>
+    <div className={classnames} onClick={onClickHandler} {...rest}>
       {children}
     </div>
   );

--- a/packages/ui-components/src/Avatar/Avatar.tsx
+++ b/packages/ui-components/src/Avatar/Avatar.tsx
@@ -4,8 +4,7 @@ import classNames from "classnames/bind";
 import styles from "./Avatar.module.scss";
 import objectToClassnames from "../utils/objectToClassnames";
 
-export interface AvatarProps {
-  children?: string;
+interface OwnAvatarProps {
   size?: AvatarSize;
   intent?: AvatarIntent;
   disabled?: boolean;
@@ -13,6 +12,13 @@ export interface AvatarProps {
   onClick?: () => void;
   transformCase?: AvatarCase;
 }
+
+type NativeDivProps = Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  keyof OwnAvatarProps
+>;
+
+export type AvatarProps = NativeDivProps & OwnAvatarProps;
 
 export type AvatarSize = "default" | "small";
 export type AvatarIntent = "default" | "active" | "pending" | "invalid";
@@ -22,6 +28,7 @@ const cx = classNames.bind(styles);
 
 export const Avatar: React.FC<AvatarProps> = ({
   children,
+  className,
   intent = "default",
   size = "default",
   disabled = false,
@@ -31,12 +38,17 @@ export const Avatar: React.FC<AvatarProps> = ({
 }) => {
   const classnames = useMemo(
     () =>
-      cx("avatar", objectToClassnames({ size, transformCase }), {
-        disabled,
-        selectable: !disabled && selectable,
-        [`intent-${intent}`]: !disabled,
-      }),
-    [intent, size, disabled, selectable, transformCase],
+      cx(
+        "avatar",
+        objectToClassnames({ size, transformCase }),
+        {
+          disabled,
+          selectable: !disabled && selectable,
+          [`intent-${intent}`]: !disabled,
+        },
+        className,
+      ),
+    [intent, size, disabled, selectable, transformCase, className],
   );
 
   const onClickHandler = useCallback(() => {


### PR DESCRIPTION
# ui-component // Extending Avatar props

I am extending the props from Avatar with attributes from HTMLDivElement.
This patten has been used in other components is necessary to extend
Avatar for integration with CockroachCloud console. I have also updated
the Avatar stories to demonstrate the use cases.

fixes #112

#### Checklist
- [X] I have written or updated test for the changes I made
- [X] I have added or updated Storybook if appropriate for my changes