### PR TITLE
ui-components: Spinner component

### DIFF
--- a/packages/storybook-ui-components/stories/Spinner.stories.tsx
+++ b/packages/storybook-ui-components/stories/Spinner.stories.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { withKnobs, select } from "@storybook/addon-knobs";
+import { Spinner } from "@cockroachlabs/ui-components";
+import { StoryContainer, StoryDescription  } from "../layout";
+
+export default {
+  title: "Spinner",
+  component: Spinner,
+  decorators: [withKnobs],
+};
+
+export const Example = () => (
+  <StoryContainer>
+    <h1>Spinner</h1>
+    <StoryDescription>
+      Loading indicator for components that might not receive all necessary data to
+      render its content.
+    </StoryDescription>
+    <section>
+      <h2>Spinner sizes</h2>
+      <h4>Default size</h4>
+      <Spinner />
+      <h4>Small size</h4>
+      <Spinner size="small" />
+      <h4>Large size</h4>
+      <Spinner size="large" />
+    </section>
+
+  </StoryContainer>
+);
+
+export const Demo = () => (
+  <StoryContainer>
+    <Spinner size={select("size", ["default", "small", "large"], "default")} />
+  </StoryContainer>
+)

--- a/packages/ui-components/src/Spinner/Spinner.module.scss
+++ b/packages/ui-components/src/Spinner/Spinner.module.scss
@@ -1,0 +1,47 @@
+@import "../styles/tokens.scss";
+
+// stroke values depend on viewBox of svg file (viewBox="0 0 100 100")
+svg.spinner {
+  circle {
+    fill: transparent;
+    stroke: $color-core-neutral-6;
+    stroke-linecap: round;
+    stroke-dasharray: 220;
+    stroke-dashoffset: 280;
+    stroke-width: 10px;
+    transform-origin: 50% 50%;
+    animation: spinner 3s linear infinite;
+  }
+}
+
+.size-default {
+  width: crl-gutters(5);
+  height: crl-gutters(5);
+}
+
+.size-small {
+  width: crl-gutters(3);
+  height: crl-gutters(3);
+}
+
+.size-large {
+  width: crl-gutters(8);
+  height: crl-gutters(8);
+}
+
+@keyframes spinner {
+  0% {
+    stroke-dashoffset: 25;
+    transform: rotate(0deg);
+  }
+
+  50% {
+    stroke-dashoffset: 125;
+    transform: rotate(720deg);
+  }
+
+  100% {
+    stroke-dashoffset: 25;
+    transform: rotate(1080deg);
+  }
+}

--- a/packages/ui-components/src/Spinner/Spinner.test.tsx
+++ b/packages/ui-components/src/Spinner/Spinner.test.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { shallow } from "enzyme";
+import { Spinner, SpinnerSize } from "./Spinner";
+
+const spinnerSizes: SpinnerSize[] = ["default", "small", "large"];
+
+describe("Spinner", () => {
+  test("renders on a screen", () => {
+    const wrapper = shallow(<Spinner />);
+    expect(wrapper).toBeDefined();
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  spinnerSizes.forEach(size => {
+    test(`renders with provided ${size} size`, () => {
+      const wrapper = shallow(<Spinner size={size} />);
+      expect(wrapper.hasClass(`size-${size}`)).toBeTruthy();
+      expect(wrapper).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/ui-components/src/Spinner/Spinner.tsx
+++ b/packages/ui-components/src/Spinner/Spinner.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import classNames from "classnames/bind";
+import styles from "./Spinner.module.scss";
+import objectToClassnames from "../utils/objectToClassnames";
+
+const cx = classNames.bind(styles);
+
+export type SpinnerSize = "default" | "large" | "small";
+
+export interface SpinnerProps {
+  size?: SpinnerSize;
+  className?: string;
+}
+
+export const Spinner: React.FC<SpinnerProps> = ({
+  size = "default",
+  className,
+}) => {
+  const classNames = cx("spinner", objectToClassnames({ size }), className);
+  return (
+    <svg
+      className={classNames}
+      viewBox="0 0 100 100"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        fillRule="evenodd"
+        clipRule="evenodd"
+        stroke="black"
+        cx="50"
+        cy="50"
+        r="44"
+        strokeWidth="12"
+        strokeDasharray="283"
+        strokeDashoffset="75"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+};

--- a/packages/ui-components/src/Spinner/__snapshots__/Spinner.test.tsx.snap
+++ b/packages/ui-components/src/Spinner/__snapshots__/Spinner.test.tsx.snap
@@ -1,0 +1,89 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Spinner renders on a screen 1`] = `
+<svg
+  className="spinner size-default"
+  fill="none"
+  viewBox="0 0 100 100"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <circle
+    clipRule="evenodd"
+    cx="50"
+    cy="50"
+    fillRule="evenodd"
+    r="44"
+    stroke="black"
+    strokeDasharray="283"
+    strokeDashoffset="75"
+    strokeLinecap="round"
+    strokeWidth="12"
+  />
+</svg>
+`;
+
+exports[`Spinner renders with provided default size 1`] = `
+<svg
+  className="spinner size-default"
+  fill="none"
+  viewBox="0 0 100 100"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <circle
+    clipRule="evenodd"
+    cx="50"
+    cy="50"
+    fillRule="evenodd"
+    r="44"
+    stroke="black"
+    strokeDasharray="283"
+    strokeDashoffset="75"
+    strokeLinecap="round"
+    strokeWidth="12"
+  />
+</svg>
+`;
+
+exports[`Spinner renders with provided large size 1`] = `
+<svg
+  className="spinner size-large"
+  fill="none"
+  viewBox="0 0 100 100"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <circle
+    clipRule="evenodd"
+    cx="50"
+    cy="50"
+    fillRule="evenodd"
+    r="44"
+    stroke="black"
+    strokeDasharray="283"
+    strokeDashoffset="75"
+    strokeLinecap="round"
+    strokeWidth="12"
+  />
+</svg>
+`;
+
+exports[`Spinner renders with provided small size 1`] = `
+<svg
+  className="spinner size-small"
+  fill="none"
+  viewBox="0 0 100 100"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <circle
+    clipRule="evenodd"
+    cx="50"
+    cy="50"
+    fillRule="evenodd"
+    r="44"
+    stroke="black"
+    strokeDasharray="283"
+    strokeDashoffset="75"
+    strokeLinecap="round"
+    strokeWidth="12"
+  />
+</svg>
+`;

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -6,3 +6,4 @@ export * from "./Tooltip/Tooltip";
 export * from "./Icon/Icon";
 export * from "./FuzzyTime/FuzzyTime";
 export * from "./InlineAlert/InlineAlert";
+export * from "./Spinner/Spinner";


### PR DESCRIPTION
<!--
  Please add a title to your Pull Request with the package the changes
  occured in.
-->
# ui-components // Spinner

<!--
  Please describe your changes by describing motivation, linking to issues,
  and adding screenshots or gifs to illustrate your changes for reviewers
 -->
Spinner component is animated loading indicator which can be
used in tables or on pages and indicate intermediate state.

This component doesn't reuse existing Spinner icon due to
technical limitations. Loading icon is rendered with `<path>`
element which is difficult to animate and make it rotate around
SVG central point. That's why current component implements its
own loading icon based on `<circle>` element.

#### Checklist
- [x] I have written or updated test for the changes I made
- [ ] I have updated the README of the package I'm working in to reflect my changes
- [x] I have added or updated Storybook if appropriate for my changes

![output](https://user-images.githubusercontent.com/3106437/98023526-bed67300-1e0f-11eb-9e48-8c726f285ff9.gif)

For comparison, loading indicator which is used in Admin UI right now:
![spinner](https://user-images.githubusercontent.com/3106437/98022970-f42e9100-1e0e-11eb-867b-6b93ef779d90.gif)

