### PR TITLE
ui: refactor icon component to use in Input components

### DIFF
--- a/packages/storybook-ui-components/stories/Icon.stories.tsx
+++ b/packages/storybook-ui-components/stories/Icon.stories.tsx
@@ -3,7 +3,7 @@ import { withKnobs, select } from "@storybook/addon-knobs";
 import { StoryContainer, StoryDescription } from "../layout";
 
 import * as Icons from "@cockroachlabs/icons";
-import { Icon, IconSize, IconTint } from "@cockroachlabs/ui-components";
+import { Icon, IconSize, IconFill } from "@cockroachlabs/ui-components";
 
 export default {
   title: "Icon",
@@ -107,16 +107,17 @@ const sizes: Array<{ key: IconSize; size: number }> = [
   { key: "medium", size: 32 },
   { key: "large", size: 48 },
   { key: "x-large", size: 56 },
-  { key: "xx-large", size: 80 },
 ];
-const tints: Array<IconTint> = [
-  "blue",
-  "green",
-  "red",
-  "white",
-  "neutral",
-  "inherit",
-  "orange",
+const fills: Array<IconFill> = [
+  "danger",
+  "default",
+  "info",
+  "primary",
+  "success",
+  "warning",
+  "inverted",
+  "disabled",
+  "disabled-light",
 ];
 
 export const Example = () => (
@@ -131,7 +132,7 @@ export const Example = () => (
     <section>
       <h2>Icon Names</h2>
       <IconDisplaySection>
-        {IconNames.map((name) => (
+        {IconNames.map(name => (
           <IconDisplay key={name}>
             <IconLabel text={name} />
             <IconFrame>
@@ -145,7 +146,7 @@ export const Example = () => (
     <section>
       <h2>Icon Sizes</h2>
       <IconDisplaySection>
-        {sizes.map((s) => (
+        {sizes.map(s => (
           <IconDisplay key={s.key}>
             <IconLabel text={`${s.key} (${s.size}px)`} />
             <IconFrame>
@@ -157,16 +158,21 @@ export const Example = () => (
     </section>
 
     <section>
-      <h2>Icon Tints</h2>
+      <h2>Icon Fills</h2>
       <IconDisplaySection>
-        {tints.map((tint) => (
-          <IconDisplay key={tint} backgroundColor="#c0c6d9">
-            <IconLabel text={tint} />
-            <IconFrame>
-              <Icon iconName="Plus" tint={tint} />
-            </IconFrame>
-          </IconDisplay>
-        ))}
+        {fills.map(fill => {
+          return (
+            <IconDisplay
+              key={fill}
+              backgroundColor={fill === "inverted" ? "#c0c6d9" : ""}
+            >
+              <IconLabel text={fill} />
+              <IconFrame>
+                <Icon iconName="Plus" fill={fill} />
+              </IconFrame>
+            </IconDisplay>
+          );
+        })}
       </IconDisplaySection>
     </section>
   </StoryContainer>
@@ -178,10 +184,10 @@ export const Demo = () => (
       iconName={select("Icon Name", IconNames, "Plus")}
       size={select(
         "Size",
-        sizes.map((s) => s.key),
+        sizes.map(s => s.key),
         "default",
       )}
-      tint={select("Tint", tints, "neutral")}
+      fill={select("Fill", fills, "default")}
     />
   </StoryContainer>
 );

--- a/packages/ui-components/src/Icon/Icon.module.scss
+++ b/packages/ui-components/src/Icon/Icon.module.scss
@@ -63,10 +63,10 @@
 }
 
 .fill-disabled {
-  fill: $color-code-neutral-5;
+  fill: $color-core-neutral-5;
 
   &-light {
-    fill: $color-code-neutral-4;
+    fill: $color-core-neutral-4;
   }
 }
 

--- a/packages/ui-components/src/Icon/Icon.module.scss
+++ b/packages/ui-components/src/Icon/Icon.module.scss
@@ -34,29 +34,39 @@
   width: 8px;
 }
 
-.intent-info {
+.fill-info {
   fill: $color-base-blue;
 }
 
-.intent-primary {
+.fill-primary {
   fill: $color-base-purple;
 }
 
-.intent-success {
+.fill-success {
   fill: $color-base-green;
 }
 
-.intent-danger {
+.fill-danger {
   fill: $color-base-red;
 }
 
-.intent-warning {
+.fill-warning {
   fill: $color-base-orange;
 }
 
-.intent-flag {
+.fill-inverted {
   fill: $color-base-white;
 }
 
+.fill-default {
+  fill: $color-core-neutral-7;
+}
 
+.fill-disabled {
+  fill: $color-code-neutral-5;
+
+  &-light {
+    fill: $color-code-neutral-4;
+  }
+}
 

--- a/packages/ui-components/src/Icon/Icon.module.scss
+++ b/packages/ui-components/src/Icon/Icon.module.scss
@@ -23,6 +23,7 @@
   width: 20px;
 }
 
+.size-default,
 .size-small {
   height: 16px;
   width: 16px;
@@ -38,7 +39,7 @@
 }
 
 .intent-primary {
-  fill: $color-base-blue;
+  fill: $color-base-purple;
 }
 
 .intent-success {

--- a/packages/ui-components/src/Icon/Icon.module.scss
+++ b/packages/ui-components/src/Icon/Icon.module.scss
@@ -1,6 +1,6 @@
 @import "../styles/tokens.scss";
 .icon {
-  fill: $crl-base-text--dark;
+  fill: $color-core-neutral-7;
   margin: auto;
 
   &:disabled {

--- a/packages/ui-components/src/Icon/Icon.module.scss
+++ b/packages/ui-components/src/Icon/Icon.module.scss
@@ -6,40 +6,31 @@
   &:disabled {
     pointer-events: none;
   }
-
-  &__container {
-    display: inline-flex;
-  }
-}
-
-.size-xx-large {
-  height: 80px;
-  width: 80px;
 }
 
 .size-x-large {
-  height: 56px;
-  width: 56px;
-}
-
-.size-large {
-  height: 48px;
-  width: 48px;
-}
-
-.size-medium {
   height: 32px;
   width: 32px;
 }
 
-.size-default {
-  height: 46px;
+.size-large {
+  height: 24px;
   width: 24px;
+}
+
+.size-medium {
+  height: 20px;
+  width: 20px;
 }
 
 .size-small {
   height: 16px;
   width: 16px;
+}
+
+.size-tiny {
+  height: 8px;
+  width: 8px;
 }
 
 .intent-info {

--- a/packages/ui-components/src/Icon/Icon.module.scss
+++ b/packages/ui-components/src/Icon/Icon.module.scss
@@ -1,11 +1,14 @@
 @import "../styles/tokens.scss";
-
 .icon {
-  display: inline-flex;
+  fill: $crl-base-text--dark;
   margin: auto;
 
   &:disabled {
     pointer-events: none;
+  }
+
+  &__container {
+    display: inline-flex;
   }
 }
 
@@ -30,7 +33,7 @@
 }
 
 .size-default {
-  height: 24px;
+  height: 46px;
   width: 24px;
 }
 
@@ -39,30 +42,29 @@
   width: 16px;
 }
 
-.tint-blue {
+.intent-info {
   fill: $color-base-blue;
 }
 
-.tint-green {
+.intent-primary {
+  fill: $color-base-blue;
+}
+
+.intent-success {
   fill: $color-base-green;
 }
 
-.tint-red {
+.intent-danger {
   fill: $color-base-red;
 }
 
-.tint-orange {
+.intent-warning {
   fill: $color-base-orange;
 }
 
-.tint-white {
+.intent-flag {
   fill: $color-base-white;
 }
 
-.tint-neutral {
-  fill: $color-font-1;
-}
 
-.tint-inherit {
-  fill: currentcolor;
-}
+

--- a/packages/ui-components/src/Icon/Icon.test.tsx
+++ b/packages/ui-components/src/Icon/Icon.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { shallow } from "enzyme";
 import { MinusCircle } from "@cockroachlabs/icons";
 
-import Icon, { IconProps, IconSize, IconTint } from "./Icon";
+import Icon, { IconProps, IconSize, IconFill } from "./Icon";
 
 const defaultProps = {
   iconName: "Plus",
@@ -38,7 +38,7 @@ describe("Icon size prop", () => {
       ["medium", "size-medium"],
       ["large", "size-large"],
       ["x-large", "size-x-large"],
-      ["xx-large", "size-xx-large"],
+      ["tiny", "size-tiny"],
     ];
 
     iconSizes.forEach(([iconSize, expectedClassName]) => {
@@ -48,27 +48,27 @@ describe("Icon size prop", () => {
   });
 });
 
-describe("Icon tint prop", () => {
+describe("Icon fill prop", () => {
   test("defaults to neutral", () => {
     const wrapper = renderSubject();
-    expect(wrapper.prop("className")).toContain("tint-neutral");
+    expect(wrapper.prop("className")).toContain("fill-default");
   });
 
-  test("changes the tint of an icon", () => {
+  test("changes the fill of an icon", () => {
     const wrapper = renderSubject();
-    const iconTints: Array<[IconTint, string]> = [
-      [undefined, "tint-neutral"],
-      ["neutral", "tint-neutral"],
-      ["inherit", "tint-inherit"],
-      ["white", "tint-white"],
-      ["red", "tint-red"],
-      ["green", "tint-green"],
-      ["blue", "tint-blue"],
-      ["orange", "tint-orange"],
+    const iconFills: Array<[IconFill, string]> = [
+      ["danger", "fill-danger"],
+      ["inverted", "fill-inverted"],
+      ["disabled", "fill-disabled"],
+      ["disabled-light", "fill-disabled-light"],
+      ["info", "fill-info"],
+      ["primary", "fill-primary"],
+      ["success", "fill-success"],
+      ["warning", "fill-warning"],
     ];
 
-    iconTints.forEach(([iconTint, expectedClassName]) => {
-      wrapper.setProps({ tint: iconTint });
+    iconFills.forEach(([iconFill, expectedClassName]) => {
+      wrapper.setProps({ fill: iconFill });
       expect(wrapper.prop("className")).toContain(expectedClassName);
     });
   });

--- a/packages/ui-components/src/Icon/Icon.tsx
+++ b/packages/ui-components/src/Icon/Icon.tsx
@@ -54,7 +54,7 @@ export const Icon: FunctionComponent<IconProps> = ({
     return null;
   }
 
-  return <Element {...props} className={classnames} />;
+  return <Element className={classnames} {...props} />;
 };
 
 export default Icon;

--- a/packages/ui-components/src/Icon/Icon.tsx
+++ b/packages/ui-components/src/Icon/Icon.tsx
@@ -15,7 +15,7 @@ export type IconSize =
   | "x-large"
   | "xx-large";
 
-export type IconStyle =
+export type IconIntent =
   | "danger"
   | "default"
   | "flag"
@@ -27,7 +27,7 @@ export type IconStyle =
 type OwnIconProps = {
   iconName: keyof typeof Icons;
   size?: IconSize;
-  intent?: IconStyle;
+  intent?: IconIntent;
 };
 
 const cx = classNames.bind(styles);
@@ -43,8 +43,6 @@ export const Icon: FunctionComponent<IconProps> = ({
   className,
   ...props
 }) => {
-
-
   const classnames = useMemo(
     () => cx("icon", objectToClassnames({ size, intent }), className),
     [className, size, intent],
@@ -56,10 +54,7 @@ export const Icon: FunctionComponent<IconProps> = ({
     return null;
   }
 
-  return (
-  <div className="icon__container">
-    <Element {...props} className={classnames} />
-  </div>);
+  return <Element {...props} className={classnames} />;
 };
 
 export default Icon;

--- a/packages/ui-components/src/Icon/Icon.tsx
+++ b/packages/ui-components/src/Icon/Icon.tsx
@@ -15,45 +15,51 @@ export type IconSize =
   | "x-large"
   | "xx-large";
 
-export type IconTint =
-  | "blue"
-  | "green"
-  | "red"
-  | "white"
-  | "neutral"
-  | "inherit"
-  | "orange";
+export type IconStyle =
+  | "danger"
+  | "default"
+  | "flag"
+  | "info"
+  | "primary"
+  | "success"
+  | "warning";
 
 type OwnIconProps = {
   iconName: keyof typeof Icons;
   size?: IconSize;
-  tint?: IconTint;
+  intent?: IconStyle;
 };
+
+const cx = classNames.bind(styles);
 
 type NativeIconProps = Omit<React.SVGProps<SVGSVGElement>, keyof OwnIconProps>;
 
 export type IconProps = NativeIconProps & OwnIconProps;
 
-const cx = classNames.bind(styles);
-
 export const Icon: FunctionComponent<IconProps> = ({
   iconName,
   size = "default",
-  tint = "neutral",
+  intent = "default",
   className,
   ...props
 }) => {
+
+
   const classnames = useMemo(
-    () => cx("icon", objectToClassnames({ size, tint }), className),
-    [className, size, tint],
+    () => cx("icon", objectToClassnames({ size, intent }), className),
+    [className, size, intent],
   );
+
   const Element = get(Icons, iconName, null);
 
   if (Element === null) {
     return null;
   }
 
-  return <Element className={classnames} {...props} />;
+  return (
+  <div className="icon__container">
+    <Element {...props} className={classnames} />
+  </div>);
 };
 
 export default Icon;

--- a/packages/ui-components/src/Icon/Icon.tsx
+++ b/packages/ui-components/src/Icon/Icon.tsx
@@ -33,7 +33,7 @@ export type IconFill = IconIntent | "inverted" | "disabled" | "disabled-light";
 type OwnIconProps = {
   iconName: keyof typeof Icons;
   size?: IconSize;
-  intent?: IconIntent;
+  fill?: IconFill;
 };
 
 const cx = classNames.bind(styles);

--- a/packages/ui-components/src/Icon/Icon.tsx
+++ b/packages/ui-components/src/Icon/Icon.tsx
@@ -8,21 +8,27 @@ import styles from "./Icon.module.scss";
 import objectToClassnames from "../utils/objectToClassnames";
 
 export type IconSize =
+  | "tiny"
   | "small"
   | "default"
   | "medium"
   | "large"
-  | "x-large"
-  | "xx-large";
+  | "x-large";
 
 export type IconIntent =
   | "danger"
   | "default"
-  | "flag"
   | "info"
   | "primary"
   | "success"
   | "warning";
+
+// The fill of an icon can be:
+//      intent based (types are defined in IconIntent)
+//      inverted (when the icon appears against a dark background)
+//      disabled (for when the background is neutral-2)
+//      disabled-light (for when the background is neutral-0)
+export type IconFill = IconIntent | "inverted" | "disabled" | "disabled-light";
 
 type OwnIconProps = {
   iconName: keyof typeof Icons;
@@ -39,13 +45,13 @@ export type IconProps = NativeIconProps & OwnIconProps;
 export const Icon: FunctionComponent<IconProps> = ({
   iconName,
   size = "default",
-  intent = "default",
+  fill = "default",
   className,
   ...props
 }) => {
   const classnames = useMemo(
-    () => cx("icon", objectToClassnames({ size, intent }), className),
-    [className, size, intent],
+    () => cx("icon", objectToClassnames({ size, fill }), className),
+    [className, size, fill],
   );
 
   const Element = get(Icons, iconName, null);

--- a/packages/ui-components/src/Icon/__snapshots__/Icon.test.tsx.snap
+++ b/packages/ui-components/src/Icon/__snapshots__/Icon.test.tsx.snap
@@ -2,6 +2,6 @@
 
 exports[`Icon should render given an iconName 1`] = `
 <SvgPlus
-  className="icon tint-neutral size-default"
+  className="icon fill-default size-default"
 />
 `;

--- a/packages/ui-components/src/InlineAlert/InlineAlert.test.tsx
+++ b/packages/ui-components/src/InlineAlert/InlineAlert.test.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 import { shallow } from "enzyme";
-import { InlineAlert, InlineAlertIntent } from "./InlineAlert";
+import { IconIntent } from "../Icon/Icon";
+import { InlineAlert } from "./InlineAlert";
 
-const alertIntents: InlineAlertIntent[] = [
+const alertIntents: IconIntent[] = [
   undefined, // should be used default intent
   "warning",
   "success",
-  "error",
+  "danger",
   "info",
 ];
 

--- a/packages/ui-components/src/InlineAlert/InlineAlert.tsx
+++ b/packages/ui-components/src/InlineAlert/InlineAlert.tsx
@@ -47,7 +47,7 @@ export const InlineAlert: React.FC<InlineAlertProps> = ({
   return (
     <div className={cx("root", `intent-${intent}`, className)}>
       <div className={cx("icon-container")}>
-        <Icon iconName={iconName} size="default" intent={intent} />
+        <Icon iconName={iconName} size="default" fill={intent} />
       </div>
       <div className={cx("container")}>
         {title && <div className={cx("title")}>{title}</div>}

--- a/packages/ui-components/src/InlineAlert/InlineAlert.tsx
+++ b/packages/ui-components/src/InlineAlert/InlineAlert.tsx
@@ -2,14 +2,12 @@ import React, { useMemo } from "react";
 import classNames from "classnames/bind";
 
 import styles from "./InlineAlert.module.scss";
-import { Icon, IconTint } from "../Icon/Icon";
-
-export type InlineAlertIntent = "info" | "error" | "success" | "warning";
+import { Icon, IconIntent } from "../Icon/Icon";
 
 const cx = classNames.bind(styles);
 
 interface InlineAlertBaseProps {
-  intent?: InlineAlertIntent;
+  intent?: IconIntent;
   className?: string;
 }
 
@@ -34,7 +32,7 @@ export const InlineAlert: React.FC<InlineAlertProps> = ({
 }) => {
   const iconName = useMemo(() => {
     switch (intent) {
-      case "error":
+      case "danger":
         return "ErrorCircleFilled";
       case "success":
         return "CheckCircleFilled";
@@ -46,24 +44,10 @@ export const InlineAlert: React.FC<InlineAlertProps> = ({
     }
   }, [intent]);
 
-  const iconTint = useMemo<IconTint>(() => {
-    switch (intent) {
-      case "error":
-        return "red";
-      case "success":
-        return "green";
-      case "warning":
-        return "orange";
-      case "info":
-      default:
-        return "blue";
-    }
-  }, [intent]);
-
   return (
     <div className={cx("root", `intent-${intent}`, className)}>
       <div className={cx("icon-container")}>
-        <Icon iconName={iconName} size="default" tint={iconTint} />
+        <Icon iconName={iconName} size="default" intent={intent} />
       </div>
       <div className={cx("container")}>
         {title && <div className={cx("title")}>{title}</div>}

--- a/packages/ui-components/src/InlineAlert/__snapshots__/InlineAlert.test.tsx.snap
+++ b/packages/ui-components/src/InlineAlert/__snapshots__/InlineAlert.test.tsx.snap
@@ -1,16 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`InlineAlert renders with error intent 1`] = `
+exports[`InlineAlert renders with danger intent 1`] = `
 <div
-  className="root intent-error"
+  className="root intent-danger"
 >
   <div
     className="icon-container"
   >
     <Component
       iconName="ErrorCircleFilled"
+      intent="danger"
       size="default"
-      tint="red"
     />
   </div>
   <div
@@ -34,8 +34,8 @@ exports[`InlineAlert renders with info intent 1`] = `
   >
     <Component
       iconName="InfoCircleFilled"
+      intent="info"
       size="default"
-      tint="blue"
     />
   </div>
   <div
@@ -59,8 +59,8 @@ exports[`InlineAlert renders with provided description 1`] = `
   >
     <Component
       iconName="InfoCircleFilled"
+      intent="info"
       size="default"
-      tint="blue"
     />
   </div>
   <div
@@ -84,8 +84,8 @@ exports[`InlineAlert renders with provided title 1`] = `
   >
     <Component
       iconName="InfoCircleFilled"
+      intent="info"
       size="default"
-      tint="blue"
     />
   </div>
   <div
@@ -109,8 +109,8 @@ exports[`InlineAlert renders with provided title and description 1`] = `
   >
     <Component
       iconName="InfoCircleFilled"
+      intent="info"
       size="default"
-      tint="blue"
     />
   </div>
   <div
@@ -139,8 +139,8 @@ exports[`InlineAlert renders with success intent 1`] = `
   >
     <Component
       iconName="CheckCircleFilled"
+      intent="success"
       size="default"
-      tint="green"
     />
   </div>
   <div
@@ -164,8 +164,8 @@ exports[`InlineAlert renders with undefined intent 1`] = `
   >
     <Component
       iconName="InfoCircleFilled"
+      intent="info"
       size="default"
-      tint="blue"
     />
   </div>
   <div
@@ -189,8 +189,8 @@ exports[`InlineAlert renders with warning intent 1`] = `
   >
     <Component
       iconName="Caution"
+      intent="warning"
       size="default"
-      tint="orange"
     />
   </div>
   <div

--- a/packages/ui-components/src/InlineAlert/__snapshots__/InlineAlert.test.tsx.snap
+++ b/packages/ui-components/src/InlineAlert/__snapshots__/InlineAlert.test.tsx.snap
@@ -8,8 +8,8 @@ exports[`InlineAlert renders with danger intent 1`] = `
     className="icon-container"
   >
     <Component
+      fill="danger"
       iconName="ErrorCircleFilled"
-      intent="danger"
       size="default"
     />
   </div>
@@ -33,8 +33,8 @@ exports[`InlineAlert renders with info intent 1`] = `
     className="icon-container"
   >
     <Component
+      fill="info"
       iconName="InfoCircleFilled"
-      intent="info"
       size="default"
     />
   </div>
@@ -58,8 +58,8 @@ exports[`InlineAlert renders with provided description 1`] = `
     className="icon-container"
   >
     <Component
+      fill="info"
       iconName="InfoCircleFilled"
-      intent="info"
       size="default"
     />
   </div>
@@ -83,8 +83,8 @@ exports[`InlineAlert renders with provided title 1`] = `
     className="icon-container"
   >
     <Component
+      fill="info"
       iconName="InfoCircleFilled"
-      intent="info"
       size="default"
     />
   </div>
@@ -108,8 +108,8 @@ exports[`InlineAlert renders with provided title and description 1`] = `
     className="icon-container"
   >
     <Component
+      fill="info"
       iconName="InfoCircleFilled"
-      intent="info"
       size="default"
     />
   </div>
@@ -138,8 +138,8 @@ exports[`InlineAlert renders with success intent 1`] = `
     className="icon-container"
   >
     <Component
+      fill="success"
       iconName="CheckCircleFilled"
-      intent="success"
       size="default"
     />
   </div>
@@ -163,8 +163,8 @@ exports[`InlineAlert renders with undefined intent 1`] = `
     className="icon-container"
   >
     <Component
+      fill="info"
       iconName="InfoCircleFilled"
-      intent="info"
       size="default"
     />
   </div>
@@ -188,8 +188,8 @@ exports[`InlineAlert renders with warning intent 1`] = `
     className="icon-container"
   >
     <Component
+      fill="warning"
       iconName="Caution"
-      intent="warning"
       size="default"
     />
   </div>


### PR DESCRIPTION
<!--
  Please add a title to your Pull Request with the package the changes
  occured in.
-->
# ui-components // refactor icon component

Tint is not used, replaced with intent, inline styling added for container incase container styling is needed (if Icon is more widely used in console, it will need container styling. Currently for being used in ui-component, in NewPasswordInput, we don't need container styling).

#### Checklist
- [ ] I have written or updated test for the changes I made
- [ ] I have updated the README of the package I'm working in to reflect my changes
- [ ] I have added or updated Storybook if appropriate for my changes

