### PR TITLE
ui-components: Illustration flexible height

### DIFF
--- a/packages/ui-components/src/Icon/Illustration.module.scss
+++ b/packages/ui-components/src/Icon/Illustration.module.scss
@@ -1,4 +1,5 @@
 .illustration {
+  height: 100%;
   max-height: 152px;
   max-width: 240px;
   width: 100%;


### PR DESCRIPTION
Adding height 100% for illustrations to fill their containers up to a
maximum specified by the design system.