### PR TITLE
Add version tag prefix for admin-ui-components

### DIFF
--- a/packages/admin-ui-components/.yarnrc
+++ b/packages/admin-ui-components/.yarnrc
@@ -1,0 +1,1 @@
+version-tag-prefix "@cockroachlabs/admin-ui-components@"


### PR DESCRIPTION
# Admin UI Components // Add version tag prefix

Necessary for clarity and to trigger the publish
step in the package.