### PR TITLE
db-console: directly set base path for API requests

### DIFF
--- a/packages/admin-ui-components/package.json
+++ b/packages/admin-ui-components/package.json
@@ -27,8 +27,8 @@
   "license": "MIT",
   "dependencies": {
     "@cockroachlabs/crdb-protobuf-client": "^0.0.3",
-    "@cockroachlabs/icons": "^0.3.0",
-    "@cockroachlabs/ui-components": "^0.2.14-alpha.0",
+    "@cockroachlabs/icons": "0.3.0",
+    "@cockroachlabs/ui-components": "0.2.14-alpha.0",
     "@popperjs/core": "^2.4.0",
     "@reduxjs/toolkit": "^1.5.0",
     "babel-polyfill": "^6.26.0",

--- a/packages/admin-ui-components/src/api/basePath.ts
+++ b/packages/admin-ui-components/src/api/basePath.ts
@@ -1,0 +1,5 @@
+let path = "";
+
+export const setBasePath = (basePath: string) => (path = basePath);
+
+export const getBasePath = () => path;

--- a/packages/admin-ui-components/src/api/fetchData.ts
+++ b/packages/admin-ui-components/src/api/fetchData.ts
@@ -1,5 +1,6 @@
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { RequestError } from "../util";
+import { getBasePath } from "./basePath";
 
 interface ProtoBuilder<
   P extends ConstructorType,
@@ -45,8 +46,9 @@ export const fetchData = <P extends ProtoBuilder<P>, T extends ProtoBuilder<T>>(
     params.method = "POST";
     params.body = toArrayBuffer(encodedRequest);
   }
+  const basePath = getBasePath();
 
-  return fetch(path, params)
+  return fetch(`${basePath}${path}`, params)
     .then(response => {
       if (!response.ok) {
         return response.arrayBuffer().then(buffer => {

--- a/packages/admin-ui-components/src/api/index.ts
+++ b/packages/admin-ui-components/src/api/index.ts
@@ -1,3 +1,4 @@
 export * from "./fetchData";
 export * from "./statementDiagnosticsApi";
 export * from "./statementsApi";
+export * from "./basePath";

--- a/packages/admin-ui-components/src/api/statementsApi.ts
+++ b/packages/admin-ui-components/src/api/statementsApi.ts
@@ -3,11 +3,9 @@ import { fetchData } from "src/api";
 
 const STATEMENTS_PATH = "/_status/statements";
 
-export const getStatements = (
-  basePath = "",
-): Promise<cockroach.server.serverpb.StatementsResponse> => {
+export const getStatements = (): Promise<cockroach.server.serverpb.StatementsResponse> => {
   return fetchData(
     cockroach.server.serverpb.StatementsResponse,
-    `${basePath}${STATEMENTS_PATH}`,
+    STATEMENTS_PATH,
   );
 };

--- a/packages/admin-ui-components/src/index.ts
+++ b/packages/admin-ui-components/src/index.ts
@@ -1,6 +1,7 @@
 import "antd/dist/antd.less";
 import "./protobufInit";
 import * as util from "./util";
+import * as api from "./api";
 export * from "./anchor";
 export * from "./badge";
 export * from "./barCharts";
@@ -22,4 +23,4 @@ export * from "./transactionsPage";
 export * from "./text";
 export * from "./tooltip";
 export * from "./tooltip2";
-export { util };
+export { util, api };

--- a/packages/admin-ui-components/src/store/sagas.ts
+++ b/packages/admin-ui-components/src/store/sagas.ts
@@ -4,10 +4,10 @@ import { localStorageSaga } from "./localStorage";
 import { statementsDiagnosticsSagas } from "./statementDiagnostics";
 import { statementsSaga } from "./statements";
 
-export function* sagas(cacheInvalidationPeriod?: number, apiBasePath?: string) {
+export function* sagas(cacheInvalidationPeriod?: number) {
   yield all([
     fork(localStorageSaga),
-    fork(statementsSaga, cacheInvalidationPeriod, apiBasePath),
+    fork(statementsSaga, cacheInvalidationPeriod),
     fork(statementsDiagnosticsSagas, cacheInvalidationPeriod),
   ]);
 }

--- a/packages/admin-ui-components/src/store/statements/statements.sagas.spec.ts
+++ b/packages/admin-ui-components/src/store/statements/statements.sagas.spec.ts
@@ -1,4 +1,4 @@
-import { expectSaga, testSaga } from "redux-saga-test-plan";
+import { expectSaga } from "redux-saga-test-plan";
 import { throwError } from "redux-saga-test-plan/providers";
 import * as matchers from "redux-saga-test-plan/matchers";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
@@ -51,14 +51,6 @@ describe("StatementsPage sagas", () => {
           valid: false,
         })
         .run();
-    });
-
-    it("accepts custom apiPath as an argument for statements api", () => {
-      const customBasePath = "customBasePath";
-      testSaga(requestStatementsSaga, customBasePath)
-        .next()
-        .call(getStatements, customBasePath)
-        .finish();
     });
   });
 

--- a/packages/admin-ui-components/src/store/statements/statements.sagas.ts
+++ b/packages/admin-ui-components/src/store/statements/statements.sagas.ts
@@ -8,9 +8,9 @@ export function* refreshStatementsSaga() {
   yield put(actions.request());
 }
 
-export function* requestStatementsSaga(apiBasePath: string) {
+export function* requestStatementsSaga() {
   try {
-    const result = yield call(getStatements, apiBasePath);
+    const result = yield call(getStatements);
     yield put(actions.received(result));
   } catch (e) {
     yield put(actions.failed(e));
@@ -24,7 +24,6 @@ export function* receivedStatementsSaga(delayMs: number) {
 
 export function* statementsSaga(
   cacheInvalidationPeriod: number = CACHE_INVALIDATION_PERIOD,
-  apiBasePath: string = undefined,
 ) {
   yield all([
     throttleWithReset(
@@ -33,7 +32,7 @@ export function* statementsSaga(
       [actions.invalidated, actions.failed],
       refreshStatementsSaga,
     ),
-    takeLatest(actions.request, requestStatementsSaga, apiBasePath),
+    takeLatest(actions.request, requestStatementsSaga),
     takeLatest(
       actions.received,
       receivedStatementsSaga,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1288,7 +1288,12 @@
   resolved "https://registry.yarnpkg.com/@cockroachlabs/crdb-protobuf-client/-/crdb-protobuf-client-0.0.3.tgz#3ce8dd4953a1209f1895c713cf90595a15c54ab1"
   integrity sha512-AXHWWW7hI05hj5fTdXgIIjfZrqfacQ/zsT83LoUsrnFUOeWZCa6qSF3qVonaR2h8FloRfEeFhC+27TDsi8RI0A==
 
-"@cockroachlabs/ui-components@next":
+"@cockroachlabs/icons@0.3.0", "@cockroachlabs/icons@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@cockroachlabs/icons/-/icons-0.3.0.tgz#160573074396f266e92fcbe5e520c5ba1d8750f9"
+  integrity sha512-GJxhlXy8Z3/PYFb9C3iM1dvU9wajGoaA/+VCj0an2ipfbkI2fhToq+h0b33vu7JuZ3dS4QMRjfVE4uhlyIUH2Q==
+
+"@cockroachlabs/ui-components@0.2.14-alpha.0", "@cockroachlabs/ui-components@next":
   version "0.2.14-alpha.0"
   resolved "https://registry.yarnpkg.com/@cockroachlabs/ui-components/-/ui-components-0.2.14-alpha.0.tgz#d90a7ce6fbede9d8b177d9a940f24218c262d267"
   integrity sha512-8zOZswstmBbJQxXmQ7yfEXEOEUJ4JT5xlzGQ5FD7z8sjy67UDXFoe6FMqFXrkpiFwlCrkK2Vd36LKhLvGY2xkA==


### PR DESCRIPTION
<!--
  Please add a title to your Pull Request with the package the changes
  occured in.
-->
# db-console // provide base path for API requests

<!--
  Please describe your changes by describing motivation, linking to issues,
  and adding screenshots or gifs to illustrate your changes for reviewers
 -->

Ported from PR https://github.com/cockroachdb/admin-ui-components/pull/48

#### Checklist
- [ ] I have written or updated test for the changes I made
- [ ] I have updated the README of the package I'm working in to reflect my changes
- [ ] I have added or updated Storybook if appropriate for my changes

With new requirements, base path for api calls can be arbitrary and
might not rely on browser's path or whatever.
This change implements getter/setter functions to directly set
base path which is needed to use for api requests.

Also it simplifies and eliminates passing basePath as extra
argument through sagas.


