### PR TITLE
ui: Extract Sessions Page from DB Console

### DIFF
--- a/packages/admin-ui-components/.storybook/decorators/index.ts
+++ b/packages/admin-ui-components/.storybook/decorators/index.ts
@@ -1,0 +1,12 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+export * from "./withRouterProvider";
+export * from "./withBackground";

--- a/packages/admin-ui-components/.storybook/decorators/withBackground.tsx
+++ b/packages/admin-ui-components/.storybook/decorators/withBackground.tsx
@@ -1,0 +1,17 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+
+export const withBackgroundFactory = (backgroundColor = "#F5F7FA") => (storyFn: any) => (
+  <div style={{backgroundColor}}>
+    {storyFn()}
+  </div>
+);

--- a/packages/admin-ui-components/.storybook/decorators/withRouterProvider.tsx
+++ b/packages/admin-ui-components/.storybook/decorators/withRouterProvider.tsx
@@ -1,0 +1,30 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import {Provider} from "react-redux";
+import {ConnectedRouter, connectRouter} from "connected-react-router";
+import {createMemoryHistory} from "history";
+import { createStore, combineReducers } from "redux";
+
+const history = createMemoryHistory();
+const routerReducer = connectRouter(history);
+
+const store = createStore(combineReducers({
+  router: routerReducer,
+}));
+
+export const withRouterProvider = (storyFn: any) => (
+  <Provider store={store}>
+    <ConnectedRouter history={history}>
+      { storyFn() }
+    </ConnectedRouter>
+  </Provider>
+);

--- a/packages/admin-ui-components/src/dropdown/dropdown.module.scss
+++ b/packages/admin-ui-components/src/dropdown/dropdown.module.scss
@@ -45,3 +45,12 @@
   color: $colors--white;
   background-color: $colors--primary-blue-3;
 }
+
+.crl-dropdown__item--disabled{
+  color: $colors--neutral-4;
+  &:hover{
+      color: $colors--neutral-4;
+      background-color: $colors--white;
+      cursor: default;
+    }
+}

--- a/packages/admin-ui-components/src/dropdown/dropdown.tsx
+++ b/packages/admin-ui-components/src/dropdown/dropdown.tsx
@@ -11,6 +11,7 @@ const cx = classnames.bind(styles);
 export interface DropdownOption<T = string> {
   value: T;
   name: React.ReactNode | string;
+  disabled?: boolean;
 }
 
 export interface DropdownProps<T> {
@@ -52,9 +53,14 @@ const DropdownButton: React.FC<DropdownButtonProps> = ({
 };
 
 function DropdownItem<T = string>(props: DropdownItemProps<T>) {
-  const { children, value, onClick } = props;
+  const { children, value, onClick, disabled } = props;
   return (
-    <div onClick={() => onClick(value)} className={cx("crl-dropdown__item")}>
+    <div
+      onClick={() => onClick(value)}
+      className={cx("crl-dropdown__item", {
+        "crl-dropdown__item--disabled": disabled,
+      })}
+    >
       {children}
     </div>
   );
@@ -121,6 +127,7 @@ export class Dropdown<T = string> extends React.Component<
         value={menuItem.value}
         onClick={this.handleItemSelection}
         key={idx}
+        disabled={menuItem.disabled}
       >
         {menuItem.name}
       </DropdownItem>
@@ -150,4 +157,5 @@ export interface DropdownItemProps<T> {
   children: React.ReactNode;
   value: T;
   onClick: (value: T) => void;
+  disabled?: boolean;
 }

--- a/packages/admin-ui-components/src/index.ts
+++ b/packages/admin-ui-components/src/index.ts
@@ -24,3 +24,4 @@ export * from "./text";
 export * from "./tooltip";
 export * from "./tooltip2";
 export { util, api };
+export * from "./sessions";

--- a/packages/admin-ui-components/src/sessions/index.ts
+++ b/packages/admin-ui-components/src/sessions/index.ts
@@ -1,0 +1,3 @@
+export * from "./sessionsPage";
+export * from "./sessionDetails";
+export { byteArrayToUuid } from "./sessionsTable";

--- a/packages/admin-ui-components/src/sessions/sessionDetails.module.scss
+++ b/packages/admin-ui-components/src/sessions/sessionDetails.module.scss
@@ -1,0 +1,47 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+@import "../core/index.module.scss";
+
+.heading-with-controls {
+  display: flex;
+  flex-direction: row;
+  padding-right: $spacing-medium;
+}
+
+.page--header__title {
+  flex-grow: 1;
+  margin-bottom: $spacing-small;
+}
+
+.heading-controls-group {
+  margin-bottom: $spacing-small;
+  > * {
+    margin-left: $spacing-xx-small;
+  }
+}
+
+.details-section {
+  padding: $spacing-small $spacing-medium;
+  margin-bottom: $spacing-large;
+}
+
+.details-header {
+  margin-bottom: 12px;
+}
+
+.details-item {
+  height: $line-height--x-large;
+  margin-bottom: unset;
+  align-items: center;
+  &:not(:last-child) {
+    box-shadow: 0 1px 0 #dbe1ea;
+  }
+}

--- a/packages/admin-ui-components/src/sessions/sessionDetails.tsx
+++ b/packages/admin-ui-components/src/sessions/sessionDetails.tsx
@@ -1,0 +1,344 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { getMatchParamByName } from "src/util/query";
+import { sessionAttr } from "src/util/constants";
+import { Helmet } from "react-helmet";
+import { Loading } from "../loading";
+import _ from "lodash";
+import { Link, RouteComponentProps, withRouter } from "react-router-dom";
+
+import { SessionInfo } from "./sessionsTable";
+
+import styles from "./sessionDetails.module.scss";
+import classNames from "classnames/bind";
+import { SummaryCard, SummaryCardItem } from "../summaryCard";
+
+import { TimestampToMoment } from "src/util/convert";
+import { Bytes, DATE_FORMAT } from "src/util/format";
+import { Col, Row } from "antd";
+
+import TerminateSessionModal, {
+  TerminateSessionModalRef,
+} from "./terminateSessionModal";
+import TerminateQueryModal, {
+  TerminateQueryModalRef,
+} from "./terminateQueryModal";
+import { Button } from "../button";
+import { ArrowLeft } from "@cockroachlabs/icons";
+import { Text, TextTypes } from "../text";
+import { SqlBox } from "src/sql/box";
+import {
+  NodeLink,
+  StatementLinkTarget,
+} from "src/statementsTable/statementsTableContent";
+
+//import {refreshSessions} from "src/redux/apiReducers";
+
+type ICancelQueryRequest = any;
+interface OwnProps {
+  id: string;
+  nodeNames: { [nodeId: string]: string };
+  session: SessionInfo;
+  sessionError: Error | null;
+  //refreshSessions: typeof refreshSessions;
+  refreshSessions: any;
+  cancel?: (req: ICancelQueryRequest) => void;
+}
+
+const cx = classNames.bind(styles);
+export type SessionDetailsProps = OwnProps & RouteComponentProps;
+
+function yesOrNo(b: boolean) {
+  return b ? "Yes" : "No";
+}
+
+export const MemoryUsageItem: React.FC<{
+  alloc_bytes: Long;
+  max_alloc_bytes: Long;
+}> = ({ alloc_bytes, max_alloc_bytes }) => (
+  <SummaryCardItem
+    label={"Memory Usage"}
+    value={
+      Bytes(alloc_bytes?.toNumber()) + "/" + Bytes(max_alloc_bytes?.toNumber())
+    }
+    className={cx("details-item")}
+  />
+);
+
+export class SessionDetails extends React.Component<SessionDetailsProps, {}> {
+  terminateSessionRef: React.RefObject<TerminateSessionModalRef>;
+  terminateQueryRef: React.RefObject<TerminateQueryModalRef>;
+
+  componentDidMount() {
+    this.props.refreshSessions();
+  }
+
+  componentDidUpdate() {
+    // Normally, we would refresh the sessions here, but we don't want to
+    // have the per-session page update whenever our data source updates
+    // because in real workloads, sessions change what they're doing very
+    // regularly, leading to a confusing and too-fast-refreshing page
+    // experience for people trying to understand what is happening in a
+    // particular session.
+    // this.props.refreshSessions();
+  }
+
+  constructor(props: SessionDetailsProps) {
+    super(props);
+    this.terminateSessionRef = React.createRef();
+    this.terminateQueryRef = React.createRef();
+  }
+
+  backToSessionsPage = () => {
+    const { history, location } = this.props;
+    history.push({
+      ...location,
+      pathname: "/sessions",
+    });
+  };
+
+  render() {
+    const sessionID = getMatchParamByName(this.props.match, sessionAttr);
+    const { sessionError, cancel } = this.props;
+    const session = this.props.session?.session;
+    const showActionButtons = !!session && !sessionError;
+    return (
+      <div>
+        <Helmet title={`Details | ${sessionID} | Sessions`} />
+        <div className={cx("section", "page--header")}>
+          <Button
+            onClick={this.backToSessionsPage}
+            type="unstyled-link"
+            size="small"
+            icon={<ArrowLeft fontSize={"10px"} />}
+            iconPosition="left"
+          >
+            Sessions
+          </Button>
+          <div className={cx("heading-with-controls")}>
+            <h1 className={cx("base-heading", "page--header__title")}>
+              Session details
+            </h1>
+            {showActionButtons && (
+              <div className={cx("heading-controls-group")}>
+                <Button
+                  disabled={session.active_queries?.length === 0}
+                  onClick={() => {
+                    if (session.active_queries?.length > 0) {
+                      this.terminateQueryRef?.current?.showModalFor({
+                        query_id: session.active_queries[0].id,
+                        node_id: session.node_id.toString(),
+                      });
+                    }
+                  }}
+                  type="secondary"
+                  size="small"
+                >
+                  Cancel query
+                </Button>
+                <Button
+                  onClick={() =>
+                    this.terminateSessionRef?.current?.showModalFor({
+                      session_id: session.id,
+                      node_id: session.node_id.toString(),
+                    })
+                  }
+                  type="secondary"
+                  size="small"
+                >
+                  Cancel session
+                </Button>
+              </div>
+            )}
+          </div>
+        </div>
+        <section className={cx("section", "section--container")}>
+          <Loading
+            loading={_.isNil(this.props.session)}
+            error={this.props.sessionError}
+            render={this.renderContent}
+          />
+        </section>
+        <TerminateSessionModal ref={this.terminateSessionRef} cancel={cancel} />
+        <TerminateQueryModal ref={this.terminateQueryRef} cancel={cancel} />
+      </div>
+    );
+  }
+
+  renderContent = () => {
+    if (!this.props.session) {
+      return null;
+    }
+    const { session } = this.props.session;
+
+    if (!session) {
+      return (
+        <section className={cx("section")}>
+          <h3>Unable to find session</h3>
+          There is no currently active session with the id{" "}
+          {getMatchParamByName(this.props.match, sessionAttr)}.
+          <div>
+            <Link className={cx("back-link")} to={"/sessions"}>
+              Back to Sessions
+            </Link>
+          </div>
+        </section>
+      );
+    }
+
+    let txnInfo = <React.Fragment>No Active Transaction</React.Fragment>;
+    if (session.active_txn) {
+      const txn = session.active_txn;
+      const start = TimestampToMoment(txn.start);
+      txnInfo = (
+        <Row gutter={16}>
+          <Col className="gutter-row" span={10}>
+            <SummaryCardItem
+              label={"Transaction Start Time"}
+              value={start.format(DATE_FORMAT)}
+              className={cx("details-item")}
+            />
+            <SummaryCardItem
+              label={"Number of Statements Executed"}
+              value={txn.num_statements_executed}
+              className={cx("details-item")}
+            />
+            <SummaryCardItem
+              label={"Number of Retries"}
+              value={txn.num_retries}
+              className={cx("details-item")}
+            />
+            <SummaryCardItem
+              label={"Number of Automatic Retries"}
+              value={txn.num_auto_retries}
+              className={cx("details-item")}
+            />
+          </Col>
+          <Col className="gutter-row" span={4}></Col>
+          <Col className="gutter-row" span={10}>
+            <SummaryCardItem
+              label={"Priority"}
+              value={txn.priority}
+              className={cx("details-item")}
+            />
+            <SummaryCardItem
+              label={"Read Only?"}
+              value={yesOrNo(txn.read_only)}
+              className={cx("details-item")}
+            />
+            <SummaryCardItem
+              label={"AS OF SYSTEM TIME?"}
+              value={yesOrNo(txn.is_historical)}
+              className={cx("details-item")}
+            />
+            <MemoryUsageItem
+              alloc_bytes={txn.alloc_bytes}
+              max_alloc_bytes={txn.max_alloc_bytes}
+            />
+          </Col>
+        </Row>
+      );
+    }
+    let curStmtInfo = (
+      <SummaryCard className={cx("details-section")}>
+        No Active Statement
+      </SummaryCard>
+    );
+
+    if (session.active_queries?.length > 0) {
+      const stmt = session.active_queries[0];
+      curStmtInfo = (
+        <React.Fragment>
+          <SqlBox value={stmt.sql}></SqlBox>
+          <SummaryCard className={cx("details-section")}>
+            <Row>
+              <Col className="gutter-row" span={10}>
+                <SummaryCardItem
+                  label={"Execution Start Time"}
+                  value={TimestampToMoment(stmt.start).format(DATE_FORMAT)}
+                  className={cx("details-item")}
+                />
+                <Link
+                  to={StatementLinkTarget({
+                    statement: stmt.sql,
+                    anonStatement: stmt.sql_anon,
+                    implicitTxn: session.active_txn?.implicit,
+                    app: "",
+                    search: "",
+                  })}
+                >
+                  View Statement Details
+                </Link>
+              </Col>
+              <Col className="gutter-row" span={4}></Col>
+              <Col className="gutter-row" span={10}>
+                <SummaryCardItem
+                  label={"Distributed Execution?"}
+                  value={yesOrNo(stmt.is_distributed)}
+                  className={cx("details-item")}
+                />
+              </Col>
+            </Row>
+          </SummaryCard>
+        </React.Fragment>
+      );
+    }
+
+    return (
+      <React.Fragment>
+        <SummaryCard className={cx("details-section")}>
+          <Row gutter={12}>
+            <Col className="gutter-row" span={10}>
+              <SummaryCardItem
+                label={"Session Start Time"}
+                value={TimestampToMoment(session.start).format(DATE_FORMAT)}
+                className={cx("details-item")}
+              />
+              <SummaryCardItem
+                label={"Gateway Node"}
+                value={
+                  <NodeLink
+                    nodeId={session.node_id.toString()}
+                    nodeNames={this.props.nodeNames}
+                  />
+                }
+                className={cx("details-item")}
+              />
+            </Col>
+            <Col className="gutter-row" span={4}></Col>
+            <Col className="gutter-row" span={10}>
+              <SummaryCardItem
+                label={"Client Address"}
+                value={session.client_address}
+                className={cx("details-item")}
+              />
+              <MemoryUsageItem
+                alloc_bytes={session.alloc_bytes}
+                max_alloc_bytes={session.max_alloc_bytes}
+              />
+            </Col>
+          </Row>
+        </SummaryCard>
+        <Text textType={TextTypes.Heading5} className={cx("details-header")}>
+          Transaction
+        </Text>
+        <SummaryCard className={cx("details-section")}>{txnInfo}</SummaryCard>
+        <Text textType={TextTypes.Heading5} className={cx("details-header")}>
+          Statement
+        </Text>
+        {curStmtInfo}
+      </React.Fragment>
+    );
+  };
+}
+
+export default SessionDetails;

--- a/packages/admin-ui-components/src/sessions/sessionDetailsPage.fixture.ts
+++ b/packages/admin-ui-components/src/sessions/sessionDetailsPage.fixture.ts
@@ -1,0 +1,66 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+//import {refreshSessions} from "src/redux/apiReducers";
+import { createMemoryHistory } from "history";
+import { SessionDetailsProps } from "./sessionDetails";
+import {
+  activeSession,
+  idleSession,
+  idleTransactionSession,
+} from "./sessionsPage.fixture";
+import { sessionAttr } from "src/util/constants";
+
+const history = createMemoryHistory({ initialEntries: ["/sessions"] });
+
+const sessionDetailsPropsBase: SessionDetailsProps = {
+  id: "blah",
+  nodeNames: {
+    1: "localhost",
+  },
+  sessionError: null,
+  session: null,
+  history,
+  location: {
+    pathname: "/sessions/blah",
+    search: "",
+    hash: "",
+    state: null,
+  },
+  match: {
+    path: "/sessions/blah",
+    url: "/sessions/blah",
+    isExact: true,
+    params: { [sessionAttr]: "blah" },
+  },
+  //refreshSessions: (() => {}) as (typeof refreshSessions),
+  refreshSessions: (() => {}) as any,
+  cancel: (() => {}) as any,
+};
+
+export const sessionDetailsIdlePropsFixture: SessionDetailsProps = {
+  ...sessionDetailsPropsBase,
+  session: idleSession,
+};
+
+export const sessionDetailsActiveTxnPropsFixture: SessionDetailsProps = {
+  ...sessionDetailsPropsBase,
+  session: idleTransactionSession,
+};
+
+export const sessionDetailsActiveStmtPropsFixture: SessionDetailsProps = {
+  ...sessionDetailsPropsBase,
+  session: activeSession,
+};
+
+export const sessionDetailsNotFound: SessionDetailsProps = {
+  ...sessionDetailsPropsBase,
+  session: { session: null },
+};

--- a/packages/admin-ui-components/src/sessions/sessionDetailsPage.stories.tsx
+++ b/packages/admin-ui-components/src/sessions/sessionDetailsPage.stories.tsx
@@ -1,0 +1,40 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { storiesOf } from "@storybook/react";
+
+import {
+  withBackgroundFactory,
+  withRouterProvider,
+} from "../../.storybook/decorators";
+import { SessionDetails } from "./sessionDetails";
+import {
+  sessionDetailsActiveStmtPropsFixture,
+  sessionDetailsActiveTxnPropsFixture,
+  sessionDetailsIdlePropsFixture,
+  sessionDetailsNotFound,
+} from "./sessionDetailsPage.fixture";
+
+storiesOf("Session Details Page", module)
+  .addDecorator(withRouterProvider)
+  .addDecorator(withBackgroundFactory())
+  .add("Idle Session", () => (
+    <SessionDetails {...sessionDetailsIdlePropsFixture} />
+  ))
+  .add("Idle Txn", () => (
+    <SessionDetails {...sessionDetailsActiveTxnPropsFixture} />
+  ))
+  .add("Session", () => (
+    <SessionDetails {...sessionDetailsActiveStmtPropsFixture} />
+  ))
+  .add("Session Not Found", () => (
+    <SessionDetails {...sessionDetailsNotFound} />
+  ));

--- a/packages/admin-ui-components/src/sessions/sessionsPage.fixture.ts
+++ b/packages/admin-ui-components/src/sessions/sessionsPage.fixture.ts
@@ -1,0 +1,174 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { SessionsPageProps } from "./sessionsPage";
+//import {refreshSessions} from "src/redux/apiReducers";
+import { createMemoryHistory } from "history";
+import { SessionInfo } from "./sessionsTable";
+import Long from "long";
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+const Phase = cockroach.server.serverpb.ActiveQuery.Phase;
+import { util } from "protobufjs";
+
+const history = createMemoryHistory({ initialEntries: ["/sessions"] });
+
+const toUuid = function(s: string): Uint8Array {
+  const buf = util.newBuffer(util.base64.length(s));
+  util.base64.decode(s, buf, 0);
+  return buf;
+};
+
+export const idleSession: SessionInfo = {
+  session: {
+    node_id: 1,
+    username: "root",
+    client_address: "127.0.0.1:57618",
+    application_name: "$ cockroach sql",
+    start: {
+      seconds: Long.fromNumber(1596816670),
+      nanos: 369989000,
+    },
+    last_active_query: "SHOW database",
+    id: toUuid("FikITSjUZoAAAAAAAAAAAQ=="),
+    last_active_query_anon: "SHOW database",
+    alloc_bytes: Long.fromNumber(0),
+    max_alloc_bytes: Long.fromNumber(10240),
+  },
+};
+
+export const idleTransactionSession = {
+  session: {
+    node_id: 1,
+    username: "root",
+    client_address: "127.0.0.1:57623",
+    application_name: "$ cockroach sql",
+    alloc_bytes: Long.fromNumber(0),
+    max_alloc_bytes: Long.fromNumber(10240),
+    start: {
+      seconds: Long.fromNumber(1596816671),
+      nanos: 835905000,
+    },
+    last_active_query: "SHOW database",
+    id: toUuid("FikITYA0lGgAAAAAAAAAAQ=="),
+    active_txn: {
+      id: toUuid("LDzmvKMqTvaVhIaBhejfgw=="),
+      start: {
+        seconds: Long.fromNumber(1596816673),
+        nanos: 134293000,
+      },
+      txn_description:
+        '"sql txn" meta={id=2c3ce6bc key=/Min pri=0.04688813 epo=0 ts=1596816673.134285000,0 min=1596816673.134285000,0 seq=0} lock=false stat=PENDING rts=1596816673.134285000,0 wto=false max=1596816673.634285000,0',
+      num_statements_executed: 2,
+      deadline: {
+        seconds: Long.fromNumber(-62135596800),
+      },
+      priority: "normal",
+      implicit: false,
+      num_retries: 5,
+      num_auto_retries: 3,
+    },
+    last_active_query_anon: "SHOW database",
+  },
+};
+
+export const activeSession: SessionInfo = {
+  session: {
+    node_id: 1,
+    username: "root",
+    client_address: "127.0.0.1:57632",
+    application_name: "$ cockroach sql",
+    active_queries: [
+      {
+        id: "16290b41dddca4600000000000000001",
+        sql: "SELECT pg_sleep(1000)",
+        start: {
+          seconds: Long.fromNumber(1596819920),
+          nanos: 402524000,
+        },
+        phase: Phase.EXECUTING,
+        txn_id: toUuid("e8NTvpOvScO1tSMreygtcg=="),
+        sql_anon: "SELECT pg_sleep(_)",
+      },
+    ],
+    start: {
+      seconds: Long.fromNumber(1596816675),
+      nanos: 652814000,
+    },
+    last_active_query: "SHOW database",
+    id: toUuid("FikITmO2BQAAAAAAAAAAAQ=="),
+    alloc_bytes: Long.fromNumber(10240),
+    max_alloc_bytes: Long.fromNumber(10240),
+    active_txn: {
+      id: toUuid("e8NTvpOvScO1tSMreygtcg=="),
+      start: {
+        seconds: Long.fromNumber(1596816677),
+        nanos: 320351000,
+      },
+      txn_description:
+        '"sql txn" meta={id=7bc353be key=/Min pri=0.05293838 epo=0 ts=1596816677.320344000,0 min=1596816677.320344000,0 seq=0} lock=false stat=PENDING rts=1596816677.320344000,0 wto=false max=1596816677.820344000,0',
+      num_statements_executed: 4,
+      deadline: {
+        seconds: Long.fromNumber(-62135596800),
+      },
+      alloc_bytes: Long.fromNumber(0),
+      max_alloc_bytes: Long.fromNumber(10240),
+      priority: "normal",
+      implicit: true,
+      num_retries: 5,
+      num_auto_retries: 3,
+    },
+    last_active_query_anon: "SHOW database",
+  },
+};
+
+const sessionsList: SessionInfo[] = [
+  idleSession,
+  idleTransactionSession,
+  activeSession,
+];
+
+export const sessionsPagePropsFixture: SessionsPageProps = {
+  history,
+  location: {
+    pathname: "/sessions",
+    search: "",
+    hash: "",
+    state: null,
+  },
+  match: {
+    path: "/sessions",
+    url: "/sessions",
+    isExact: true,
+    params: {},
+  },
+  sessions: sessionsList,
+  sessionsError: null,
+  refreshSessions: (() => {}) as any,
+};
+
+export const sessionsPagePropsEmptyFixture: SessionsPageProps = {
+  history,
+  location: {
+    pathname: "/sessions",
+    search: "",
+    hash: "",
+    state: null,
+  },
+  match: {
+    path: "/sessions",
+    url: "/sessions",
+    isExact: true,
+    params: {},
+  },
+  sessions: [],
+  sessionsError: null,
+  refreshSessions: (() => {}) as any,
+  cancel: (() => {}) as any,
+};

--- a/packages/admin-ui-components/src/sessions/sessionsPage.module.scss
+++ b/packages/admin-ui-components/src/sessions/sessionsPage.module.scss
@@ -1,0 +1,49 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+@import "../core/index.module.scss";
+
+.cl-table-statistic {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 7px;
+}
+
+.cl-count-title {
+  font-family: SourceSansPro-Regular;
+  font-size: 14px;
+  padding: 0px;
+  margin: 0px;
+  color: $placeholder;
+  line-height: 1.57;
+  letter-spacing: 0.1px;
+  .label {
+    font-family: $font-family--bold;
+    color: $colors--neutral-7;
+  }
+}
+
+.section {
+  flex: 0 0 auto;
+  padding: 12px 24px;
+
+  &--heading {
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+
+  &--container {
+    padding: 0 24px 0 0;
+  }
+}
+
+.base-heading {
+  @include text--heading-2;
+}

--- a/packages/admin-ui-components/src/sessions/sessionsPage.stories.tsx
+++ b/packages/admin-ui-components/src/sessions/sessionsPage.stories.tsx
@@ -1,0 +1,30 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { storiesOf } from "@storybook/react";
+
+import {
+  withBackgroundFactory,
+  withRouterProvider,
+} from "../../.storybook/decorators";
+import { SessionsPage } from "./sessionsPage";
+import {
+  sessionsPagePropsEmptyFixture,
+  sessionsPagePropsFixture,
+} from "./sessionsPage.fixture";
+
+storiesOf("Sessions Page", module)
+  .addDecorator(withRouterProvider)
+  .addDecorator(withBackgroundFactory())
+  .add("Overview Page", () => <SessionsPage {...sessionsPagePropsFixture} />)
+  .add("Empty Overview Page", () => (
+    <SessionsPage {...sessionsPagePropsEmptyFixture} />
+  ));

--- a/packages/admin-ui-components/src/sessions/sessionsPage.tsx
+++ b/packages/admin-ui-components/src/sessions/sessionsPage.tsx
@@ -1,0 +1,231 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { forIn, isNil, merge } from "lodash";
+
+import { getMatchParamByName } from "src/util/query";
+import { appAttr } from "src/util/constants";
+import {
+  makeSessionsColumns,
+  SessionInfo,
+  SessionsSortedTable,
+} from "./sessionsTable";
+import Helmet from "react-helmet";
+import { RouteComponentProps } from "react-router-dom";
+import classNames from "classnames/bind";
+import { sessionsTable } from "src/util/docs";
+
+import emptyTableResultsIcon from "../assets/emptyState/empty-table-results.svg";
+
+import { Pagination } from "antd";
+import { SortSetting } from "../sortedtable";
+import {
+  ISortedTablePagination,
+  ResultsPerPageLabel,
+  EmptyTable,
+  Anchor,
+  Loading,
+} from "src";
+import TerminateQueryModal, {
+  TerminateQueryModalRef,
+} from "./terminateQueryModal";
+import TerminateSessionModal, {
+  TerminateSessionModalRef,
+} from "./terminateSessionModal";
+
+import sortableTableStyles from "src/sortedtable/sortedtable.module.scss";
+
+const sortableTableCx = classNames.bind(sortableTableStyles);
+
+type ICancelQueryRequest = any;
+interface OwnProps {
+  sessions: SessionInfo[];
+  sessionsError: Error | null;
+  //refreshSessions: typeof refreshSessions;
+  refreshSessions: any;
+  cancel?: (req: ICancelQueryRequest) => void;
+  onPageChanged?: (newPage: number) => void;
+}
+
+export interface SessionsPageState {
+  sortSetting: SortSetting;
+  pagination: ISortedTablePagination;
+}
+
+export type SessionsPageProps = OwnProps & RouteComponentProps<any>;
+
+export class SessionsPage extends React.Component<
+  SessionsPageProps,
+  SessionsPageState
+> {
+  terminateSessionRef: React.RefObject<TerminateSessionModalRef>;
+  terminateQueryRef: React.RefObject<TerminateQueryModalRef>;
+
+  constructor(props: SessionsPageProps) {
+    super(props);
+    const defaultState = {
+      sortSetting: {
+        sortKey: 2, // Sort by Statement Age column as default option.
+        ascending: false,
+      },
+      pagination: {
+        pageSize: 20,
+        current: 1,
+      },
+    };
+
+    const stateFromHistory = this.getStateFromHistory();
+    this.state = merge(defaultState, stateFromHistory);
+    this.terminateSessionRef = React.createRef();
+    this.terminateQueryRef = React.createRef();
+  }
+
+  getStateFromHistory = (): Partial<SessionsPageState> => {
+    const { history } = this.props;
+    const searchParams = new URLSearchParams(history.location.search);
+    const sortKey = searchParams.get("sortKey") || undefined;
+    const ascending = searchParams.get("ascending") || undefined;
+
+    return {
+      sortSetting: {
+        sortKey: sortKey,
+        ascending: Boolean(ascending),
+      },
+    };
+  };
+
+  syncHistory = (params: Record<string, string | undefined>) => {
+    const { history } = this.props;
+    const currentSearchParams = new URLSearchParams(history.location.search);
+    forIn(params, (value, key) => {
+      if (!value) {
+        currentSearchParams.delete(key);
+      } else {
+        currentSearchParams.set(key, value);
+      }
+    });
+
+    history.location.search = currentSearchParams.toString();
+    history.replace(history.location);
+  };
+
+  changeSortSetting = (ss: SortSetting) => {
+    this.setState({
+      sortSetting: ss,
+    });
+
+    this.syncHistory({
+      sortKey: ss.sortKey,
+      ascending: Boolean(ss.ascending).toString(),
+    });
+  };
+
+  resetPagination = () => {
+    this.setState(prevState => {
+      return {
+        pagination: {
+          current: 1,
+          pageSize: prevState.pagination.pageSize,
+        },
+      };
+    });
+  };
+
+  componentDidMount() {
+    this.props.refreshSessions();
+  }
+
+  componentDidUpdate = (__: SessionsPageProps, _: SessionsPageState) => {
+    this.props.refreshSessions();
+  };
+
+  onChangePage = (current: number) => {
+    const { pagination } = this.state;
+    this.setState({ pagination: { ...pagination, current } });
+    this.props.onPageChanged(current);
+  };
+
+  renderSessions = () => {
+    const sessionsData = this.props.sessions;
+    const { pagination } = this.state;
+    return (
+      <div>
+        <section className={sortableTableCx("cl-table-container")}>
+          <div>
+            <h4>
+              <ResultsPerPageLabel
+                pagination={{
+                  ...pagination,
+                  total: this.props.sessions.length,
+                }}
+                pageName={"active sessions"}
+                selectedApp={appAttr}
+              />
+            </h4>
+          </div>
+          <SessionsSortedTable
+            className="sessions-table"
+            data={sessionsData}
+            columns={makeSessionsColumns(
+              this.terminateSessionRef,
+              this.terminateQueryRef,
+            )}
+            renderNoResult={
+              <EmptyTable
+                title="No sessions are currently running"
+                icon={emptyTableResultsIcon}
+                message="Sessions show you which statements and transactions are running for the active session."
+                footer={
+                  <Anchor href={sessionsTable} target="_blank">
+                    Learn more about sessions
+                  </Anchor>
+                }
+              />
+            }
+            sortSetting={this.state.sortSetting}
+            onChangeSortSetting={this.changeSortSetting}
+            pagination={pagination}
+          />
+        </section>
+        <Pagination
+          pageSize={pagination.pageSize}
+          current={pagination.current}
+          total={sessionsData.length}
+          onChange={this.onChangePage}
+        />
+      </div>
+    );
+  };
+
+  render() {
+    const { match, cancel } = this.props;
+    const app = getMatchParamByName(match, appAttr);
+    return (
+      <React.Fragment>
+        <Helmet title={app ? `${app} App | Sessions` : "Sessions"} />
+
+        <section>
+          <h1>Sessions</h1>
+        </section>
+
+        <Loading
+          loading={isNil(this.props.sessions)}
+          error={this.props.sessionsError}
+          render={this.renderSessions}
+        />
+        <TerminateSessionModal ref={this.terminateSessionRef} cancel={cancel} />
+        <TerminateQueryModal ref={this.terminateQueryRef} cancel={cancel} />
+      </React.Fragment>
+    );
+  }
+}
+
+export default SessionsPage;

--- a/packages/admin-ui-components/src/sessions/sessionsTable.module.scss
+++ b/packages/admin-ui-components/src/sessions/sessionsTable.module.scss
@@ -1,0 +1,33 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+@import "../core/index.module.scss";
+
+.sessions-table__col-time {
+  white-space: nowrap;
+}
+
+.cl-table__col-query-text a {
+  font-family: $font-family--monospace;
+  font-size: $font-size--small;
+  line-height: 1.83;
+  color: $adminui-grey-1;
+  width: 400px;
+  text-decoration: none;
+  cursor: pointer;
+  &:hover {
+    color: $colors--link;
+    text-decoration: underline;
+  }
+}
+
+.session-action--dropdown {
+  align-items: flex-end;
+}

--- a/packages/admin-ui-components/src/sessions/sessionsTable.tsx
+++ b/packages/admin-ui-components/src/sessions/sessionsTable.tsx
@@ -1,0 +1,233 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import classNames from "classnames/bind";
+
+import styles from "./sessionsTable.module.scss";
+import { SessionTableTitle } from "./sessionsTableContent";
+import { TimestampToMoment } from "src/util/convert";
+import { BytesWithPrecision, DATE_FORMAT } from "src/util/format";
+import { Link } from "react-router-dom";
+import React from "react";
+
+import { Moment } from "moment";
+
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+//import ISession = cockroach.server.serverpb.ISession;
+type ISession = any;
+
+import { TerminateSessionModalRef } from "./terminateSessionModal";
+import { TerminateQueryModalRef } from "./terminateQueryModal";
+
+import { StatementLink } from "src/statementsTable/statementsTableContent";
+import { ColumnDescriptor, SortedTable } from "src/sortedtable/sortedtable";
+
+import { Icon } from "antd";
+import {
+  Dropdown,
+  DropdownOption as DropdownItem,
+} from "src/dropdown/dropdown";
+import { Button } from "src/button/button";
+import { Tooltip2 } from "src/tooltip2";
+
+const cx = classNames.bind(styles);
+
+export interface SessionInfo {
+  session: ISession;
+}
+
+export class SessionsSortedTable extends SortedTable<SessionInfo> {}
+
+export function byteArrayToUuid(array: Uint8Array) {
+  const hexDigits: string[] = [];
+  array.forEach(t => hexDigits.push(t.toString(16).padStart(2, "0")));
+  return [
+    hexDigits.slice(0, 4).join(""),
+    hexDigits.slice(4, 6).join(""),
+    hexDigits.slice(6, 8).join(""),
+    hexDigits.slice(8, 10).join(""),
+    hexDigits.slice(10, 16).join(""),
+  ].join("-");
+}
+
+const SessionLink = (props: { session: ISession }) => {
+  const base = `/session`;
+  const start = TimestampToMoment(props.session.start);
+  const sessionID = byteArrayToUuid(props.session.id);
+
+  return (
+    <Tooltip2
+      placement="bottom"
+      tableTitle
+      title={<>Session started at {start.format(DATE_FORMAT)}</>}
+    >
+      <Link to={`${base}/${encodeURIComponent(sessionID)}`}>
+        <div>{start.fromNow(true)}</div>
+      </Link>
+    </Tooltip2>
+  );
+};
+
+const AgeLabel = (props: { start: Moment; thingName: string }) => {
+  return (
+    <Tooltip2
+      placement="bottom"
+      tableTitle
+      title={
+        <>
+          {props.thingName} started at {props.start.format(DATE_FORMAT)}
+        </>
+      }
+    >
+      {props.start.fromNow(true)}
+    </Tooltip2>
+  );
+};
+
+export function makeSessionsColumns(
+  terminateSessionRef?: React.RefObject<TerminateSessionModalRef>,
+  terminateQueryRef?: React.RefObject<TerminateQueryModalRef>,
+): ColumnDescriptor<SessionInfo>[] {
+  return [
+    {
+      name: "1",
+      title: SessionTableTitle.sessionAge,
+      className: cx("cl-table__col-session-age"),
+      cell: session => SessionLink({ session: session.session }),
+      sort: session => TimestampToMoment(session.session.start).valueOf(),
+    },
+    {
+      name: "1",
+      title: SessionTableTitle.txnAge,
+      className: cx("cl-table__col-session-start"),
+      cell: function(session: SessionInfo) {
+        if (session.session.active_txn) {
+          return AgeLabel({
+            start: TimestampToMoment(session.session.active_txn.start),
+            thingName: "Transaction",
+          });
+        }
+        return "N/A";
+      },
+      sort: session => session.session.active_txn?.start.seconds || 0,
+    },
+    {
+      name: "1",
+      title: SessionTableTitle.statementAge,
+      className: cx("cl-table__col-session-start"),
+      cell: function(session: SessionInfo) {
+        if (session.session.active_queries?.length > 0) {
+          return AgeLabel({
+            start: TimestampToMoment(session.session.active_queries[0].start),
+            thingName: "Statement",
+          });
+        }
+        return "N/A";
+      },
+      sort: function(session: SessionInfo): number {
+        if (session.session.active_queries?.length > 0) {
+          return session.session.active_queries[0].start.seconds.toNumber();
+        }
+        return 0;
+      },
+    },
+    {
+      name: "1",
+      title: SessionTableTitle.memUsage,
+      className: cx("cl-table__col-session-mem-usage"),
+      cell: session =>
+        BytesWithPrecision(session.session.alloc_bytes?.toNumber(), 0) +
+        "/" +
+        BytesWithPrecision(session.session.max_alloc_bytes?.toNumber(), 0),
+      sort: session => session.session.alloc_bytes?.toNumber(),
+    },
+    {
+      name: "1",
+      title: SessionTableTitle.statement,
+      className: cx("cl-table__col-query-text"),
+      cell: session => {
+        if (!(session.session.active_queries?.length > 0)) {
+          return "N/A";
+        }
+        const stmt = session.session.active_queries[0].sql;
+        const anonStmt = session.session.active_queries[0].sql_anon;
+        return (
+          <StatementLink
+            statement={stmt}
+            anonStatement={anonStmt}
+            implicitTxn={session.session.active_txn?.implicit}
+            search={""}
+            app={""}
+          />
+        );
+      },
+    },
+    {
+      name: "1",
+      title: SessionTableTitle.actions,
+      className: cx("cl-table__col-session-actions"),
+      titleAlign: "right",
+      cell: ({ session }) => {
+        const menuItems: DropdownItem[] = [
+          {
+            value: "terminateStatement",
+            name: "Terminate Statement",
+            disabled: session.active_queries?.length === 0,
+          },
+          {
+            value: "terminateSession",
+            name: "Terminate Session",
+          },
+        ];
+
+        const onMenuItemChange = (
+          value: "terminateStatement" | "terminateSession",
+        ) => {
+          switch (value) {
+            case "terminateSession":
+              terminateSessionRef?.current?.showModalFor({
+                session_id: session.id,
+                node_id: session.node_id.toString(),
+              });
+              break;
+            case "terminateStatement":
+              if (session.active_queries?.length > 0) {
+                terminateQueryRef?.current?.showModalFor({
+                  query_id: session.active_queries[0].id,
+                  node_id: session.node_id.toString(),
+                });
+              }
+              break;
+            default:
+              break;
+          }
+        };
+
+        const renderDropdownToggleButton: JSX.Element = (
+          <>
+            <Button type="secondary" size="small">
+              <Icon type="ellipsis" />
+            </Button>
+          </>
+        );
+
+        return (
+          <Dropdown
+            items={menuItems}
+            customToggleButton={renderDropdownToggleButton}
+            onChange={onMenuItemChange}
+            className={cx("session-action--dropdown")}
+            menuPosition="right"
+          />
+        );
+      },
+    },
+  ];
+}

--- a/packages/admin-ui-components/src/sessions/sessionsTableContent.tsx
+++ b/packages/admin-ui-components/src/sessions/sessionsTableContent.tsx
@@ -1,0 +1,123 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { Tooltip2 } from "../tooltip2";
+
+export const SessionTableTitle = {
+  id: (
+    <Tooltip2 tableTitle placement="bottom" title={<>{"Session ID."}</>}>
+      Session ID
+    </Tooltip2>
+  ),
+  statement: (
+    <Tooltip2
+      tableTitle
+      placement="bottom"
+      title={<>{"Most recent or currently active statement."}</>}
+    >
+      Statement
+    </Tooltip2>
+  ),
+  actions: (
+    <Tooltip2
+      tableTitle
+      placement="bottom"
+      title={<>{"Actions to take on the session."}</>}
+    >
+      Actions
+    </Tooltip2>
+  ),
+  sessionAge: (
+    <Tooltip2
+      tableTitle
+      placement="bottom"
+      title={<>{"The age of the session."}</>}
+    >
+      Session Age
+    </Tooltip2>
+  ),
+  txnAge: (
+    <Tooltip2
+      tableTitle
+      placement="bottom"
+      title={<>{"The age of the open transaction, if there is one."}</>}
+    >
+      Txn Age
+    </Tooltip2>
+  ),
+  statementAge: (
+    <Tooltip2
+      tableTitle
+      placement="bottom"
+      title={<>{"The age of the active statement, if there is one."}</>}
+    >
+      Statement Age
+    </Tooltip2>
+  ),
+  memUsage: (
+    <Tooltip2
+      tableTitle
+      placement="bottom"
+      title={
+        <>
+          {"The current amount of allocated memory on this session and the maximum amount of memory this" +
+            " session has ever allocated."}
+        </>
+      }
+    >
+      Memory Usage
+    </Tooltip2>
+  ),
+  maxMemUsed: (
+    <Tooltip2
+      tableTitle
+      placement="bottom"
+      title={
+        <>{"The maximum amount of allocated memory this session ever had."}</>
+      }
+    >
+      Maximum Memory Usage
+    </Tooltip2>
+  ),
+  numRetries: (
+    <Tooltip2
+      tableTitle
+      placement="bottom"
+      title={<>{"The number of times this transaction encountered a retry."}</>}
+    >
+      Retries
+    </Tooltip2>
+  ),
+  lastActiveStatement: (
+    <Tooltip2
+      tableTitle
+      placement="bottom"
+      title={<>{"The last statement that was completed on this session."}</>}
+    >
+      Last Statement
+    </Tooltip2>
+  ),
+  numStmts: (
+    <Tooltip2
+      tableTitle
+      placement="bottom"
+      title={
+        <>
+          {
+            "Number of statements that have been run in this transaction so far."
+          }
+        </>
+      }
+    >
+      Statements Run
+    </Tooltip2>
+  ),
+};

--- a/packages/admin-ui-components/src/sessions/terminateQueryModal.tsx
+++ b/packages/admin-ui-components/src/sessions/terminateQueryModal.tsx
@@ -1,0 +1,78 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React, {
+  forwardRef,
+  useCallback,
+  useImperativeHandle,
+  useState,
+} from "react";
+import { Modal } from "../modal";
+import { Text } from "../text";
+
+// import {cockroach} from "src/js/protos";
+// import {trackTerminateQuery} from "src/util/analytics/trackTerminate";
+
+// import ICancelQueryRequest = cockroach.server.serverpb.ICancelQueryRequest;
+type ICancelQueryRequest = any;
+
+export interface TerminateQueryModalRef {
+  showModalFor: (req: ICancelQueryRequest) => void;
+}
+
+interface TerminateQueryModalProps {
+  //cancel: (req: ICancelQueryRequest) => void;
+  cancel?: (req: ICancelQueryRequest) => void;
+}
+
+// tslint:disable-next-line:variable-name
+const TerminateQueryModal = (
+  props: TerminateQueryModalProps,
+  ref: React.RefObject<TerminateQueryModalRef>,
+) => {
+  const { cancel } = props;
+  const [visible, setVisible] = useState(false);
+  const [req, setReq] = useState<ICancelQueryRequest>();
+
+  const onOkHandler = useCallback(() => {
+    cancel(req);
+    //trackTerminateQuery();
+    setVisible(false);
+  }, [req, cancel]);
+
+  const onCancelHandler = useCallback(() => setVisible(false), []);
+
+  useImperativeHandle(ref, () => {
+    return {
+      showModalFor: (r: ICancelQueryRequest) => {
+        setReq(r);
+        setVisible(true);
+      },
+    };
+  });
+
+  return (
+    <Modal
+      visible={visible}
+      onOk={onOkHandler}
+      onCancel={onCancelHandler}
+      okText="Yes"
+      cancelText="No"
+      title="Terminate the Statement?"
+    >
+      <Text>
+        Terminating a statement ends the statement, returning an error to the
+        session.
+      </Text>
+    </Modal>
+  );
+};
+
+export default forwardRef(TerminateQueryModal);

--- a/packages/admin-ui-components/src/sessions/terminateSessionModal.tsx
+++ b/packages/admin-ui-components/src/sessions/terminateSessionModal.tsx
@@ -1,0 +1,78 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React, {
+  forwardRef,
+  useCallback,
+  useImperativeHandle,
+  useState,
+} from "react";
+import { Modal } from "../modal";
+import { Text } from "../text";
+
+//import {cockroach} from "src/js/protos";
+//import ICancelSessionRequest = cockroach.server.serverpb.ICancelSessionRequest;
+type ICancelSessionRequest = any;
+//import {trackTerminateSession} from "src/util/analytics/trackTerminate";
+
+export interface TerminateSessionModalRef {
+  showModalFor: (req: ICancelSessionRequest) => void;
+}
+
+interface TerminateSessionModalProps {
+  //cancel: (req: ICancelSessionRequest) => void;
+  cancel?: (req: ICancelSessionRequest) => void;
+}
+
+// tslint:disable-next-line:variable-name
+const TerminateSessionModal = (
+  props: TerminateSessionModalProps,
+  ref: React.RefObject<TerminateSessionModalRef>,
+) => {
+  const { cancel } = props;
+  const [visible, setVisible] = useState(false);
+  const [req, setReq] = useState<ICancelSessionRequest>();
+
+  const onOkHandler = useCallback(() => {
+    cancel(req);
+    //trackTerminateSession();
+    setVisible(false);
+  }, [req, cancel]);
+
+  const onCancelHandler = useCallback(() => setVisible(false), []);
+
+  useImperativeHandle(ref, () => {
+    return {
+      showModalFor: (r: ICancelSessionRequest) => {
+        setReq(r);
+        setVisible(true);
+      },
+    };
+  });
+
+  return (
+    <Modal
+      visible={visible}
+      onOk={onOkHandler}
+      onCancel={onCancelHandler}
+      okText="Yes"
+      cancelText="No"
+      title="Terminate the Session?"
+    >
+      <Text>
+        Terminating a session ends the session, terminating its associated
+        connection. The client that holds this session will receive a
+        &quot;connection terminated&quot; event.
+      </Text>
+    </Modal>
+  );
+};
+
+export default forwardRef(TerminateSessionModal);

--- a/packages/admin-ui-components/src/statementsTable/statementsTableContent.tsx
+++ b/packages/admin-ui-components/src/statementsTable/statementsTableContent.tsx
@@ -276,19 +276,35 @@ export const StatementTableCell = {
   ),
 };
 
-export const StatementLink = (props: {
+interface StatementLinkProps {
   statement: string;
   app: string;
   implicitTxn: boolean;
   search: string;
-}) => {
+  anonStatement?: string;
+}
+
+// StatementLinkTarget returns the link to the relevant statement page, given
+// the input statement details.
+export const StatementLinkTarget = (props: StatementLinkProps) => {
+  let base: string;
+  if (props.app && props.app.length > 0) {
+    base = `/statements/${props.app}/${props.implicitTxn}`;
+  } else {
+    base = `/statement/${props.implicitTxn}`;
+  }
+
+  let linkStatement = props.statement;
+  if (props.anonStatement) {
+    linkStatement = props.anonStatement;
+  }
+  return `${base}/${encodeURIComponent(linkStatement)}`;
+};
+
+export const StatementLink = (props: StatementLinkProps) => {
   const summary = summarize(props.statement);
-  const base =
-    props.app && props.app.length > 0
-      ? `/statements/${props.app}/${props.implicitTxn}`
-      : `/statement/${props.implicitTxn}`;
   return (
-    <Link to={`${base}/${encodeURIComponent(props.statement)}`}>
+    <Link to={StatementLinkTarget(props)}>
       <div>
         <Tooltip
           placement="bottom"
@@ -299,7 +315,7 @@ export const StatementLink = (props: {
           }
           overlayClassName={cx("cl-table-link__statement-tooltip--fixed-width")}
         >
-          <div className={cx("cl-table-link__tooltip-hover-area")}>
+          <div className="cl-table-link__tooltip-hover-area">
             {getHighlightedText(
               shortStatement(summary, props.statement),
               props.search,
@@ -312,7 +328,7 @@ export const StatementLink = (props: {
   );
 };
 
-const NodeLink = (props: { nodeId: string; nodeNames: NodeNames }) => (
+export const NodeLink = (props: { nodeId: string; nodeNames: NodeNames }) => (
   <Link to={`/node/${props.nodeId}`}>
     <div className={cx("node-name-tooltip__info-icon")}>
       {props.nodeNames[props.nodeId]}

--- a/packages/admin-ui-components/src/summaryCard/index.tsx
+++ b/packages/admin-ui-components/src/summaryCard/index.tsx
@@ -1,0 +1,43 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import classnames from "classnames/bind";
+import styles from "./summaryCard.module.scss";
+
+interface ISummaryCardProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+const cx = classnames.bind(styles);
+
+// tslint:disable-next-line: variable-name
+export const SummaryCard: React.FC<ISummaryCardProps> = ({
+  children,
+  className = "",
+}) => <div className={`${cx("summary--card")} ${className}`}>{children}</div>;
+
+interface ISummaryCardItemProps {
+  label: React.ReactNode;
+  value: React.ReactNode;
+  className?: string;
+}
+
+export const SummaryCardItem: React.FC<ISummaryCardItemProps> = ({
+  label,
+  value,
+  className = "",
+}) => (
+  <div className={cx("summary--card__item", className)}>
+    <h4 className={cx("summary--card__item--label")}>{label}</h4>
+    <p className={cx("summary--card__item--value")}>{value}</p>
+  </div>
+);

--- a/packages/admin-ui-components/src/summaryCard/styles.scss
+++ b/packages/admin-ui-components/src/summaryCard/styles.scss
@@ -1,0 +1,76 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+@import "../core/index.module.scss";
+
+.summary--card {
+  border-radius: 3px;
+  box-shadow: 0px 0px 1px rgba(67, 90, 111, 0.415);
+  background-color: $colors--neutral-0;
+  padding: 22px;
+  margin-bottom: 15px;
+  &__divider {
+    width: 100%;
+    height: 1px;
+    margin: 22px 0;
+    background: $table-border;
+  }
+  &__title {
+    font-family: SourceSansPro-Regular;
+    font-size: 20px;
+    line-height: 1.6;
+    letter-spacing: -0.2px;
+    color: $popover-color;
+    margin-bottom: 25px;
+  }
+  &__counting {
+    &--value {
+      font-family: $font-family--bold;
+      font-size: $font-size--x-large;
+      line-height: $line-height--x-large;
+      color: $colors--neutral-7;
+      margin-bottom: 15px;
+    }
+    &--label {
+      font-family: $font-family--base;
+      font-size: $font-size--medium;
+      line-height: 22px;
+      letter-spacing: 0.1px;
+      color: $colors--neutral-6;
+      margin-bottom: 0;
+    }
+  }
+  &__item {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 10px;
+    &--label {
+      font-family: SourceSansPro-Regular;
+      font-size: 14px;
+      line-height: 1.57;
+      letter-spacing: 0.1px;
+      color: $secondary-text-color;
+      margin-right: 5px;
+      margin-bottom: 0;
+    }
+    &--value {
+      font-family: SourceSansPro-Regular;
+      font-size: 14px;
+      font-weight: 600;
+      line-height: 1.71;
+      letter-spacing: 0.1px;
+      color: $popover-color;
+      margin-bottom: 0;
+      &-red {
+        color: $alert-color;
+      }
+    }
+  }
+}

--- a/packages/admin-ui-components/src/summaryCard/summaryCard.module.scss
+++ b/packages/admin-ui-components/src/summaryCard/summaryCard.module.scss
@@ -1,0 +1,77 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+@import "../core/index.module.scss";
+
+.summary--card {
+  border-radius: 3px;
+  box-shadow: 0 0 1px 0 rgba(67, 90, 111, 0.41);
+  background-color: $adminui-white;
+  padding: 25px;
+  margin-bottom: 15px;
+  &__divider {
+    width: 100%;
+    height: 1px;
+    margin: 22px 0;
+    background: $table-border;
+  }
+  &__title {
+    font-family: SourceSansPro-Regular;
+    font-size: 20px;
+    line-height: 1.6;
+    letter-spacing: -0.2px;
+    color: $popover-color;
+    margin-bottom: 25px;
+  }
+  &__counting {
+    &--value {
+      font-family: SourceSansPro-Regular;
+      font-size: 20pt;
+      line-height: 1.6;
+      letter-spacing: -0.2px;
+      color: $text-color;
+      margin-bottom: 15px;
+    }
+    &--label {
+      font-family: SourceSansPro-Regular;
+      font-size: 14pt;
+      line-height: 1.67;
+      letter-spacing: 0.3px;
+      color: $secondary-text-color;
+      margin-bottom: 0;
+    }
+  }
+  &__item {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 10px;
+    &--label {
+      font-family: SourceSansPro-Regular;
+      font-size: 14px;
+      line-height: 1.57;
+      letter-spacing: 0.1px;
+      color: $secondary-text-color;
+      margin-right: 5px;
+      margin-bottom: 0;
+    }
+    &--value {
+      font-family: SourceSansPro-Regular;
+      font-size: 14px;
+      font-weight: 600;
+      line-height: 1.71;
+      letter-spacing: 0.1px;
+      color: $popover-color;
+      margin-bottom: 0;
+      &-red {
+        color: $alert-color;
+      }
+    }
+  }
+}

--- a/packages/admin-ui-components/src/tooltip2/tooltip.tsx
+++ b/packages/admin-ui-components/src/tooltip2/tooltip.tsx
@@ -9,19 +9,32 @@ import styles from "./tooltip.module.scss";
 export interface TooltipProps {
   children: React.ReactNode;
   theme?: "default" | "blue";
+  tableTitle?: boolean;
 }
 
 const cx = classNames.bind(styles);
 
 export const Tooltip = (props: TooltipProps & AntTooltipProps) => {
-  const { children, theme, overlayClassName } = props;
+  const { children, theme, overlayClassName, tableTitle } = props;
   const classes = cx(
     "tooltip-overlay",
     `crl-tooltip--theme-${theme}`,
     overlayClassName,
   );
+
+  const title = tableTitle ? (
+    <div className={cx("tooltip__table--title")}>{props.title}</div>
+  ) : (
+    props.title
+  );
+
   return (
-    <AntTooltip {...props} mouseEnterDelay={0.5} overlayClassName={classes}>
+    <AntTooltip
+      {...props}
+      title={title}
+      mouseEnterDelay={0.5}
+      overlayClassName={classes}
+    >
       {children}
     </AntTooltip>
   );
@@ -30,4 +43,5 @@ export const Tooltip = (props: TooltipProps & AntTooltipProps) => {
 Tooltip.defaultProps = {
   theme: "default",
   placement: "top",
+  tableTitle: false,
 };

--- a/packages/admin-ui-components/src/util/constants.ts
+++ b/packages/admin-ui-components/src/util/constants.ts
@@ -8,6 +8,7 @@ export const nodeQueryString = "node";
 export const rangeIDAttr = "range_id";
 export const statementAttr = "statement";
 export const tableNameAttr = "table_name";
+export const sessionAttr = "session";
 
 export const REMOTE_DEBUGGING_ERROR_TEXT =
   "This information is not available due to the current value of the 'server.remote_debugging.mode' setting.";

--- a/packages/admin-ui-components/src/util/docs.ts
+++ b/packages/admin-ui-components/src/util/docs.ts
@@ -60,6 +60,7 @@ export const clusterGlossary = docsURL("architecture/overview.html#glossary");
 export const reviewOfCockroachTerminology = docsURL(
   "admin-ui-replication-dashboard.html#review-of-cockroachdb-terminology",
 );
+export const sessionsTable = docsURL("ui-sessions-page.html");
 // Note that these explicitly don't use the current version, since we want to
 // link to the most up-to-date documentation available.
 export const upgradeCockroachVersion =


### PR DESCRIPTION
ui: Extract Sessions Page from DB Console

extract session page into ui repo:
- most of the components moved without any or minimal changes
- styles converted to scss modules

Resolves: #57296

Release note (ui): none