### PR TITLE
[DS-13] Form update: edits from forms retro

### DIFF
--- a/packages/ui-components/src/Input/CheckboxInput.tsx
+++ b/packages/ui-components/src/Input/CheckboxInput.tsx
@@ -35,9 +35,6 @@ export const CheckboxInput = ({
     <CommonInput
       className={className}
       error={error}
-      invalid={invalid}
-      label={label}
-      ariaLabel={ariaLabel}
       {...rest}
       fieldInput={fieldInput}
     />

--- a/packages/ui-components/src/Input/CheckboxInput.tsx
+++ b/packages/ui-components/src/Input/CheckboxInput.tsx
@@ -2,10 +2,6 @@ import React from "react";
 import classNames from "classnames/bind";
 import { CommonInputProps, CommonInput } from "./CommonInput";
 
-type CheckboxProps = React.InputHTMLAttributes<HTMLInputElement>;
-
-export type CheckboxInputProps = CommonInputProps & CheckboxProps;
-
 export const CheckboxInput = ({
   id,
   className,
@@ -15,7 +11,7 @@ export const CheckboxInput = ({
   ariaLabel,
   required,
   ...rest
-}: CheckboxInputProps) => {
+}: CommonInputProps) => {
   const inputProps = {
     id: id,
     className: classNames("crl-input", className, {

--- a/packages/ui-components/src/Input/CommonInput.tsx
+++ b/packages/ui-components/src/Input/CommonInput.tsx
@@ -1,26 +1,28 @@
 import React from "react";
 import classNames from "classnames/bind";
 import "./input.module.scss";
-import { FieldMetaState } from "react-final-form";
 
-export interface CommonInputProps {
+export interface CommonInputProps
+  extends React.DetailedHTMLProps<
+    React.InputHTMLAttributes<HTMLInputElement>,
+    HTMLInputElement
+  > {
   // this should be the element containing the input
   fieldInput?: JSX.Element;
-  className?: string;
   help?: string | JSX.Element;
   // derived from final form type
-  // error is assigned a value of meta.error
-  // which has type any
+  // error is assigned a value of meta.error which has type any
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   error?: any;
   inline?: boolean;
-  // FieldValue passed to meta is string for all TextTypeInputs
-  // boolean for CheckboxInput, and number for NumberInput
-  meta?: FieldMetaState<string | number | boolean>;
   // following are used in Checkbox, TextType Inputs, which render CommonInput
   invalid?: boolean;
   label?: string | JSX.Element;
+  // these props are used for accessibility and aren't part of DetailedHTMLProps
+  // because they're formatted with dashes (i.e. aria-label)
+  // recall objects don't accept a dash in keys (passed to inputProps in [])
   ariaLabel?: string;
+  ariaLabelledBy?: string;
 }
 
 // a component defining how error and help messages

--- a/packages/ui-components/src/Input/CommonInput.tsx
+++ b/packages/ui-components/src/Input/CommonInput.tsx
@@ -43,15 +43,17 @@ export const CommonInput = ({
 
   return (
     <div
-      className={classNames("input-container", className, {
+      className={classNames(className, {
         inline: inline,
       })}
     >
       {fieldInput}
-      <div className="message">
-        {errorMsg}
-        {helpMsg}
-      </div>
+      {(errorMsg || helpMsg) && (
+        <div className="message">
+          {errorMsg}
+          {helpMsg}
+        </div>
+      )}
     </div>
   );
 };

--- a/packages/ui-components/src/Input/CommonInput.tsx
+++ b/packages/ui-components/src/Input/CommonInput.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import classNames from "classnames/bind";
 import "./input.module.scss";
-import { FieldRenderProps, FieldMetaState } from "react-final-form";
+import { FieldMetaState } from "react-final-form";
 
 export interface CommonInputProps {
   // this should be the element containing the input

--- a/packages/ui-components/src/Input/CommonInput.tsx
+++ b/packages/ui-components/src/Input/CommonInput.tsx
@@ -10,14 +10,13 @@ export interface CommonInputProps
   // this should be the element containing the input
   fieldInput?: JSX.Element;
   help?: string | JSX.Element;
-  // derived from final form type
-  // error is assigned a value of meta.error which has type any
+  // error is assigned a value of meta.error which has type any in react-final-forms
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   error?: any;
   inline?: boolean;
   // following are used in Checkbox, TextType Inputs, which render CommonInput
   invalid?: boolean;
-  label?: string | JSX.Element;
+  label?: string;
   // these props are used for accessibility and aren't part of DetailedHTMLProps
   // because they're formatted with dashes (i.e. aria-label)
   // recall objects don't accept a dash in keys (passed to inputProps in [])

--- a/packages/ui-components/src/Input/CommonInput.tsx
+++ b/packages/ui-components/src/Input/CommonInput.tsx
@@ -16,7 +16,7 @@ export interface CommonInputProps
   inline?: boolean;
   // following are used in Checkbox, TextType Inputs, which render CommonInput
   invalid?: boolean;
-  label?: string;
+  label?: string | JSX.Element;
   // these props are used for accessibility and aren't part of DetailedHTMLProps
   // because they're formatted with dashes (i.e. aria-label)
   // recall objects don't accept a dash in keys (passed to inputProps in [])

--- a/packages/ui-components/src/Input/EmailPassword.module.scss
+++ b/packages/ui-components/src/Input/EmailPassword.module.scss
@@ -6,9 +6,7 @@
 }
 
 .new-password-validation-container {
-  display: flex;
-  flex-flow: column wrap;
-  list-style: none;
+  column-count: 2;
   margin-bottom: crl-gutters(3);
   padding: 0;
 }
@@ -19,6 +17,18 @@
   font-size: 12px;
 }
 
-.new-password-validation-label {
+.new-password-validation-icon {
+  padding-top: crl-gutters(0.5);
+  display: inline-flex;
+  opacity: 0.35,
+}
+
+.new-password-validation-error,
+.new-password-validation-success {
   padding-left: crl-gutters(0.75);
+  color: $color-font-2;
+}
+
+.new-password-validation-error {
+  color: $color-font-4;
 }

--- a/packages/ui-components/src/Input/EmailPasswordInput.tsx
+++ b/packages/ui-components/src/Input/EmailPasswordInput.tsx
@@ -52,23 +52,21 @@ export const PasswordInput = ({
 
   // we only want to show the check icon if the user is retyping the password
   // and the password matches the previous password field
-  const doesRetypedPasswordMatch = !error && meta && meta.touched &&  (
-    <Icon
-      iconName={"Check"}
-      size="medium"
-      fill="success"
-    />
+  const doesRetypedPasswordMatch = !error && meta && meta.touched && (
+    <Icon iconName={"Check"} size="medium" fill="success" />
   );
 
   const suffixIcon = (
     <div style={{ display: "inline-flex" }}>
       {retypePassword && doesRetypedPasswordMatch}
-      {reveal && <Icon
-        iconName={type === PasswordInputType.Password ? "Eye" : "EyeOff"}
-        size="medium"
-        fill={meta && meta.active ? "info" : "default"}
-        onClick={toggleType}
-      />}
+      {reveal && (
+        <Icon
+          iconName={type === PasswordInputType.Password ? "Eye" : "EyeOff"}
+          size="medium"
+          fill={meta && meta.active ? "info" : "default"}
+          onClick={toggleType}
+        />
+      )}
     </div>
   );
 
@@ -84,7 +82,11 @@ export const PasswordInput = ({
           suffix={suffixIcon}
           // for new passwords, the error should reflect whether the password is valid
           // for existing/retyped passwords, the error should be consistent with a standard input error
-          {...(newPassword && !retypePassword && { error: undefined, invalid: meta && meta.touched && meta.invalid })}
+          {...(newPassword &&
+            !retypePassword && {
+              error: undefined,
+              invalid: meta && meta.touched && meta.invalid,
+            })}
         />
       </div>
       {// we don't want to show the validations if the user is retyping password

--- a/packages/ui-components/src/Input/EmailPasswordInput.tsx
+++ b/packages/ui-components/src/Input/EmailPasswordInput.tsx
@@ -80,8 +80,6 @@ export const PasswordInput = ({
     <>
       <div className="new-password-input-container">
         <BaseTextInput
-          meta={meta}
-          input={input}
           {...rest}
           type={type}
           suffix={suffixIcon}

--- a/packages/ui-components/src/Input/EmailPasswordInput.tsx
+++ b/packages/ui-components/src/Input/EmailPasswordInput.tsx
@@ -53,7 +53,7 @@ export const NewPasswordInput = ({
           error={undefined}
         />
       </div>
-      {touched && validatorLabel && (
+      {touched && (validatorLabel !== undefined) && (
         <ul className="new-password-validation-container">
           <li
             key={validatorLabel}

--- a/packages/ui-components/src/Input/EmailPasswordInput.tsx
+++ b/packages/ui-components/src/Input/EmailPasswordInput.tsx
@@ -2,18 +2,21 @@ import React, { useState, useEffect } from "react";
 import { BaseTextInput, TextInputProps } from "./TextTypeInput";
 import "./EmailPassword.module.scss";
 import { Icon } from "../Icon/Icon";
+import { FieldRenderProps } from "react-final-form";
 
 export interface Validator {
   fn: (val: string) => boolean;
   label: string;
 }
 
-export type PasswordProps = TextInputProps & {
+export interface PasswordProps
+  extends Partial<FieldRenderProps<"text", HTMLInputElement>>,
+    TextInputProps {
   validatorArray?: Validator[];
   reveal?: boolean;
   newPassword?: boolean;
   retypePassword?: boolean;
-};
+}
 
 export enum PasswordInputType {
   Text = "text",

--- a/packages/ui-components/src/Input/EmailPasswordInput.tsx
+++ b/packages/ui-components/src/Input/EmailPasswordInput.tsx
@@ -8,7 +8,7 @@ export type ExistingPasswordProps = Omit<AllProps, "multiline">;
 // since we use at most one validator currently
 // we only want to accept one validator label
 export type NewPasswordProps = Omit<
-  ExistingPasswordProps & { validatorLabel: string },
+  ExistingPasswordProps & { validatorLabel?: string },
   "forgotPasswordLinkElement"
 >;
 export type EmailProps = NewPasswordProps;

--- a/packages/ui-components/src/Input/EmailPasswordInput.tsx
+++ b/packages/ui-components/src/Input/EmailPasswordInput.tsx
@@ -53,7 +53,7 @@ export const NewPasswordInput = ({
           error={undefined}
         />
       </div>
-      {touched && (validatorLabel !== undefined) && (
+      {touched && validatorLabel !== undefined && (
         <ul className="new-password-validation-container">
           <li
             key={validatorLabel}

--- a/packages/ui-components/src/Input/EmailPasswordInput.tsx
+++ b/packages/ui-components/src/Input/EmailPasswordInput.tsx
@@ -3,15 +3,10 @@ import { BaseTextInput, AllProps } from "./TextTypeInput";
 import "./EmailPassword.module.scss";
 import { Icon } from "../Icon/Icon";
 
-export type ExistingPasswordProps = Omit<AllProps, "multiline">;
-
 // since we use at most one validator currently
 // we only want to accept one validator label
-export type NewPasswordProps = Omit<
-  ExistingPasswordProps & { validatorLabel?: string },
-  "forgotPasswordLinkElement"
->;
-export type EmailProps = NewPasswordProps;
+export type PasswordProps = AllProps;
+export type EmailProps = AllProps;
 
 export enum PasswordInputType {
   Text = "text",
@@ -25,18 +20,57 @@ export const EmailInput = (props: EmailProps) => {
   return <BaseTextInput type="email" {...props} />;
 };
 
-export const NewPasswordInput = ({
+export const PasswordInput = ({
   meta,
+  reveal,
   validatorLabel = undefined,
+  newPassword,
+  retypePassword,
   ...rest
-}: NewPasswordProps) => {
+}: PasswordProps) => {
   const [error, setError] = useState(meta && meta.error);
   const [touched, setTouched] = useState(meta && meta.touched);
+  // hidden password will render a password field
+  // open password will render a text field
+  // the hidden/open state is toggled by the suffix icon
+  const [type, setType] = useState<PasswordInputType>(
+    PasswordInputType.Password,
+  );
+
+  const toggleType = () => {
+    setType(
+      type === PasswordInputType.Password
+        ? PasswordInputType.Text
+        : PasswordInputType.Password,
+    );
+  };
 
   useEffect(() => {
     setError(meta && meta.error && meta.invalid);
     setTouched(meta && meta.touched);
   }, [meta]);
+
+  // we only want to show the check icon if the user is retyping the password
+  // and the password matches the previous password field
+  const doesRetypedPasswordMatch = !error && meta && meta.touched &&  (
+    <Icon
+      iconName={"Check"}
+      size="medium"
+      fill="success"
+    />
+  );
+
+  const suffixIcon = (
+    <div style={{ display: "inline-flex" }}>
+      {retypePassword && doesRetypedPasswordMatch}
+      {reveal && <Icon
+        iconName={type === PasswordInputType.Password ? "Eye" : "EyeOff"}
+        size="medium"
+        fill={meta && meta.active ? "info" : "default"}
+        onClick={toggleType}
+      />}
+    </div>
+  );
 
   // returns a password input, followed by an icon and message denoting
   // whether validation has been passed
@@ -44,16 +78,18 @@ export const NewPasswordInput = ({
     <>
       <div className="new-password-input-container">
         <BaseTextInput
-          type="password"
+          type={type}
           meta={meta}
           {...rest}
-          // we don't want to show standard React Input error in NewPasswordInput fields
-          // instead error is indicated by the conditional validation message below
-          invalid={meta && meta.touched && meta.invalid}
-          error={undefined}
+          suffix={suffixIcon}
+          // for new passwords, the error should reflect whether the password is valid
+          // for existing/retyped passwords, the error should be consistent with a standard input error
+          {...(newPassword && !retypePassword && { error: undefined, invalid: meta && meta.touched && meta.invalid })}
         />
       </div>
-      {touched && validatorLabel !== undefined && (
+      {// we don't want to show the validations if the user is retyping password
+      // or hasn't begun to type the password
+      !retypePassword && touched && validatorLabel && (
         <ul className="new-password-validation-container">
           <li
             key={validatorLabel}
@@ -74,8 +110,4 @@ export const NewPasswordInput = ({
       )}
     </>
   );
-};
-
-export const ExistingPasswordInput = (props: ExistingPasswordProps) => {
-  return <BaseTextInput type="password" existingPassword={true} {...props} />;
 };

--- a/packages/ui-components/src/Input/Field.tsx
+++ b/packages/ui-components/src/Input/Field.tsx
@@ -4,23 +4,27 @@ import { SingleLineTextInput, NumberInput } from "./TextTypeInput";
 import { EmailInput, PasswordInput } from "./EmailPasswordInput";
 import { CheckboxInput } from "./CheckboxInput";
 
-type propTypes =
+// not including multiline input as it depends on Figma designs
+type InputTypes =
   | typeof PasswordInput
   | typeof EmailInput
   | typeof SingleLineTextInput
   | typeof NumberInput
   | typeof CheckboxInput;
 
+// Extends field render props, which will be passed to the Field component in InputField
 export interface InputFieldProps<
-  IComponent extends React.ComponentType<propTypes>
+  IComponent extends React.ComponentType<InputTypes>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 > extends FieldProps<any, FieldRenderProps<any, HTMLElement>, HTMLElement> {
-  as: IComponent;
-  type?: "text" | "email" | "password" | "number";
+  as: IComponent;  
+  // should include types currently supported
+  type?: "text" | "email" | "password" | "number" | "checkbox";
 }
 
-type FieldPropsTwo<
-  IComponent extends React.ComponentType<propTypes>
+// remove any properties defined in InputFieldProps, so we can handle them exclusively.
+type FieldPropsRefined<
+  IComponent extends React.ComponentType<InputTypes>
 > = InputFieldProps<IComponent> &
   Omit<
     React.ComponentPropsWithoutRef<IComponent>,
@@ -43,7 +47,7 @@ export function InputField({
   validateFields,
   name,
   ...rest
-}: FieldPropsTwo<propTypes>) {
+}: FieldPropsRefined<InputTypes>) {
   return (
     <Field
       afterSubmit={afterSubmit}

--- a/packages/ui-components/src/Input/Field.tsx
+++ b/packages/ui-components/src/Input/Field.tsx
@@ -6,6 +6,8 @@ import {
   TextInputProps,
   NumberInput,
   NumberProps,
+  MultilineTextInput,
+  MultilineTextInputProps,
 } from "./TextTypeInput";
 import {
   EmailInput,
@@ -119,6 +121,16 @@ export const TextField = (props: TextInputFieldProps) => {
     <InputField
       type="text"
       InputFieldComponent={SingleLineTextInput}
+      {...props}
+    />
+  );
+};
+
+export const MultilineTextField = (props: MultilineTextInputProps) => {
+  return (
+    <InputField
+      type="text"
+      InputFieldComponent={MultilineTextInput}
       {...props}
     />
   );

--- a/packages/ui-components/src/Input/Field.tsx
+++ b/packages/ui-components/src/Input/Field.tsx
@@ -8,8 +8,6 @@ import {
 import { EmailInput, PasswordInput } from "./EmailPasswordInput";
 import { CheckboxInput } from "./CheckboxInput";
 
-type InputTypes = "text" | "email" | "password" | "number" | "checkbox";
-
 type InputComponentTypes =
   | typeof PasswordInput
   | typeof EmailInput
@@ -25,7 +23,7 @@ export interface InputFieldProps<
 > extends FieldProps<any, FieldRenderProps<any, HTMLElement>, HTMLElement> {
   as: IComponent;
   // should include types currently supported
-  type: InputTypes;
+  type: "text" | "email" | "password" | "number" | "checkbox";
 }
 
 // remove any properties defined in InputFieldProps, so we can handle them exclusively.

--- a/packages/ui-components/src/Input/Field.tsx
+++ b/packages/ui-components/src/Input/Field.tsx
@@ -1,61 +1,34 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { Field, FieldProps, FieldRenderProps } from "react-final-form";
+import { SingleLineTextInput, NumberInput } from "./TextTypeInput";
+import { EmailInput, PasswordInput } from "./EmailPasswordInput";
+import { CheckboxInput } from "./CheckboxInput";
 
-import {
-  SingleLineTextInput,
-  TextInputProps,
-  NumberInput,
-  NumberProps,
-  MultilineTextInput,
-  MultilineTextInputProps,
-} from "./TextTypeInput";
-import {
-  EmailInput,
-  PasswordInput,
-  PasswordProps,
-  EmailProps,
-} from "./EmailPasswordInput";
-import { CheckboxInput, CheckboxInputProps } from "./CheckboxInput";
+type propTypes =
+  | typeof PasswordInput
+  | typeof EmailInput
+  | typeof SingleLineTextInput
+  | typeof NumberInput
+  | typeof CheckboxInput;
 
-// the following omit statements can be removed
-// once type better limits what props can be passed in
-type TextInputFieldProps = Omit<
-  FieldProps<string, FieldRenderProps<string, HTMLElement>, HTMLElement> &
-    TextInputProps,
-  "type"
->;
+export interface InputFieldProps<
+  IComponent extends React.ComponentType<propTypes>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+> extends FieldProps<any, FieldRenderProps<any, HTMLElement>, HTMLElement> {
+  as: IComponent;
+  type?: "text" | "email" | "password" | "number";
+}
 
-type NumberInputFieldProps = Omit<
-  FieldProps<number, FieldRenderProps<number, HTMLElement>, HTMLElement> &
-    NumberProps,
-  "type"
->;
+type FieldPropsTwo<
+  IComponent extends React.ComponentType<propTypes>
+> = InputFieldProps<IComponent> &
+  Omit<
+    React.ComponentPropsWithoutRef<IComponent>,
+    keyof InputFieldProps<IComponent>
+  >;
 
-type CheckboxInputFieldProps = Omit<
-  FieldProps<boolean, FieldRenderProps<boolean, HTMLElement>, HTMLElement> &
-    CheckboxInputProps,
-  "type"
->;
-
-type EmailInputFieldProps = Omit<
-  FieldProps<string, FieldRenderProps<string, HTMLElement>, HTMLElement> &
-    EmailProps,
-  "type"
->;
-
-type PasswordInputFieldProps = Omit<
-  FieldProps<string, FieldRenderProps<string, HTMLElement>, HTMLElement> &
-    PasswordProps,
-  "type"
->;
-
-type InternalFieldProps =
-  | ({ InputFieldComponent: React.FunctionComponent } & TextInputFieldProps)
-  | CheckboxInputFieldProps
-  | EmailInputFieldProps
-  | PasswordInputFieldProps;
-
-const InputField = ({
+export function InputField({
+  as: ComponentReturned,
   afterSubmit,
   allowNull = false,
   beforeSubmit,
@@ -69,9 +42,8 @@ const InputField = ({
   validate,
   validateFields,
   name,
-  InputFieldComponent,
-  ...inputProps
-}: InternalFieldProps) => {
+  ...rest
+}: FieldPropsTwo<propTypes>) {
   return (
     <Field
       afterSubmit={afterSubmit}
@@ -89,69 +61,14 @@ const InputField = ({
       name={name}
       render={({ input, meta }) => {
         return (
-          <InputFieldComponent
+          <ComponentReturned
             meta={meta}
             {...input}
-            {...inputProps}
+            {...rest}
             error={meta.touched && meta.error}
           />
         );
       }}
     />
   );
-};
-
-// It's not necessary to pass the type prop for a Field
-// This is to prevent passing a type for which the input component
-// isn't defined
-
-export const TextField = (props: TextInputFieldProps) => {
-  return (
-    <InputField
-      type="text"
-      InputFieldComponent={SingleLineTextInput}
-      {...props}
-    />
-  );
-};
-
-export const MultilineTextField = (props: MultilineTextInputProps) => {
-  return (
-    <InputField
-      type="text"
-      InputFieldComponent={MultilineTextInput}
-      {...props}
-    />
-  );
-};
-
-export const NumberField = (props: NumberInputFieldProps) => {
-  return (
-    <InputField type="number" InputFieldComponent={NumberInput} {...props} />
-  );
-};
-
-export const CheckboxField = (props: CheckboxInputFieldProps) => {
-  return (
-    <InputField
-      type="checkbox"
-      InputFieldComponent={CheckboxInput}
-      {...props}
-    />
-  );
-};
-
-export const EmailField = (props: EmailInputFieldProps) => {
-  return (
-    <InputField type="email" InputFieldComponent={EmailInput} {...props} />
-  );
-};
-
-export const PasswordField = (props: PasswordInputFieldProps) => {
-  return (
-    <InputField
-      InputFieldComponent={PasswordInput}
-      {...props}
-    />
-  );
-};
+}

--- a/packages/ui-components/src/Input/Field.tsx
+++ b/packages/ui-components/src/Input/Field.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Field, FieldProps, FieldRenderProps } from "react-final-form";
 
 import {
@@ -11,15 +11,11 @@ import {
 } from "./TextTypeInput";
 import {
   EmailInput,
-  NewPasswordInput,
-  ExistingPasswordInput,
+  PasswordInput,
+  PasswordProps,
   EmailProps,
-  NewPasswordProps,
-  ExistingPasswordProps,
-  PasswordInputType,
 } from "./EmailPasswordInput";
 import { CheckboxInput, CheckboxInputProps } from "./CheckboxInput";
-import Icon from "../Icon/Icon";
 
 // the following omit statements can be removed
 // once type better limits what props can be passed in
@@ -47,15 +43,9 @@ type EmailInputFieldProps = Omit<
   "type"
 >;
 
-type NewPasswordInputFieldProps = Omit<
+type PasswordInputFieldProps = Omit<
   FieldProps<string, FieldRenderProps<string, HTMLElement>, HTMLElement> &
-    NewPasswordProps,
-  "type"
->;
-
-type ExistingPasswordInputFieldProps = Omit<
-  FieldProps<string, FieldRenderProps<string, HTMLElement>, HTMLElement> &
-    ExistingPasswordProps,
+    PasswordProps,
   "type"
 >;
 
@@ -63,8 +53,7 @@ type InternalFieldProps =
   | ({ InputFieldComponent: React.FunctionComponent } & TextInputFieldProps)
   | CheckboxInputFieldProps
   | EmailInputFieldProps
-  | NewPasswordInputFieldProps
-  | ExistingPasswordInputFieldProps;
+  | PasswordInputFieldProps;
 
 const InputField = ({
   afterSubmit,
@@ -158,51 +147,10 @@ export const EmailField = (props: EmailInputFieldProps) => {
   );
 };
 
-export const NewPasswordField = (props: NewPasswordInputFieldProps) => {
-  const { meta } = props;
-  const [type, setType] = useState<PasswordInputType>(
-    PasswordInputType.Password,
-  );
-
-  const toggleType = () => {
-    setType(
-      type === PasswordInputType.Password
-        ? PasswordInputType.Text
-        : PasswordInputType.Password,
-    );
-  };
-
-  const suffixIcon = (
-    <div style={{ display: "inline-flex" }}>
-      <Icon
-        iconName={type === PasswordInputType.Password ? "Eye" : "EyeOff"}
-        size="medium"
-        fill={meta && meta.active ? "info" : "default"}
-        onClick={toggleType}
-      />
-    </div>
-  );
-
-  // hidden password will render a password field
-  // open password will render a text field
-  // the hidden/open state is toggled by the suffix icon
+export const PasswordField = (props: PasswordInputFieldProps) => {
   return (
     <InputField
-      type={type}
-      suffix={suffixIcon}
-      InputFieldComponent={NewPasswordInput}
-      {...props}
-    />
-  );
-};
-
-export const ExistingPasswordField = (
-  props: ExistingPasswordInputFieldProps,
-) => {
-  return (
-    <InputField
-      type="password"
-      InputFieldComponent={ExistingPasswordInput}
+      InputFieldComponent={PasswordInput}
       {...props}
     />
   );

--- a/packages/ui-components/src/Input/Field.tsx
+++ b/packages/ui-components/src/Input/Field.tsx
@@ -1,30 +1,36 @@
 import React from "react";
 import { Field, FieldProps, FieldRenderProps } from "react-final-form";
-import { SingleLineTextInput, NumberInput } from "./TextTypeInput";
+import {
+  SingleLineTextInput,
+  MultilineTextInput,
+  NumberInput,
+} from "./TextTypeInput";
 import { EmailInput, PasswordInput } from "./EmailPasswordInput";
 import { CheckboxInput } from "./CheckboxInput";
 
-// not including multiline input as it depends on Figma designs
-type InputTypes =
+type InputTypes = "text" | "email" | "password" | "number" | "checkbox";
+
+type InputComponentTypes =
   | typeof PasswordInput
   | typeof EmailInput
   | typeof SingleLineTextInput
+  | typeof MultilineTextInput
   | typeof NumberInput
   | typeof CheckboxInput;
 
 // Extends field render props, which will be passed to the Field component in InputField
 export interface InputFieldProps<
-  IComponent extends React.ComponentType<InputTypes>
+  IComponent extends React.ComponentType<InputComponentTypes>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 > extends FieldProps<any, FieldRenderProps<any, HTMLElement>, HTMLElement> {
   as: IComponent;
   // should include types currently supported
-  type: "text" | "email" | "password" | "number" | "checkbox";
+  type: InputTypes;
 }
 
 // remove any properties defined in InputFieldProps, so we can handle them exclusively.
 type FieldPropsRefined<
-  IComponent extends React.ComponentType<InputTypes>
+  IComponent extends React.ComponentType<InputComponentTypes>
 > = InputFieldProps<IComponent> &
   Omit<
     React.ComponentPropsWithoutRef<IComponent>,
@@ -47,7 +53,7 @@ export function InputField({
   validateFields,
   name,
   ...rest
-}: FieldPropsRefined<InputTypes>) {
+}: FieldPropsRefined<InputComponentTypes>) {
   return (
     <Field
       afterSubmit={afterSubmit}

--- a/packages/ui-components/src/Input/Field.tsx
+++ b/packages/ui-components/src/Input/Field.tsx
@@ -19,7 +19,7 @@ export interface InputFieldProps<
 > extends FieldProps<any, FieldRenderProps<any, HTMLElement>, HTMLElement> {
   as: IComponent;
   // should include types currently supported
-  type?: "text" | "email" | "password" | "number" | "checkbox";
+  type: "text" | "email" | "password" | "number" | "checkbox";
 }
 
 // remove any properties defined in InputFieldProps, so we can handle them exclusively.

--- a/packages/ui-components/src/Input/Field.tsx
+++ b/packages/ui-components/src/Input/Field.tsx
@@ -17,7 +17,7 @@ export interface InputFieldProps<
   IComponent extends React.ComponentType<InputTypes>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 > extends FieldProps<any, FieldRenderProps<any, HTMLElement>, HTMLElement> {
-  as: IComponent;  
+  as: IComponent;
   // should include types currently supported
   type?: "text" | "email" | "password" | "number" | "checkbox";
 }

--- a/packages/ui-components/src/Input/InputField.tsx
+++ b/packages/ui-components/src/Input/InputField.tsx
@@ -8,6 +8,7 @@ import {
 import { EmailInput, PasswordInput } from "./EmailPasswordInput";
 import { CheckboxInput } from "./CheckboxInput";
 
+// this type ensures the props always match one that of one of these InputProps
 type InputComponentTypes =
   | typeof PasswordInput
   | typeof EmailInput
@@ -35,7 +36,7 @@ type FieldPropsRefined<
     keyof InputFieldProps<IComponent>
   >;
 
-export function InputField({
+export default function InputField({
   as: ComponentReturned,
   afterSubmit,
   allowNull = false,

--- a/packages/ui-components/src/Input/NumberInput.tsx
+++ b/packages/ui-components/src/Input/NumberInput.tsx
@@ -9,8 +9,11 @@ const cx = classNames.bind(styles);
 
 export type NumberInputProps = TextAndNumberProps & {
   onChange?: (value: number) => void;
-  initialValue: number;
-  value: number;
+  initialValue?: number;
+  value?: number;
+  prefix?: JSX.Element;
+  invalid?: boolean;
+  disabled?: boolean;
 };
 
 // Use NumberInput instead of this
@@ -18,9 +21,9 @@ export const DeprecatedNumberInput = ({
   onChange,
   value: outerValue,
   initialValue,
-  prefix,
-  invalid,
   disabled,
+  invalid,
+  prefix,
   ...props
 }: NumberInputProps) => {
   const [value, setValue] = useState<number>(outerValue || initialValue || 0);

--- a/packages/ui-components/src/Input/NumberInput.tsx
+++ b/packages/ui-components/src/Input/NumberInput.tsx
@@ -1,13 +1,13 @@
 import React, { useCallback, useState } from "react";
 import classNames from "classnames/bind";
 import { CaretUp, CaretDown } from "@cockroachlabs/icons";
-import { NumberInput, NumberProps } from "./TextTypeInput";
+import { NumberInput, TextAndNumberProps } from "./TextTypeInput";
 import styles from "./styles.module.scss";
 import { InputPrefix, InputWrapper } from "./helpers";
 
 const cx = classNames.bind(styles);
 
-export type NumberInputProps = NumberProps & {
+export type NumberInputProps = TextAndNumberProps & {
   onChange?: (value: number) => void;
   initialValue: number;
   value: number;

--- a/packages/ui-components/src/Input/TextTypeInput.tsx
+++ b/packages/ui-components/src/Input/TextTypeInput.tsx
@@ -8,8 +8,6 @@ export interface TextAndNumberProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
   suffix?: JSX.Element;
   prefixElement?: JSX.Element;
-  // prop only used internally for implementation
-  type?: "text" | "email" | "password" | "number";
   // this defines the input type rendered by this field
   // for multiline text types, this will be <textarea>
   // for text/email/password/number types this will be <input> with a type field
@@ -26,7 +24,7 @@ export interface MultilineProps
 
 // the following props are used to implement {Email, Password, Number}Input
 // it is recommended to use those components instead of passing an "email" type to TextInput
-interface CustomProps extends React.InputHTMLAttributes<HTMLInputElement> {
+interface CustomProps {
   ariaLabel?: string;
   ariaLabelledBy?: string;
   validatorLabel?: string;

--- a/packages/ui-components/src/Input/TextTypeInput.tsx
+++ b/packages/ui-components/src/Input/TextTypeInput.tsx
@@ -29,21 +29,18 @@ export interface MultilineProps
 interface CustomProps extends React.InputHTMLAttributes<HTMLInputElement> {
   ariaLabel?: string;
   ariaLabelledBy?: string;
-  forgotPasswordLinkElement?: JSX.Element;
-  // this prop is only used for internal implementation
-  // whether the password exists or not, should be indicated by New/Existing PasswordInput
-  existingPassword?: boolean;
+  validatorLabel?: string;
+  reveal?: boolean;
+  newPassword?: boolean;
+  retypePassword?: boolean;
 }
 
 export type TextInputProps = CommonInputProps & TextAndNumberProps;
 export type MultilineTextInputProps = CommonInputProps & MultilineProps;
 export type NumberProps = TextInputProps & CustomProps;
+export type AllProps = TextInputProps & CustomProps;
 
-type InternalTextProps = TextInputProps & CustomProps;
-
-export type AllProps = Omit<InternalTextProps, "existingPassword">;
-
-export const BaseTextInput: React.FC<InternalTextProps> = props => {
+export const BaseTextInput: React.FC<AllProps> = props => {
   const {
     id,
     JSXInput,
@@ -57,8 +54,6 @@ export const BaseTextInput: React.FC<InternalTextProps> = props => {
     type = "text",
     prefixElement,
     ariaLabelledBy,
-    existingPassword = false,
-    forgotPasswordLinkElement,
     ...rest
   } = props;
 
@@ -69,7 +64,6 @@ export const BaseTextInput: React.FC<InternalTextProps> = props => {
       "crl-input--suffix": suffix,
       invalid: error || invalid,
     }),
-    name: name,
     ["aria-label"]: ariaLabel,
     ["aria-invalid"]: !!error || invalid,
     ["aria-required"]: required,
@@ -96,18 +90,9 @@ export const BaseTextInput: React.FC<InternalTextProps> = props => {
     </>
   );
 
-  const labelElement = existingPassword ? (
-    <div className="existing-password-label">
-      {labelDiv}
-      {forgotPasswordLinkElement}
-    </div>
-  ) : (
-    labelDiv
-  );
-
   const fieldInput = (
     <>
-      {labelElement}
+      {labelDiv}
       <div className="affix-container">
         {prefixElement && (
           <span className="crl-input__prefix">{prefixElement}</span>

--- a/packages/ui-components/src/Input/TextTypeInput.tsx
+++ b/packages/ui-components/src/Input/TextTypeInput.tsx
@@ -63,6 +63,7 @@ export const BaseTextInput: React.FC<InternalTextProps> = props => {
   } = props;
 
   const inputProps = {
+    id: id,
     className: classNames("crl-input", className, {
       "crl-input--prefix": prefixElement,
       "crl-input--suffix": suffix,

--- a/packages/ui-components/src/Input/TextTypeInput.tsx
+++ b/packages/ui-components/src/Input/TextTypeInput.tsx
@@ -3,33 +3,26 @@ import classNames from "classnames/bind";
 import { CommonInputProps, CommonInput } from "./CommonInput";
 import { isEmpty } from "lodash";
 import "./input.module.scss";
-import { FieldRenderProps } from "react-final-form";
 
-// extending the fieldrender props here ensures that we have access to meta and input
-// if we need thems
-export interface TextAndNumberProps<T>
-  extends Partial<FieldRenderProps<T, HTMLInputElement>> {
+export interface TextAndNumberProps {
   suffix?: JSX.Element;
   prefixElement?: JSX.Element;
-  // this defines the input type rendered by this field
   // for multiline text types, this will be <textarea>
   // for text/email/password/number types this will be <input> with a type field
   JSXInput?: JSX.Element;
+  forgotPasswordLinkElement?: boolean;
 }
 
-export interface MultilineProps
-  extends React.DetailedHTMLProps<
-    React.TextareaHTMLAttributes<HTMLTextAreaElement>,
-    HTMLTextAreaElement
-  > {
-  suffix?: JSX.Element;
-}
+export type TextInputProps = CommonInputProps & TextAndNumberProps;
+export type MultilineTextInputProps = CommonInputProps &
+  Partial<
+    React.DetailedHTMLProps<
+      React.TextareaHTMLAttributes<HTMLTextAreaElement>,
+      HTMLTextAreaElement
+    >
+  >;
 
-export type TextInputProps = CommonInputProps & TextAndNumberProps<string>;
-export type MultilineTextInputProps = CommonInputProps & MultilineProps;
-export type NumberProps = CommonInputProps & TextAndNumberProps<number>;
-
-export const BaseTextInput: React.FC<TextInputProps | NumberProps> = props => {
+export const BaseTextInput = (props: TextInputProps) => {
   const {
     id,
     JSXInput,
@@ -43,6 +36,7 @@ export const BaseTextInput: React.FC<TextInputProps | NumberProps> = props => {
     type = "text",
     prefixElement,
     ariaLabelledBy,
+    forgotPasswordLinkElement,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     inline,
     ...rest
@@ -63,25 +57,24 @@ export const BaseTextInput: React.FC<TextInputProps | NumberProps> = props => {
 
   const input = JSXInput || <input {...inputProps} />;
 
-  const labelDiv = (
-    <>
-      {!isEmpty(label) && (
-        <label
-          aria-label={name}
-          className={classNames({
-            required: required,
-          })}
-          htmlFor={id}
-        >
-          {label}
-        </label>
-      )}
-    </>
+  const labelDiv = !isEmpty(label) && (
+    <label
+      aria-label={name}
+      className={classNames({
+        required: required,
+      })}
+      htmlFor={id}
+    >
+      {label}
+    </label>
   );
 
   const fieldInput = (
     <>
-      {labelDiv}
+      <div className="existing-password-label">
+        {labelDiv}
+        {forgotPasswordLinkElement}
+      </div>
       <div className="affix-container">
         {prefixElement && (
           <span className="crl-input__prefix">{prefixElement}</span>
@@ -102,29 +95,17 @@ export const SingleLineTextInput = (props: TextInputProps) => {
 export const MultilineTextInput = (props: MultilineTextInputProps) => {
   const inputProps = {
     className: classNames("crl-input", props.className, {
-      "crl-input--suffix": props.suffix,
       invalid: props.error,
     }),
-    name: name,
     ["aria-label"]: props.ariaLabel,
     ["aria-invalid"]: !!props.error,
     ["aria-required"]: props.required,
-    type: "text",
     ...props,
   };
   const JSXInput = <textarea {...inputProps} />;
-  return (
-    <BaseTextInput
-      label={props.label}
-      name={props.name}
-      suffix={props.suffix}
-      required={props.required}
-      id={props.id}
-      JSXInput={JSXInput}
-    />
-  );
+  return <BaseTextInput {...props} JSXInput={JSXInput} />;
 };
 
-export const NumberInput = (props: NumberProps) => {
+export const NumberInput = (props: TextInputProps) => {
   return <BaseTextInput type="number" {...props} />;
 };

--- a/packages/ui-components/src/Input/TextTypeInput.tsx
+++ b/packages/ui-components/src/Input/TextTypeInput.tsx
@@ -51,8 +51,6 @@ export const BaseTextInput: React.FC<TextInputProps | NumberProps> = props => {
   const inputProps = {
     id: id,
     className: classNames("crl-input", className, {
-      "crl-input--prefix": prefixElement,
-      "crl-input--suffix": suffix,
       invalid: error || invalid,
     }),
     ["aria-label"]: ariaLabel,

--- a/packages/ui-components/src/Input/TextTypeInput.tsx
+++ b/packages/ui-components/src/Input/TextTypeInput.tsx
@@ -3,9 +3,12 @@ import classNames from "classnames/bind";
 import { CommonInputProps, CommonInput } from "./CommonInput";
 import { isEmpty } from "lodash";
 import "./input.module.scss";
+import { FieldRenderProps } from "react-final-form";
 
-export interface TextAndNumberProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {
+// extending the fieldrender props here ensures that we have access to meta and input
+// if we need thems
+export interface TextAndNumberProps<T>
+  extends Partial<FieldRenderProps<T, HTMLInputElement>> {
   suffix?: JSX.Element;
   prefixElement?: JSX.Element;
   // this defines the input type rendered by this field
@@ -22,23 +25,11 @@ export interface MultilineProps
   suffix?: JSX.Element;
 }
 
-// the following props are used to implement {Email, Password, Number}Input
-// it is recommended to use those components instead of passing an "email" type to TextInput
-interface CustomProps {
-  ariaLabel?: string;
-  ariaLabelledBy?: string;
-  validatorLabel?: string;
-  reveal?: boolean;
-  newPassword?: boolean;
-  retypePassword?: boolean;
-}
-
-export type TextInputProps = CommonInputProps & TextAndNumberProps;
+export type TextInputProps = CommonInputProps & TextAndNumberProps<string>;
 export type MultilineTextInputProps = CommonInputProps & MultilineProps;
-export type NumberProps = TextInputProps & CustomProps;
-export type AllProps = TextInputProps & CustomProps;
+export type NumberProps = CommonInputProps & TextAndNumberProps<number>;
 
-export const BaseTextInput: React.FC<AllProps> = props => {
+export const BaseTextInput: React.FC<TextInputProps | NumberProps> = props => {
   const {
     id,
     JSXInput,
@@ -52,6 +43,8 @@ export const BaseTextInput: React.FC<AllProps> = props => {
     type = "text",
     prefixElement,
     ariaLabelledBy,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    inline,
     ...rest
   } = props;
 
@@ -112,11 +105,11 @@ export const MultilineTextInput = (props: MultilineTextInputProps) => {
   const inputProps = {
     className: classNames("crl-input", props.className, {
       "crl-input--suffix": props.suffix,
-      invalid: props.error || props.invalid,
+      invalid: props.error,
     }),
     name: name,
     ["aria-label"]: props.ariaLabel,
-    ["aria-invalid"]: !!props.error || props.invalid,
+    ["aria-invalid"]: !!props.error,
     ["aria-required"]: props.required,
     type: "text",
     ...props,
@@ -129,7 +122,6 @@ export const MultilineTextInput = (props: MultilineTextInputProps) => {
       suffix={props.suffix}
       required={props.required}
       id={props.id}
-      meta={props.meta}
       JSXInput={JSXInput}
     />
   );

--- a/packages/ui-components/src/Input/index.ts
+++ b/packages/ui-components/src/Input/index.ts
@@ -6,6 +6,5 @@ export {
   MultilineTextInput,
   MultilineTextInputProps,
   TextInputProps,
-  NumberInput,
-  NumberProps,
+  NumberInput
 } from "./TextTypeInput";

--- a/packages/ui-components/src/Input/index.ts
+++ b/packages/ui-components/src/Input/index.ts
@@ -6,5 +6,5 @@ export {
   MultilineTextInput,
   MultilineTextInputProps,
   TextInputProps,
-  NumberInput
+  NumberInput,
 } from "./TextTypeInput";

--- a/packages/ui-components/src/Input/index.ts
+++ b/packages/ui-components/src/Input/index.ts
@@ -3,6 +3,8 @@ export * from "./EmailPasswordInput";
 export * from "./CheckboxInput";
 export {
   SingleLineTextInput as TextInput,
+  MultilineTextInput,
+  MultilineTextInputProps,
   TextInputProps,
   NumberInput,
   NumberProps,

--- a/packages/ui-components/src/Input/index.ts
+++ b/packages/ui-components/src/Input/index.ts
@@ -1,4 +1,4 @@
-export * from "./Field";
+export * from "./InputField";
 export * from "./EmailPasswordInput";
 export * from "./CheckboxInput";
 export {

--- a/packages/ui-components/src/Input/input.module.scss
+++ b/packages/ui-components/src/Input/input.module.scss
@@ -76,7 +76,7 @@
   label {
     margin-bottom: 0;
     @extend .type-body;
-    color: $crl-base-text;
+    color: $color-font-3;
 
     &--human-readable {
       display: block;

--- a/packages/ui-components/src/Input/input.module.scss
+++ b/packages/ui-components/src/Input/input.module.scss
@@ -58,6 +58,16 @@
   &[type="checkbox"] {
     margin-right: crl-gutters(1);
   }
+
+  &.invalid {
+    background-color: rgba($color-base-red, 0.05);
+    color: $color-base-red;
+    border-color: $color-base-red;
+  
+    &:focus {
+      @include crl-box-shadow(0, 0, 4px, 2px, rgba($color-base-red, 0.4));
+    }
+  }
 }
 
 .checkbox-container {
@@ -65,8 +75,15 @@
   align-items: center;
   label {
     margin-bottom: 0;
+    @include crl-type-body;
+    color: $crl-base-text;
+
+    &--human-readable {
+      display: block;
+      @include crl-type-body--strong;
+    }
   }
-}
+}s
 
 .prefix {
   padding-left: 30px;
@@ -112,15 +129,20 @@
 }
 
 .inline {
+  width: 100%;
+  position: relative;
   display: inline-block;
-  margin-right: 6%;
-  width: 47%;
   vertical-align: top;
 }
 
 .crl-form-group {
-  .inline:last-child {
-    margin-right: 0;
+  .inline {
+    margin-right: 6%;
+    width: 47%;
+
+    &:last-child {
+      margin-right: 0;
+    }
   }
 }
 

--- a/packages/ui-components/src/Input/input.module.scss
+++ b/packages/ui-components/src/Input/input.module.scss
@@ -75,12 +75,12 @@
   align-items: center;
   label {
     margin-bottom: 0;
-    @include crl-type-body;
+    @extend .type-body;
     color: $crl-base-text;
 
     &--human-readable {
       display: block;
-      @include crl-type-body--strong;
+      @extend .type-body-strong;
     }
   }
 }

--- a/packages/ui-components/src/Input/input.module.scss
+++ b/packages/ui-components/src/Input/input.module.scss
@@ -90,12 +90,6 @@
   color: $color-base-red;
 }
 
-.crl-form-group {
-  .crl-input--inline:last-child {
-    margin-right: 0;
-  }
-}
-
 .invalid {
   background-color: rgba($color-base-red, 0.05);
   color: $color-base-red;
@@ -115,12 +109,18 @@
 .input-container {
   width: 100%;
   position: relative;
+}
 
-  .inline {
-    display: inline-block;
-    margin-right: 6%;
-    width: 47%;
-    vertical-align: top;
+.inline {
+  display: inline-block;
+  margin-right: 6%;
+  width: 47%;
+  vertical-align: top;
+}
+
+.crl-form-group {
+  .inline:last-child {
+    margin-right: 0;
   }
 }
 

--- a/packages/ui-components/src/Input/input.module.scss
+++ b/packages/ui-components/src/Input/input.module.scss
@@ -83,7 +83,7 @@
       @include crl-type-body--strong;
     }
   }
-}s
+}
 
 .prefix {
   padding-left: 30px;
@@ -107,25 +107,10 @@
   color: $color-base-red;
 }
 
-.invalid {
-  background-color: rgba($color-base-red, 0.05);
-  color: $color-base-red;
-  border-color: $color-base-red;
-
-  &:focus {
-    @include crl-box-shadow(0, 0, 4px, 2px, rgba($color-base-red, 0.4));
-  }
-}
-
 .input-reference:not([type="checkbox"]):disabled {
   color: $color-core-neutral-7;
   background-color: $color-core-neutral-1;
   border-color: $color-core-neutral-1;
-}
-
-.input-container {
-  width: 100%;
-  position: relative;
 }
 
 .inline {


### PR DESCRIPTION
# ui-components // edits from forms retro (re-type password field, reveal prop, type changes in Field component, multiple validators for password)

[Jira Issue](https://cockroachlabs.atlassian.net/browse/DS-13
)
[Forms Retro](https://docs.google.com/document/d/1e83kWWWck9FsVcM8HyShvH6dJ8RLG8UfcyrIy4Bi9kw/edit?ts=5fdbcf71
)

GIF of Password Changes (reveal prop, Re-type password field, validation):
![2021-01-05 12 57 31](https://user-images.githubusercontent.com/71023228/103681746-e18f2000-4f55-11eb-84de-742e4708637a.gif)

Screenshot of multiple validators:
![image](https://user-images.githubusercontent.com/71023228/103811795-76b01880-502b-11eb-92e3-27e93a1c15bc.png)

#### Checklist
- [ ] I have written or updated test for the changes I made
- [ ] I have updated the README of the package I'm working in to reflect my changes
- [ ] I have added or updated Storybook if appropriate for my changes

