### PR TITLE
db-console: alter base path with HOCs

### DIFF
--- a/packages/admin-ui-components/src/index.ts
+++ b/packages/admin-ui-components/src/index.ts
@@ -23,5 +23,6 @@ export * from "./transactionsPage";
 export * from "./text";
 export * from "./tooltip";
 export * from "./tooltip2";
+export * from "./routeNavigation";
 export { util, api };
 export * from "./sessions";

--- a/packages/admin-ui-components/src/routeNavigation/basePathContext.ts
+++ b/packages/admin-ui-components/src/routeNavigation/basePathContext.ts
@@ -1,0 +1,3 @@
+import React from "react";
+
+export const BasePathContext = React.createContext("");

--- a/packages/admin-ui-components/src/routeNavigation/index.ts
+++ b/packages/admin-ui-components/src/routeNavigation/index.ts
@@ -1,0 +1,4 @@
+export * from "./withNavigation";
+export * from "./basePathContext";
+export * from "./pathUtils";
+export * from "./useNavigation";

--- a/packages/admin-ui-components/src/routeNavigation/pathUtils.ts
+++ b/packages/admin-ui-components/src/routeNavigation/pathUtils.ts
@@ -1,0 +1,29 @@
+import { LocationDescriptor } from "history";
+
+export const removeTrailingSlash = (path: string) =>
+  path.charAt(path.length - 1) === "/" ? path.slice(0, -1) : path;
+
+export const removeLeadingSlash = (path: string) =>
+  path.charAt(0) === "/" ? path.slice(1) : path;
+
+export const extendWithBasePath = (
+  path: LocationDescriptor,
+  basePath: string,
+): LocationDescriptor => {
+  if (typeof path === "string") {
+    if (path.startsWith(basePath)) {
+      return path;
+    }
+    return `${removeTrailingSlash(basePath)}/${removeLeadingSlash(path)}`;
+  } else if ("pathname" in path) {
+    if (path.pathname.startsWith(basePath)) {
+      return path;
+    }
+    return {
+      ...path,
+      pathname: `${removeTrailingSlash(basePath)}/${removeLeadingSlash(
+        path.pathname,
+      )}`,
+    };
+  }
+};

--- a/packages/admin-ui-components/src/routeNavigation/useNavigation.ts
+++ b/packages/admin-ui-components/src/routeNavigation/useNavigation.ts
@@ -1,0 +1,22 @@
+import React from "react";
+import { LocationDescriptor } from "history";
+import { useHistory } from "react-router-dom";
+import { BasePathContext } from "./basePathContext";
+import { extendWithBasePath } from "./pathUtils";
+
+export const useNavigation = () => {
+  const basePath = React.useContext(BasePathContext);
+  const history = useHistory();
+  const navigate = React.useCallback(
+    (path: LocationDescriptor, action: "PUSH" | "REPLACE" = "PUSH") => {
+      const nextPath = extendWithBasePath(path, basePath);
+      if (action === "PUSH") {
+        history.push(nextPath);
+      } else {
+        history.replace(nextPath);
+      }
+    },
+    [history, basePath],
+  );
+  return { navigate };
+};

--- a/packages/admin-ui-components/src/routeNavigation/withNavigation.tsx
+++ b/packages/admin-ui-components/src/routeNavigation/withNavigation.tsx
@@ -1,0 +1,16 @@
+import React, { ComponentType } from "react";
+import { LocationDescriptor } from "history";
+import { useNavigation } from "./useNavigation";
+
+export type WithNavigationProps = {
+  navigate: (path: LocationDescriptor, action?: "PUSH" | "REPLACE") => void;
+};
+
+export const withNavigation = <P extends {}>(
+  WrappedComponent: ComponentType<P & WithNavigationProps>,
+): React.FC<P> => {
+  return (props: P) => {
+    const { navigate } = useNavigation();
+    return <WrappedComponent {...props} navigate={navigate} />;
+  };
+};

--- a/packages/admin-ui-components/src/statementsPage/statementsPage.fixture.ts
+++ b/packages/admin-ui-components/src/statementsPage/statementsPage.fixture.ts
@@ -427,6 +427,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
   onDiagnosticsModalOpen: noop,
   onSearchComplete: noop,
   onDiagnosticsReportDownload: noop,
+  navigate: noop,
 };
 
 export const statementsPagePropsWithRequestError: StatementsPageProps = {

--- a/packages/admin-ui-components/src/statementsPage/statementsPage.tsx
+++ b/packages/admin-ui-components/src/statementsPage/statementsPage.tsx
@@ -34,6 +34,7 @@ import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 
 type IStatementDiagnosticsReport = cockroach.server.serverpb.IStatementDiagnosticsReport;
 import sortableTableStyles from "src/sortedtable/sortedtable.module.scss";
+import { WithNavigationProps } from "../routeNavigation";
 
 const cx = classNames.bind(styles);
 const sortableTableCx = classNames.bind(sortableTableStyles);
@@ -79,7 +80,8 @@ export interface StatementsPageState {
 export type StatementsPageProps = StatementsPageDispatchProps &
   StatementsPageStateProps &
   StatementsPageOuterProps &
-  RouteComponentProps<any>;
+  RouteComponentProps<any> &
+  WithNavigationProps;
 
 export class StatementsPage extends React.Component<
   StatementsPageProps,
@@ -123,7 +125,7 @@ export class StatementsPage extends React.Component<
   };
 
   syncHistory = (params: Record<string, string | undefined>) => {
-    const { history } = this.props;
+    const { history, navigate } = this.props;
     const currentSearchParams = new URLSearchParams(history.location.search);
 
     forIn(params, (value, key) => {
@@ -135,7 +137,7 @@ export class StatementsPage extends React.Component<
     });
 
     history.location.search = currentSearchParams.toString();
-    history.replace(history.location);
+    navigate(history.location, "REPLACE");
   };
 
   changeSortSetting = (ss: SortSetting) => {
@@ -155,9 +157,9 @@ export class StatementsPage extends React.Component<
   };
 
   selectApp = (value: string) => {
-    const { history } = this.props;
+    const { history, navigate } = this.props;
     history.location.pathname = `/statements/${encodeURIComponent(value)}`;
-    history.replace(history.location);
+    navigate(history.location, "REPLACE");
     this.resetPagination();
   };
 

--- a/packages/admin-ui-components/src/statementsPage/statementsPageConnected.tsx
+++ b/packages/admin-ui-components/src/statementsPage/statementsPageConnected.tsx
@@ -1,5 +1,6 @@
 import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
+import { compose } from "redux";
 
 import { AppState } from "src/store";
 import { actions as statementActions } from "src/store/statements";
@@ -21,10 +22,13 @@ import {
   selectTotalFingerprints,
 } from "./statementsPage.selectors";
 import { AggregateStatistics } from "../statementsTable";
+import { withNavigation } from "../routeNavigation";
 
 type OwnProps = StatementsPageOuterProps & RouteComponentProps;
 
-export const ConnectedStatementsPage = withRouter(
+export const ConnectedStatementsPage = compose(
+  withNavigation,
+  withRouter,
   connect<StatementsPageStateProps, StatementsPageDispatchProps, OwnProps>(
     (state: AppState, props: StatementsPageProps) => ({
       statements: selectStatements(state, props),
@@ -68,5 +72,5 @@ export const ConnectedStatementsPage = withRouter(
           },
         }),
     },
-  )(StatementsPage),
-);
+  ),
+)(StatementsPage);

--- a/packages/admin-ui-components/src/statementsTable/statementsTableContent.tsx
+++ b/packages/admin-ui-components/src/statementsTable/statementsTableContent.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Link } from "react-router-dom";
 import classNames from "classnames/bind";
 import { noop } from "lodash";
 import {
@@ -25,6 +24,7 @@ import { shortStatement } from "./statementsTable";
 import styles from "./statementsTableContent.module.scss";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { Download } from "@cockroachlabs/icons";
+import { useNavigation } from "../routeNavigation";
 
 export type NodeNames = { [nodeId: string]: string };
 const cx = classNames.bind(styles);
@@ -276,13 +276,13 @@ export const StatementTableCell = {
   ),
 };
 
-interface StatementLinkProps {
+export type StatementLinkProps = {
   statement: string;
   app: string;
   implicitTxn: boolean;
   search: string;
   anonStatement?: string;
-}
+};
 
 // StatementLinkTarget returns the link to the relevant statement page, given
 // the input statement details.
@@ -302,9 +302,14 @@ export const StatementLinkTarget = (props: StatementLinkProps) => {
 };
 
 export const StatementLink = (props: StatementLinkProps) => {
-  const summary = summarize(props.statement);
+  const { statement } = props;
+  const summary = summarize(statement);
+  const { navigate } = useNavigation();
+  const onLinkClick = React.useCallback(() => {
+    navigate(StatementLinkTarget(props));
+  }, [props, navigate]);
   return (
-    <Link to={StatementLinkTarget(props)}>
+    <Anchor onClick={onLinkClick} target="_self">
       <div>
         <Tooltip
           placement="bottom"
@@ -324,14 +329,25 @@ export const StatementLink = (props: StatementLinkProps) => {
           </div>
         </Tooltip>
       </div>
-    </Link>
+    </Anchor>
   );
 };
 
-export const NodeLink = (props: { nodeId: string; nodeNames: NodeNames }) => (
-  <Link to={`/node/${props.nodeId}`}>
-    <div className={cx("node-name-tooltip__info-icon")}>
-      {props.nodeNames[props.nodeId]}
-    </div>
-  </Link>
-);
+export type NodeLinkProps = {
+  nodeId: string;
+  nodeNames: NodeNames;
+};
+
+export const NodeLink = ({ nodeId, nodeNames }: NodeLinkProps) => {
+  const { navigate } = useNavigation();
+  const onLinkClick = React.useCallback(() => {
+    navigate(`/node/${nodeId}`);
+  }, [nodeId, navigate]);
+  return (
+    <Anchor onClick={onLinkClick} target="_self">
+      <div className={cx("node-name-tooltip__info-icon")}>
+        {nodeNames[nodeId]}
+      </div>
+    </Anchor>
+  );
+};

--- a/packages/admin-ui-components/src/transactionsPage/transactions.fixture.ts
+++ b/packages/admin-ui-components/src/transactionsPage/transactions.fixture.ts
@@ -2,6 +2,7 @@
 import { createMemoryHistory } from "history";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import Long from "long";
+import { noop } from "lodash";
 
 const history = createMemoryHistory({ initialEntries: ["/transactions"] });
 
@@ -21,6 +22,7 @@ export const routeProps = {
     isExact: true,
     params: {},
   },
+  navigate: noop,
 };
 
 export const data: cockroach.server.serverpb.IStatementsResponse = {

--- a/packages/admin-ui-components/src/transactionsPage/transactionsPage.tsx
+++ b/packages/admin-ui-components/src/transactionsPage/transactionsPage.tsx
@@ -24,6 +24,7 @@ import { Loading } from "../loading";
 import { PageConfig, PageConfigItem } from "../pageConfig";
 import { Search } from "../search";
 import { Filter } from "./filter";
+import { WithNavigationProps } from "../routeNavigation";
 
 type IStatementsResponse = protos.cockroach.server.serverpb.IStatementsResponse;
 
@@ -58,7 +59,7 @@ interface TransactionsPageProps {
 }
 
 export class TransactionsPage extends React.Component<
-  RouteComponentProps & TransactionsPageProps
+  RouteComponentProps & TransactionsPageProps & WithNavigationProps
 > {
   trxSearchParams = getSearchParams(this.props.history.location.search);
 
@@ -88,7 +89,7 @@ export class TransactionsPage extends React.Component<
   }
 
   syncHistory = (params: Record<string, string | undefined>) => {
-    const { history } = this.props;
+    const { history, navigate } = this.props;
     const currentSearchParams = new URLSearchParams(history.location.search);
 
     forIn(params, (value, key) => {
@@ -100,7 +101,7 @@ export class TransactionsPage extends React.Component<
     });
 
     history.location.search = currentSearchParams.toString();
-    history.replace(history.location);
+    navigate(history.location, "REPLACE");
   };
 
   onChangeSortSetting = (ss: SortSetting) => {


### PR DESCRIPTION
Current change is an attempt to resolve the issue when route paths have to be altered with some base path provided from outside. All paths inside of `db-console` suppose that base path is `/` and in case client application has defined another base path for Statements page than these internal paths inside of statements page won't know about this and will be broken.

This change suggests following:
- `react-router` and navigation isn't used directly inside of pages - `history.push` and `history.replace` methods are wrapped inside of `useNavigation` hook which is a single point for calling this methods and it also has an access to `basePath` which can be defined with `BasePathContext`. It allows us to avoid usage of contexts directly in components and abstract logic in hook (and as HOC for class components).
- `useNavigation` hook should be used for functional components
- `withNavigation` HOC should be used for class components (provides `navigate` prop)

Pros:
- changing browsers history can be considered as a side effect and has to be called outside of component.
- entire logic of handling navigation and altering base path is defined in a single place

Cons:
- It is not possible to disallow calling `history.push/replace` methods from component and might break usage of base paths;