### PR TITLE
admin-ui-components: sessions page copy changes

### DIFF
--- a/packages/admin-ui-components/src/sessions/sessionsTableContent.tsx
+++ b/packages/admin-ui-components/src/sessions/sessionsTableContent.tsx
@@ -39,27 +39,27 @@ export const SessionTableTitle = {
     <Tooltip2
       tableTitle
       placement="bottom"
-      title={<>{"The age of the session."}</>}
+      title={<>{"The duration of the session."}</>}
     >
-      Session Age
+      Session Duration
     </Tooltip2>
   ),
   txnAge: (
     <Tooltip2
       tableTitle
       placement="bottom"
-      title={<>{"The age of the open transaction, if there is one."}</>}
+      title={<>{"The duration of the open transaction, if there is one."}</>}
     >
-      Txn Age
+      Transaction Duration
     </Tooltip2>
   ),
   statementAge: (
     <Tooltip2
       tableTitle
       placement="bottom"
-      title={<>{"The age of the active statement, if there is one."}</>}
+      title={<>{"The duration of the active statement, if there is one."}</>}
     >
-      Statement Age
+      Statement Duration
     </Tooltip2>
   ),
   memUsage: (


### PR DESCRIPTION
This change updates the sessions page to use
'duration' instead of 'age' and 'transaction'
instead of 'txn'. This aims to make the meaning
of these fields less ambiguous.

Release note (ui change): On the sessions page in db console, any 'age'
label has been replaced with 'duration' and 'txn' has been replaced with
'transaction'. This was only a label change, with the actual metrics
remaining unchanged.

Relates to cockroachdb/cockroach#57047.

