### PR TITLE
db-console: fix path for bundled declarations file

### DIFF
--- a/packages/admin-ui-components/package.json
+++ b/packages/admin-ui-components/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/cockroachdb/admin-ui-components"
   },
   "main": "dist/main.js",
-  "types": "dist/types/index.d.ts",
+  "types": "dist/types/src/index.d.ts",
   "scripts": {
     "build": "npm-run-all build:typescript build:bundle",
     "build:bundle": "NODE_ENV=production webpack --display-error-details",


### PR DESCRIPTION
Initially, path to declaration file was wrong and didn't
allow to properly provide type definitions in client apps
which imported `admin-ui-components`.

Changed to reflect correct path where index.d.ts file is
generated during build.

