### PR TITLE
db-console: tsconfig to generate typings for source files only

### DIFF
--- a/packages/admin-ui-components/.npmignore
+++ b/packages/admin-ui-components/.npmignore
@@ -6,6 +6,10 @@
 
 # source
 src/
+.jest
+.storybook
+enzyme.setup.js
+.eslintrc.json
 
 # source maps
 */**/*.js.map

--- a/packages/admin-ui-components/package.json
+++ b/packages/admin-ui-components/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/cockroachdb/admin-ui-components"
   },
   "main": "dist/main.js",
-  "types": "dist/types/src/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "npm-run-all build:typescript build:bundle",
     "build:bundle": "NODE_ENV=production webpack --display-error-details",

--- a/packages/admin-ui-components/tsconfig.json
+++ b/packages/admin-ui-components/tsconfig.json
@@ -12,11 +12,14 @@
     "outDir": "./dist/types",
     "target": "es6",
     "skipLibCheck": true,
-    "sourceMap": false,
+    "sourceMap": false
   },
   "exclude": [
     "node_modules",
     "dist",
-    "**/*.test.*"
+    "**/*.test.*",
+    ".jest",
+    ".storybook",
+    "**/*.stories.tsx"
   ]
 }


### PR DESCRIPTION
Previous tsconfig.json configuration didn't exclude files files
for test configurations and storybooks and somehow it caused
strange behavior when source typings weren't included in final
package.

This change explicitly excludes any top level config files and
storybooks in ./src to prevent typescript from generating any
typings for those files.
It doesn't affect test execution and storybooks.

Excluded files from `.npmignore` is just clean up to avoid
non-production files to be included in package.

