### PR TITLE
db-console: optimize Webpack build process with production mode

### DIFF
--- a/packages/cluster-ui/package.json
+++ b/packages/cluster-ui/package.json
@@ -10,9 +10,9 @@
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "npm-run-all build:typescript build:bundle",
-    "build:bundle": "NODE_ENV=production webpack --display-error-details",
+    "build:bundle": "NODE_ENV=production webpack --display-error-details --mode=production",
     "build:typescript": "tsc",
-    "build:watch": "webpack --watch",
+    "build:watch": "webpack --watch --mode=development",
     "ci": "jest --ci -i",
     "clean": "rm -rf  ./dist/*",
     "lint": "eslint './src/**/*.{tsx,ts,js}' --format=codeframe",

--- a/packages/cluster-ui/webpack.config.js
+++ b/packages/cluster-ui/webpack.config.js
@@ -2,8 +2,6 @@ const path = require("path");
 const WebpackBar = require("webpackbar");
 
 module.exports = {
-  mode: "development",
-
   entry: "./src/index.ts",
 
   output: {


### PR DESCRIPTION
Initially, webpack config was defined with hard coded "development"
mode that isn't sufficient for production.
Now, webpack's "mode" option is provided as an argument in package.json
to set production mode for builds.
Production mode provides a set of optimizations to minify bundle
