### PR TITLE
fix naming in cluster-ui publish action

### DIFF
--- a/.github/workflows/publish-cluster-ui.yml
+++ b/.github/workflows/publish-cluster-ui.yml
@@ -50,7 +50,7 @@ jobs:
           yarn version --patch
           git push --follow-tags
         working-directory: ./packages/cluster-ui
-      - name: Publish ui-components
+      - name: Publish cluster-ui
         run: yarn publish --access public
         working-directory: ./packages/cluster-ui
         env:


### PR DESCRIPTION
# Cluster UI // Fix naming in cluster-ui publish action

- renamed publish yml file to reflect new package name
- fixed name of final publish action to reflect correct package name

#### Checklist
- [X] I have written or updated test for the changes I made -- N/A
- [X] I have updated the README of the package I'm working in to reflect my changes -- N/A
- [X] I have added or updated Storybook if appropriate for my changes -- N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/ui/175)
<!-- Reviewable:end -->
