### PR TITLE
cluster-ui: optimize bundle size

### DIFF
--- a/packages/cluster-ui/babel.config.js
+++ b/packages/cluster-ui/babel.config.js
@@ -17,6 +17,7 @@ const presets = [
 const plugins = [
   "@babel/proposal-class-properties",
   "@babel/proposal-object-rest-spread",
+  ["import", { "libraryName": "antd", "style": "css" }]
 ];
 
 const env = {

--- a/packages/cluster-ui/package.json
+++ b/packages/cluster-ui/package.json
@@ -83,6 +83,7 @@
     "astroturf": "^0.10.2",
     "babel-jest": "^26.2.2",
     "babel-loader": "^8.0.6",
+    "babel-plugin-import": "^1.13.3",
     "babel-preset-react-app": "^9.1.2",
     "chai": "^4.2.0",
     "classnames": "^2.2.6",

--- a/packages/cluster-ui/package.json
+++ b/packages/cluster-ui/package.json
@@ -106,6 +106,7 @@
     "jest-runner-eslint": "^0.7.6",
     "less": "^3.12.2",
     "less-loader": "^6.2.0",
+    "moment-locales-webpack-plugin": "^1.2.0",
     "node-sass": "^4.13.1",
     "prettier": "^1.19.1",
     "protobufjs": "6.8.6",

--- a/packages/cluster-ui/src/declaration.d.ts
+++ b/packages/cluster-ui/src/declaration.d.ts
@@ -18,3 +18,6 @@ type Tuple<T> = [T, T];
 type Dictionary<V> = {
   [key: string]: V;
 };
+
+declare module "highlight.js/lib/core";
+declare module "highlight.js/lib/languages/pgsql";

--- a/packages/cluster-ui/src/index.ts
+++ b/packages/cluster-ui/src/index.ts
@@ -1,4 +1,3 @@
-import "antd/dist/antd.less";
 import "./protobufInit";
 import * as util from "./util";
 import * as api from "./api";

--- a/packages/cluster-ui/src/modal/modal.tsx
+++ b/packages/cluster-ui/src/modal/modal.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import classNames from "classnames/bind";
-import AntModal from "antd/lib/modal";
+import { Modal as AntModal } from "antd";
 import { Button } from "../button";
 import { Text, TextTypes } from "../text";
 import styles from "./modal.module.scss";

--- a/packages/cluster-ui/src/pagination/pagination.tsx
+++ b/packages/cluster-ui/src/pagination/pagination.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import AntPagination from "antd/lib/pagination";
+import { Pagination as AntPagination } from "antd";
 import { PaginationProps as AntPaginationProps } from "antd/lib/pagination";
 import classNames from "classnames/bind";
 import styles from "./pagination.module.scss";

--- a/packages/cluster-ui/src/search/search.tsx
+++ b/packages/cluster-ui/src/search/search.tsx
@@ -1,7 +1,6 @@
 import React from "react";
-import Button from "antd/lib/button";
-import Form from "antd/lib/form";
-import Input, { InputProps } from "antd/lib/input";
+import { Button, Form, Input } from "antd";
+import { InputProps } from "antd/lib/input";
 import classNames from "classnames/bind";
 import {
   Cancel as CancelIcon,

--- a/packages/cluster-ui/src/sortedtable/tableSpinner/tableSpinner.tsx
+++ b/packages/cluster-ui/src/sortedtable/tableSpinner/tableSpinner.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Spinner } from "@cockroachlabs/icons";
-import Spin from "antd/lib/spin";
-import Icon from "antd/lib/icon";
+import { Spin, Icon } from "antd";
 import classNames from "classnames/bind";
 import styles from "./tableSpinner.module.scss";
 

--- a/packages/cluster-ui/src/sql/highlight.tsx
+++ b/packages/cluster-ui/src/sql/highlight.tsx
@@ -8,13 +8,19 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import * as hljs from "highlight.js";
+import hljs from "highlight.js/lib/core";
+import sqlLangSyntax from "highlight.js/lib/languages/pgsql";
 import React from "react";
 import classNames from "classnames/bind";
 import styles from "./sqlhighlight.module.scss";
 import { SqlBoxProps } from "./box";
 
 const cx = classNames.bind(styles);
+
+hljs.registerLanguage("sql", sqlLangSyntax);
+hljs.configure({
+  tabReplace: "  ",
+});
 
 export class Highlight extends React.Component<SqlBoxProps> {
   preNode: React.RefObject<HTMLPreElement> = React.createRef();
@@ -24,9 +30,6 @@ export class Highlight extends React.Component<SqlBoxProps> {
   }
 
   componentDidMount() {
-    hljs.configure({
-      tabReplace: "  ",
-    });
     hljs.highlightBlock(this.preNode.current);
   }
 

--- a/packages/cluster-ui/src/table/table.tsx
+++ b/packages/cluster-ui/src/table/table.tsx
@@ -1,9 +1,7 @@
 import React from "react";
-import { default as AntTable, ColumnProps } from "antd/lib/table";
-import ConfigProvider from "antd/lib/config-provider";
+import { Table as AntTable, ConfigProvider } from "antd";
+import { ColumnProps } from "antd/lib/table";
 import classnames from "classnames/bind";
-
-import "antd/lib/table/style/css";
 import styles from "./table.module.scss";
 
 export type ColumnsConfig<T> = Array<ColumnProps<T>>;

--- a/packages/cluster-ui/src/tooltip/tooltip.tsx
+++ b/packages/cluster-ui/src/tooltip/tooltip.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import AntTooltip, { AbstractTooltipProps } from "antd/lib/tooltip";
+import { Tooltip as AntTooltip } from "antd";
+import { AbstractTooltipProps } from "antd/lib/tooltip";
 import classNames from "classnames/bind";
 import styles from "./tooltip.module.scss";
 

--- a/packages/cluster-ui/src/tooltip2/tooltip.tsx
+++ b/packages/cluster-ui/src/tooltip2/tooltip.tsx
@@ -1,8 +1,6 @@
 import * as React from "react";
-import {
-  default as AntTooltip,
-  TooltipProps as AntTooltipProps,
-} from "antd/lib/tooltip";
+import { Tooltip as AntTooltip } from "antd";
+import { TooltipProps as AntTooltipProps } from "antd/lib/tooltip";
 import classNames from "classnames/bind";
 import styles from "./tooltip.module.scss";
 

--- a/packages/cluster-ui/src/transactionsPage/filter/filter.tsx
+++ b/packages/cluster-ui/src/transactionsPage/filter/filter.tsx
@@ -1,16 +1,14 @@
 import React from "react";
-// import Checkbox from "rc-checkbox";
 import Select from "react-select";
 import { Button } from "../../button";
 import { CaretDown } from "@cockroachlabs/icons";
 import { Filters } from "../../transactionsPage";
-import Input from "antd/lib/input";
+import { Input } from "antd";
 import {
   dropdownButton,
   dropdownContentWrapper,
   timePair,
   filterLabel,
-  // checkbox,
   applyBtn,
   dropdown,
   hidden,
@@ -34,12 +32,6 @@ export interface SelectOptions {
   label: string;
   value: string;
 }
-
-// const TransactionsType = [
-//   { label: "Insert values 1", value: "Insert values 1" },
-//   { label: "Insert values 2", value: "Insert values 2" },
-//   { label: "Insert values 3", value: "Insert values 3" },
-// ];
 
 const timeUnit = [
   { label: "seconds", value: "seconds" },
@@ -146,13 +138,6 @@ export class Filter extends React.Component<TransactionsFilter, FilterState> {
               placeholder="All"
               {...defaultSelectProps}
             />
-            {/* <div className={filterLabel.type}> Transaction type </div>
-            <Select
-              options={TransactionsType}
-              onChange={e => this.handleChange(e, "transactionType")}
-              placeholder={"Select DDL, DML"}
-              {...defaultSelectProps}
-            /> */}
             <div className={filterLabel.query}>
               Query fingerprint runs longer than
             </div>
@@ -171,19 +156,6 @@ export class Filter extends React.Component<TransactionsFilter, FilterState> {
                 {...defaultSelectProps}
               />
             </section>
-            {/* <div className={checkbox.fullScansWrapper}>
-              <Checkbox onChange={e => this.handleChange(e, "fullScans")} />
-              <div className={checkbox.label}>
-                Only show transactions that contain queries with full table
-                scans
-              </div>
-            </div>
-            <div className={checkbox.distributedWrapper}>
-              <Checkbox onChange={e => this.handleChange(e, "distributed")} />
-              <div className={checkbox.label}>
-                Only show distributed transactions (across multiple nodes)
-              </div>
-            </div> */}
             <div className={applyBtn.wrapper}>
               <Button
                 className={applyBtn.btn}

--- a/packages/cluster-ui/webpack.config.js
+++ b/packages/cluster-ui/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require("path");
 const WebpackBar = require("webpackbar");
+const MomentLocalesPlugin = require("moment-locales-webpack-plugin");
 
 module.exports = {
   mode: "development",
@@ -108,6 +109,7 @@ module.exports = {
       color: "cyan",
       profile: true,
     }),
+    new MomentLocalesPlugin(),
   ],
 
   // When importing a module whose path matches one of the following, just

--- a/yarn.lock
+++ b/yarn.lock
@@ -1225,7 +1225,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.0", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
   integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
@@ -1287,20 +1287,6 @@
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/@cockroachlabs/crdb-protobuf-client/-/crdb-protobuf-client-0.0.4.tgz#9b53ef7cbb187cd7d73b4269c95b0f573caafd45"
   integrity sha512-n/SEmLzU7i9h5m8cAw9NPRAcQSgzHNdm5+F0dN3myfQSCuEMTgTlbWsfm6EnjTRL1FnZlieqY2gZzgyx4Ke0Ug==
-
-"@cockroachlabs/icons@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@cockroachlabs/icons/-/icons-0.3.0.tgz#160573074396f266e92fcbe5e520c5ba1d8750f9"
-  integrity sha512-GJxhlXy8Z3/PYFb9C3iM1dvU9wajGoaA/+VCj0an2ipfbkI2fhToq+h0b33vu7JuZ3dS4QMRjfVE4uhlyIUH2Q==
-
-"@cockroachlabs/ui-components@^0.2.14-alpha.0":
-  version "0.2.15"
-  resolved "https://registry.yarnpkg.com/@cockroachlabs/ui-components/-/ui-components-0.2.15.tgz#f93e61bc5af33ef0ba0155230674ba9741a270fe"
-  integrity sha512-5er6ZsGD8RgnBR7LrFd78u/UYpye21xbAuPR9r5M3Wt4wCkZetVaQA8x1g7BeKzKkKv0uLcA5swhCxKhoEzNxA==
-  dependencies:
-    "@cockroachlabs/icons" "^0.4.0"
-    "@popperjs/core" "^2.4.3"
-    react-popper "^2.2.3"
 
 "@cockroachlabs/icons@0.3.0", "@cockroachlabs/icons@^0.3.0":
   version "0.3.0"
@@ -8784,6 +8770,13 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+final-form@4.20.1:
+  version "4.20.1"
+  resolved "https://registry.yarnpkg.com/final-form/-/final-form-4.20.1.tgz#525a7f7f27f55c28d8994b157b24d6104fc560e9"
+  integrity sha512-IIsOK3JRxJrN72OBj7vFWZxtGt3xc1bYwJVPchjVWmDol9DlzMSAOPB+vwe75TUYsw1JaH0fTQnIgwSQZQ9Acg==
+  dependencies:
+    "@babel/runtime" "^7.10.0"
+
 finalhandler@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.2.tgz#b7e7d000ffd11938d0fdb053506f6ebabe9f587d"
@@ -12087,6 +12080,11 @@ lodash.debounce@^4.0.0, lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
+lodash.difference@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz#9ccb4e505d486b91651345772885a2df27fd017c"
+  integrity sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=
+
 lodash.escape@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-4.0.1.tgz#c9044690c21e04294beaa517712fded1fa88de98"
@@ -12868,6 +12866,13 @@ modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
+
+moment-locales-webpack-plugin@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/moment-locales-webpack-plugin/-/moment-locales-webpack-plugin-1.2.0.tgz#9af83876a44053706b868ceece5119584d10d7aa"
+  integrity sha512-QAi5v0OlPUP7GXviKMtxnpBAo8WmTHrUNN7iciAhNOEAd9evCOvuN0g1N7ThIg3q11GLCkjY1zQ2saRcf/43nQ==
+  dependencies:
+    lodash.difference "^4.5.0"
 
 moment@2.x, moment@^2.24.0:
   version "2.29.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5273,6 +5273,14 @@ babel-plugin-extract-import-names@1.6.22:
   dependencies:
     "@babel/helper-plugin-utils" "7.10.4"
 
+babel-plugin-import@^1.13.3:
+  version "1.13.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-import/-/babel-plugin-import-1.13.3.tgz#9dbbba7d1ac72bd412917a830d445e00941d26d7"
+  integrity sha512-1qCWdljJOrDRH/ybaCZuDgySii4yYrtQ8OJQwrcDqdt0y67N30ng3X3nABg6j7gR7qUJgcMa9OMhc4AGViDwWw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/runtime" "^7.0.0"
+
 babel-plugin-istanbul@^5.1.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz#df4ade83d897a92df069c4d9a25cf2671293c854"


### PR DESCRIPTION
There is five dependencies that mostly impacted the size of bundle: `crdb-protobuf-client`, `moment.js`, `lodash`, `highlight.js`, and `antd`.
- Moment.js by default imported all locales;
- highlight.js imported syntax configs for different languages (only SQL syntax is used)
- antd imported many unused components and styles.

Current changes handle these three libs (except `lodash`) with limiting imports to required functionalities.
It is easier to review this PR per commit with more detailed explanation in commit messages.

Current changes reduce the size of bundle from ~20Mb to ~14Mb

PS: `lodash` imports aren't optimized here because they require code changes (eliminate `_.chain` usage)
PS: `crdb-protobuf-client` size is ~6Mb from total size (50%) not minified. Require optimizations during package build.

- [x] tabulation for highlight SQL syntax is broken