### PR TITLE
cluster-ui: update statements page

### DIFF
--- a/packages/cluster-ui/package.json
+++ b/packages/cluster-ui/package.json
@@ -26,7 +26,7 @@
   "keywords": [],
   "license": "MIT",
   "dependencies": {
-    "@cockroachlabs/crdb-protobuf-client": "^0.0.4",
+    "@cockroachlabs/crdb-protobuf-client": "^0.0.5",
     "@cockroachlabs/icons": "0.3.0",
     "@cockroachlabs/ui-components": "0.2.14-alpha.0",
     "@popperjs/core": "^2.4.0",

--- a/packages/cluster-ui/src/barCharts/barCharts.module.scss
+++ b/packages/cluster-ui/src/barCharts/barCharts.module.scss
@@ -55,12 +55,12 @@
     background-color: $colors--alert;
   }
 
-  .rows {
+  .rows, .rows-read, .bytes-read, .max-mem-usage, .network-bytes {
     background-color: $colors--neutral-4;
     border-radius: 3px;
   }
 
-  .rows-dev {
+  .rows-dev, .rows-read-dev, .bytes-read-dev, .max-mem-usage-dev, .network-bytes-dev {
     background-color: $colors--primary-blue-3;
   }
 

--- a/packages/cluster-ui/src/barCharts/barCharts.stories.tsx
+++ b/packages/cluster-ui/src/barCharts/barCharts.stories.tsx
@@ -3,9 +3,12 @@ import { storiesOf, DecoratorFn } from "@storybook/react";
 
 import {
   countBarChart,
+  rowsReadBarChart,
+  bytesReadBarChart,
   latencyBarChart,
+  maxMemUsageBarChart,
+  networkBytesBarChart,
   retryBarChart,
-  rowsBarChart,
 } from "./barCharts";
 import statementsPagePropsFixture from "src/statementsPage/statementsPage.fixture";
 import Long from "long";
@@ -41,16 +44,28 @@ storiesOf("BarCharts", module)
     const chartFactory = countBarChart(statements);
     return chartFactory(statements[0]);
   })
+  .add("rowsReadBarChart", () => {
+    const chartFactory = rowsReadBarChart(statements);
+    return chartFactory(statements[0]);
+  })
+  .add("bytesReadBarChart", () => {
+    const chartFactory = bytesReadBarChart(statements);
+    return chartFactory(statements[0]);
+  })
   .add("latencyBarChart", () => {
     const chartFactory = latencyBarChart(statements);
     return chartFactory(statements[0]);
   })
-  .add("retryBarChart", () => {
-    const chartFactory = retryBarChart(statements);
+  .add("maxMemUsageBarChart", () => {
+    const chartFactory = maxMemUsageBarChart(statements);
     return chartFactory(statements[0]);
   })
-  .add("rowsBarChart", () => {
-    const chartFactory = rowsBarChart(statements);
+  .add("networkBytesBarChart", () => {
+    const chartFactory = networkBytesBarChart(statements);
+    return chartFactory(statements[0]);
+  })
+  .add("retryBarChart", () => {
+    const chartFactory = retryBarChart(statements);
     return chartFactory(statements[0]);
   });
 
@@ -60,8 +75,20 @@ storiesOf("BarCharts/within column (150px)", module)
     const chartFactory = countBarChart(statements);
     return chartFactory(statements[0]);
   })
+  .add("rowsReadBarChart", () => {
+    const chartFactory = rowsReadBarChart(statements);
+    return chartFactory(statements[0]);
+  })
+  .add("bytesReadBarChart", () => {
+    const chartFactory = bytesReadBarChart(statements);
+    return chartFactory(statements[0]);
+  })
   .add("latencyBarChart", () => {
     const chartFactory = latencyBarChart(statements);
+    return chartFactory(statements[0]);
+  })
+  .add("maxMemUsageBarChart", () => {
+    const chartFactory = maxMemUsageBarChart(statements);
     return chartFactory(statements[0]);
   })
   .add("retryBarChart", () => {
@@ -80,8 +107,4 @@ storiesOf("BarCharts/within column (150px)", module)
     }));
     const chartFactory = retryBarChart(withoutRetries);
     return chartFactory(withoutRetries[0]);
-  })
-  .add("rowsBarChart", () => {
-    const chartFactory = rowsBarChart(statements);
-    return chartFactory(statements[0]);
   });

--- a/packages/cluster-ui/src/barCharts/barCharts.tsx
+++ b/packages/cluster-ui/src/barCharts/barCharts.tsx
@@ -39,8 +39,11 @@ const maxMemUsageBars = [
 ];
 
 const networkBytesBars = [
-  bar("network-bytes", (d: StatementStatistics) => d.stats.bytes_sent_over_network?.mean),
-]
+  bar(
+    "network-bytes",
+    (d: StatementStatistics) => d.stats.bytes_sent_over_network?.mean,
+  ),
+];
 
 const retryBars = [
   bar(
@@ -68,7 +71,10 @@ const maxMemUsageStdDev = bar(
 const networkBytesStdDev = bar(
   cx("network-bytes-dev"),
   (d: StatementStatistics) =>
-    stdDevLong(d.stats.bytes_sent_over_network, d.stats.exec_stat_collection_count),
+    stdDevLong(
+      d.stats.bytes_sent_over_network,
+      d.stats.exec_stat_collection_count,
+    ),
 );
 
 export const countBarChart = barChartFactory("grey", countBars, approximify);
@@ -92,16 +98,16 @@ export const latencyBarChart = barChartFactory(
   latencyStdDev,
 );
 export const maxMemUsageBarChart = barChartFactory(
-    "grey",
-    maxMemUsageBars,
-    Bytes,
-    maxMemUsageStdDev,
-)
+  "grey",
+  maxMemUsageBars,
+  Bytes,
+  maxMemUsageStdDev,
+);
 export const networkBytesBarChart = barChartFactory(
   "grey",
   networkBytesBars,
   Bytes,
   networkBytesStdDev,
-)
+);
 
 export const retryBarChart = barChartFactory("red", retryBars, approximify);

--- a/packages/cluster-ui/src/statementDetails/statementDetails.fixture.ts
+++ b/packages/cluster-ui/src/statementDetails/statementDetails.fixture.ts
@@ -73,6 +73,15 @@ const statementStats: any = {
       ],
     },
   },
+  bytes_sent_over_network: {
+    mean: 4160407,
+    squared_diffs: 47880000000000,
+  },
+  max_mem_usage: {
+    mean: 4160407,
+    squared_diffs: 47880000000000,
+  },
+  exec_stat_collection_count: 1,
 };
 
 export const getStatementDetailsPropsFixture = (): StatementDetailsProps => ({

--- a/packages/cluster-ui/src/statementsPage/statementsPage.fixture.ts
+++ b/packages/cluster-ui/src/statementsPage/statementsPage.fixture.ts
@@ -148,6 +148,23 @@ const statementStats: IStatementStatistics = {
       ],
     },
   },
+  "bytes_read": {
+    "mean": 80,
+    "squared_diffs": 0.01,
+  },
+  "rows_read": {
+    "mean": 10,
+    "squared_diffs": 1,
+  },
+  "bytes_sent_over_network": {
+    "mean": 80,
+    "squared_diffs": 0.01,
+  },
+  "max_mem_usage": {
+    "mean": 80,
+    "squared_diffs": 0.01,
+  },
+  "exec_stat_collection_count": Long.fromNumber(180),
 };
 
 const diagnosticsReports: IStatementDiagnosticsReport[] = [

--- a/packages/cluster-ui/src/statementsTable/statementsTable.module.scss
+++ b/packages/cluster-ui/src/statementsTable/statementsTable.module.scss
@@ -4,34 +4,13 @@
   white-space: nowrap;
 }
 
-.statements-table__col-count--bar-chart {
-  width: 100px;
-}
-
-.statements-table__col-retries--bar-chart {
-  width: 80px;
-}
-
 .numeric-stats-table {
   .bar-chart {
     width: 200px;
   }
 }
 
-.statements-table__col-rows,
-.statements-table__col-latency {
-  &--bar-chart {
-    min-width: 150px;
-  }
-}
-
-.statements-table__col-count,
-.statements-table__col-rows,
-.statements-table__col-rows-read,
-.statements-table__col-bytes-read ,
-.statements-table__col-max-mem-usage,
-.statements-tabe__col-network-bytes,
-.statements-table__col-retries {
+.statements-table__col {
   &--bar-chart {
     margin-left: 0;
 
@@ -42,6 +21,30 @@
     }
   }
 }
+
+// Overrides to widths of specific table columns
+// to make them look nicer or emphasize certain
+// bar graphs over others, otherwise by default
+// widths of table columns will be governed by
+// the length of the name of the column
+.statements-table__col-count {
+  .statements-table__col--bar-chart {
+    width: 100px;
+  }
+}
+
+.statements-table__col-retries {
+  .statements-table__col--bar-chart {
+    width: 80px;
+  }
+}
+
+.statements-table__col-rows-read, .statements-table__col-latency {
+  .statements-table__col--bar-chart {
+    min-width: 150px;
+  }
+}
+
 
 .cl-table__col-query-text a {
   font-family: $font-family--monospace;

--- a/packages/cluster-ui/src/statementsTable/statementsTable.module.scss
+++ b/packages/cluster-ui/src/statementsTable/statementsTable.module.scss
@@ -26,8 +26,12 @@
 }
 
 .statements-table__col-count,
-.statements-table__col-retries,
-.statements-table__col-rows {
+.statements-table__col-rows,
+.statements-table__col-rows-read,
+.statements-table__col-bytes-read ,
+.statements-table__col-max-mem-usage,
+.statements-tabe__col-network-bytes,
+.statements-table__col-retries {
   &--bar-chart {
     margin-left: 0;
 

--- a/packages/cluster-ui/src/statementsTable/statementsTable.tsx
+++ b/packages/cluster-ui/src/statementsTable/statementsTable.tsx
@@ -31,47 +31,20 @@ const longToInt = (d: number | Long) => Number(FixLong(d));
 function makeCommonColumns(
   statements: AggregateStatistics[],
 ): ColumnDescriptor<AggregateStatistics>[] {
-  const countBar = countBarChart(statements, {
+  const barChartOptions = {
     classes: {
-      root: cx("statements-table__col-count--bar-chart"),
-      label: cx("statements-table__col-count--bar-chart__label"),
+      root: cx("statements-table__col--bar-chart"),
+      label: cx("statements-table__col--bar-chart__label"),
     },
-  });
-  const rowsReadBar = rowsReadBarChart(statements, {
-    classes: {
-      root: cx("statements-table__col-rows-read--bar-chart"),
-      label: cx("statements-table__col-rows-read--bar-chart__label"),
-    },
-  });
-  const bytesReadBar = bytesReadBarChart(statements, {
-    classes: {
-      root: cx("statements-table__col-bytes-read--bar-chart"),
-      label: cx("statements-table__col-bytes-read--bar-chart__label"),
-    },
-  });
-  const latencyBar = latencyBarChart(statements, {
-    classes: {
-      root: cx("statements-table__col-latency--bar-chart"),
-    },
-  });
-  const maxMemUsageBar = maxMemUsageBarChart(statements, {
-    classes: {
-      root: cx("statements-table__col-max-mem-usage--bar-chart"),
-      label: cx("statements-table__col-max-mem-usage--bar-chart__label"),
-    },
-  });
-  const networkBytesBar = networkBytesBarChart(statements, {
-    classes: {
-      root: cx("statements-table__col-network-bytes--bar-chart"),
-      label: cx("statements-table__col-network-bytes--bar-chart__label"),
-    },
-  });
-  const retryBar = retryBarChart(statements, {
-    classes: {
-      root: cx("statements-table__col-retries--bar-chart"),
-      label: cx("statements-table__col-retries--bar-chart__label"),
-    },
-  });
+  };
+
+  const countBar = countBarChart(statements, barChartOptions);
+  const rowsReadBar = rowsReadBarChart(statements, barChartOptions);
+  const bytesReadBar = bytesReadBarChart(statements, barChartOptions);
+  const latencyBar = latencyBarChart(statements, barChartOptions);
+  const maxMemUsageBar = maxMemUsageBarChart(statements, barChartOptions);
+  const networkBytesBar = networkBytesBarChart(statements, barChartOptions);
+  const retryBar = retryBarChart(statements, barChartOptions);
 
   return [
     {

--- a/packages/cluster-ui/src/statementsTable/statementsTable.tsx
+++ b/packages/cluster-ui/src/statementsTable/statementsTable.tsx
@@ -5,9 +5,12 @@ import Long from "long";
 import { FixLong, StatementSummary, StatementStatistics } from "src/util";
 import {
   countBarChart,
+  rowsReadBarChart,
+  bytesReadBarChart,
   latencyBarChart,
+  maxMemUsageBarChart,
+  networkBytesBarChart,
   retryBarChart,
-  rowsBarChart,
   ActivateDiagnosticsModalRef,
   ColumnDescriptor,
   SortedTable,
@@ -34,16 +37,16 @@ function makeCommonColumns(
       label: cx("statements-table__col-count--bar-chart__label"),
     },
   });
-  const retryBar = retryBarChart(statements, {
+  const rowsReadBar = rowsReadBarChart(statements, {
     classes: {
-      root: cx("statements-table__col-retries--bar-chart"),
-      label: cx("statements-table__col-retries--bar-chart__label"),
+      root: cx("statements-table__col-rows-read--bar-chart"),
+      label: cx("statements-table__col-rows-read--bar-chart__label"),
     },
   });
-  const rowsBar = rowsBarChart(statements, {
+  const bytesReadBar = bytesReadBarChart(statements, {
     classes: {
-      root: cx("statements-table__col-rows--bar-chart"),
-      label: cx("statements-table__col-rows--bar-chart__label"),
+      root: cx("statements-table__col-bytes-read--bar-chart"),
+      label: cx("statements-table__col-bytes-read--bar-chart__label"),
     },
   });
   const latencyBar = latencyBarChart(statements, {
@@ -51,16 +54,26 @@ function makeCommonColumns(
       root: cx("statements-table__col-latency--bar-chart"),
     },
   });
+  const maxMemUsageBar = maxMemUsageBarChart(statements, {
+    classes: {
+      root: cx("statements-table__col-max-mem-usage--bar-chart"),
+      label: cx("statements-table__col-max-mem-usage--bar-chart__label"),
+    },
+  });
+  const networkBytesBar = networkBytesBarChart(statements, {
+    classes: {
+      root: cx("statements-table__col-network-bytes--bar-chart"),
+      label: cx("statements-table__col-network-bytes--bar-chart__label"),
+    },
+  });
+  const retryBar = retryBarChart(statements, {
+    classes: {
+      root: cx("statements-table__col-retries--bar-chart"),
+      label: cx("statements-table__col-retries--bar-chart__label"),
+    },
+  });
 
   return [
-    {
-      name: "retries",
-      title: StatementTableTitle.retries,
-      className: cx("statements-table__col-retries"),
-      cell: retryBar,
-      sort: stmt =>
-        longToInt(stmt.stats.count) - longToInt(stmt.stats.first_attempt_count),
-    },
     {
       name: "executionCount",
       title: StatementTableTitle.executionCount,
@@ -69,11 +82,18 @@ function makeCommonColumns(
       sort: stmt => FixLong(Number(stmt.stats.count)),
     },
     {
-      name: "rowsAffected",
-      title: StatementTableTitle.rowsAffected,
-      className: cx("statements-table__col-rows"),
-      cell: rowsBar,
-      sort: stmt => stmt.stats.num_rows.mean,
+      name: "rowsRead",
+      title: StatementTableTitle.rowsRead,
+      className: cx("statements-table__col-rows-read"),
+      cell: rowsReadBar,
+      sort: stmt => FixLong(Number(stmt.stats.rows_read.mean)),
+    },
+    {
+      name: "bytesRead",
+      title: StatementTableTitle.bytesRead,
+      className: cx("statements-table__col-bytes-read"),
+      cell: bytesReadBar,
+      sort: stmt => FixLong(Number(stmt.stats.bytes_read.mean)),
     },
     {
       name: "latency",
@@ -81,6 +101,28 @@ function makeCommonColumns(
       className: cx("statements-table__col-latency"),
       cell: latencyBar,
       sort: stmt => stmt.stats.service_lat.mean,
+    },
+    {
+      name: "maxMemoryUsage",
+      title: StatementTableTitle.maxMemUsage,
+      className: cx("statements-table__col-max-mem-usage"),
+      cell: maxMemUsageBar,
+      sort: stmt => FixLong(Number(stmt.stats.max_mem_usage.mean)),
+    },
+    {
+      name: "networkBytes",
+      title: StatementTableTitle.networkBytes,
+      className: cx("statements-table__col-network-bytes"),
+      cell: networkBytesBar,
+      sort: stmt => FixLong(Number(stmt.stats.bytes_sent_over_network.mean)),
+    },
+    {
+      name: "retries",
+      title: StatementTableTitle.retries,
+      className: cx("statements-table__col-retries"),
+      cell: retryBar,
+      sort: stmt =>
+        longToInt(stmt.stats.count) - longToInt(stmt.stats.first_attempt_count),
     },
   ];
 }

--- a/packages/cluster-ui/src/statementsTable/statementsTableContent.tsx
+++ b/packages/cluster-ui/src/statementsTable/statementsTableContent.tsx
@@ -82,47 +82,6 @@ export const StatementTableTitle = {
       TXN Type
     </Tooltip>
   ),
-  diagnostics: (
-    <Tooltip
-      placement="bottom"
-      title={
-        <div className={cx("tooltip__table--title")}>
-          <p>
-            {"Option to activate "}
-            <Anchor href={statementDiagnostics} target="_blank">
-              diagnostics
-            </Anchor>
-            {
-              " for each statement. If activated, this displays the status of diagnostics collection ("
-            }
-            <code>WAITING</code>, <code>READY</code>, OR <code>ERROR</code>).
-          </p>
-        </div>
-      }
-    >
-      Diagnostics
-    </Tooltip>
-  ),
-  retries: (
-    <Tooltip
-      placement="bottom"
-      title={
-        <div className={cx("tooltip__table--title")}>
-          <p>
-            {"Cumulative number of "}
-            <Anchor href={statementsRetries} target="_blank">
-              retries
-            </Anchor>
-            {
-              " of statements with this fingerprint within the last hour or specified time interval."
-            }
-          </p>
-        </div>
-      }
-    >
-      Retries
-    </Tooltip>
-  ),
   executionCount: (
     <Tooltip
       placement="bottom"
@@ -174,6 +133,54 @@ export const StatementTableTitle = {
       Rows Affected
     </Tooltip>
   ),
+  rowsRead: (
+    <Tooltip
+      placement="bottom"
+      title={
+        <div className={cx("tooltip__table--title")}>
+          <p>
+            {
+              "Average number of rows read while executing statements with this fingerprint within the last hour or specified "
+            }
+            <Anchor href={statementsTimeInterval} target="_blank">
+              time interval
+            </Anchor>
+            .
+          </p>
+          <p>
+            The gray bar indicates the mean number of rows returned. The blue
+            bar indicates one standard deviation from the mean.
+          </p>
+        </div>
+      }
+    >
+      Rows Read
+    </Tooltip>
+  ),
+  bytesRead: (
+    <Tooltip
+      placement="bottom"
+      title={
+        <div className={cx("tooltip__table--title")}>
+          <p>
+            {
+              "Average number of bytes read while executing statements with this fingerprint within the last hour or specified "
+            }
+            <Anchor href={statementsTimeInterval} target="_blank">
+              time interval
+            </Anchor>
+            .
+          </p>
+          <p>
+            The gray bar indicates the mean number of rows returned. The blue
+            bar indicates one standard deviation from the mean.
+          </p>
+        </div>
+      }
+    >
+      Bytes Read
+    </Tooltip>
+  ),
   latency: (
     <Tooltip
       placement="bottom"
@@ -191,6 +198,95 @@ export const StatementTableTitle = {
       }
     >
       Latency
+    </Tooltip>
+  ),
+  maxMemUsage: (
+    <Tooltip
+      placement="bottom"
+      title={
+        <div className={cx("tooltip__table--title")}>
+          <p>
+            {
+              "Average of the maximum memory used while executing statements with this fingerprint within the last hour or specified "
+            }
+            <Anchor href={statementsTimeInterval} target="_blank">
+              time interval
+            </Anchor>
+            .
+          </p>
+          <p>
+            The gray bar indicates the mean number of rows returned. The blue
+            bar indicates one standard deviation from the mean.
+          </p>
+        </div>
+      }
+    >
+      Max Memory
+    </Tooltip>
+  ),
+  networkBytes: (
+    <Tooltip
+      placement="bottom"
+      title={
+        <div className={cx("tooltip__table--title")}>
+          <p>
+            {
+              "Average number of bytes sent over the network while executing statements with this fingerprint within the last hour or specified "
+            }
+            <Anchor href={statementsTimeInterval} target="_blank">
+              time interval
+            </Anchor>
+            .
+          </p>
+          <p>
+            The gray bar indicates the mean number of rows returned. The blue
+            bar indicates one standard deviation from the mean.
+          </p>
+        </div>
+      }
+    >
+      Network
+    </Tooltip>
+  ),
+  retries: (
+    <Tooltip
+      placement="bottom"
+      title={
+        <div className={cx("tooltip__table--title")}>
+          <p>
+            {"Cumulative number of "}
+            <Anchor href={statementsRetries} target="_blank">
+              retries
+            </Anchor>
+            {
+              " of statements with this fingerprint within the last hour or specified time interval."
+            }
+          </p>
+        </div>
+      }
+    >
+      Retries
+    </Tooltip>
+  ),
+  diagnostics: (
+    <Tooltip
+      placement="bottom"
+      title={
+        <div className={cx("tooltip__table--title")}>
+          <p>
+            {"Option to activate "}
+            <Anchor href={statementDiagnostics} target="_blank">
+              diagnostics
+            </Anchor>
+            {
+              " for each statement. If activated, this displays the status of diagnostics collection ("
+            }
+            <code>WAITING</code>, <code>READY</code>, OR <code>ERROR</code>).
+          </p>
+        </div>
+      }
+    >
+      Diagnostics
     </Tooltip>
   ),
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1283,10 +1283,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@cockroachlabs/crdb-protobuf-client@^0.0.4":
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/@cockroachlabs/crdb-protobuf-client/-/crdb-protobuf-client-0.0.4.tgz#9b53ef7cbb187cd7d73b4269c95b0f573caafd45"
-  integrity sha512-n/SEmLzU7i9h5m8cAw9NPRAcQSgzHNdm5+F0dN3myfQSCuEMTgTlbWsfm6EnjTRL1FnZlieqY2gZzgyx4Ke0Ug==
+"@cockroachlabs/crdb-protobuf-client@0.0.5-beta.0":
+  version "0.0.5-beta.0"
+  resolved "https://registry.yarnpkg.com/@cockroachlabs/crdb-protobuf-client/-/crdb-protobuf-client-0.0.5-beta.0.tgz#5dc2b2b698067b3ea6013b4f36719056431b9dc6"
+  integrity sha512-+qQRXMBaaljhxghizCnwhDKw/bspfNMvnSPWBs35ixHfZLhwM3OQaHOqUtTRcgTZGC2qbuU4MMOoZ5j2wds4tw==
 
 "@cockroachlabs/icons@0.3.0", "@cockroachlabs/icons@^0.3.0":
   version "0.3.0"


### PR DESCRIPTION
This commit adds columns for execution stats that we want to display for 21.1.
Namely, this adds rows/bytes read, max memory, and network bytes sent. The
rows affected column has been removed.
The commit also reorders all column-related code to follow the graphical order.

Here is what that looks like with some example queries run against tpch:
![image](https://user-images.githubusercontent.com/10560359/105510312-c864ce00-5cce-11eb-8945-9a86ec243b17.png)

Closes https://github.com/cockroachdb/cockroach/issues/59294

Please let me know which tests to update and how. I have run into some issues with "accessing property mean of undefined" which is most likely due to unset proto fields. Is that something I need to handle in the protojs package in cockroach? If not, I'd appreciate if someone could point me to how to write tests for this and other cases.

I'm explicitly not adding code to handle cases when the stats haven't been collected. I leave this for the future if we decide to keep the sampling cluster setting. I focused on just getting the stats out there using preexisting components.

#### Checklist
- [x] Decide whether to remove the TXN Type column. The design doesn't have it, but want to double check cc @awoods187 @Annebirzin 
- [x] I have written or updated test for the changes I made
- [x] I have updated the README of the package I'm working in to reflect my changes
- [x] I have added or updated Storybook if appropriate for my changes

cc @awoods187 @cockroachdb/sql-execution 