### PR TITLE
# cluster-ui // Truncating long queries with CSS

### DIFF
--- a/packages/cluster-ui/src/core/index.module.scss
+++ b/packages/cluster-ui/src/core/index.module.scss
@@ -1,5 +1,5 @@
-@import './typography.module';
-@import './colors.module';
+@import "./typography.module";
+@import "./colors.module";
 @import "./base.module";
 @import "./palette.module";
 

--- a/packages/cluster-ui/src/core/typography.module.scss
+++ b/packages/cluster-ui/src/core/typography.module.scss
@@ -128,3 +128,26 @@ $spacing-xx-large: 48px;
   line-height: $line-height--medium;
   font-weight: $font-weight--bold;
 }
+
+//
+//    Text Truncation
+//
+
+// text-overflow - limits a line of text to a single line. If text overflows
+// the container will be truncated with an ellipsis
+@mixin text-overflow {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+// line-clamp - limits text in a container to a number of lines. If text
+// overflows container past number of lines, text will be truncated with an
+// ellipsis. This mixin takes a single parameter that is the number of line
+// to limit text to (default is 2)
+@mixin line-clamp($lines: 2) {
+  display: -webkit-box;
+  -webkit-line-clamp: $lines;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}

--- a/packages/cluster-ui/src/dropdown/dropdown.tsx
+++ b/packages/cluster-ui/src/dropdown/dropdown.tsx
@@ -14,6 +14,13 @@ export interface DropdownOption<T = string> {
   disabled?: boolean;
 }
 
+export interface DropdownItemProps<T> {
+  children: React.ReactNode;
+  value: T;
+  onClick: (value: T) => void;
+  disabled?: boolean;
+  className?: string;
+}
 export interface DropdownProps<T> {
   items: Array<DropdownOption<T>>;
   onChange: (item: DropdownOption<T>["value"]) => void;
@@ -22,6 +29,7 @@ export interface DropdownProps<T> {
   customToggleButtonOptions?: Partial<ButtonProps>;
   menuPosition?: "left" | "right";
   className?: string;
+  itemsClassname?: string;
 }
 
 interface DropdownState {
@@ -53,13 +61,17 @@ const DropdownButton: React.FC<DropdownButtonProps> = ({
 };
 
 function DropdownItem<T = string>(props: DropdownItemProps<T>) {
-  const { children, value, onClick, disabled } = props;
+  const { children, value, onClick, disabled, className } = props;
   return (
     <div
       onClick={() => onClick(value)}
-      className={cx("crl-dropdown__item", {
-        "crl-dropdown__item--disabled": disabled,
-      })}
+      className={cx(
+        "crl-dropdown__item",
+        {
+          "crl-dropdown__item--disabled": disabled,
+        },
+        className,
+      )}
     >
       {children}
     </div>
@@ -111,7 +123,12 @@ export class Dropdown<T = string> extends React.Component<
   };
 
   render() {
-    const { items, menuPosition = "left", className } = this.props;
+    const {
+      items,
+      menuPosition = "left",
+      className,
+      itemsClassname,
+    } = this.props;
     const { isOpen } = this.state;
 
     const menuStyles = cx(
@@ -128,6 +145,7 @@ export class Dropdown<T = string> extends React.Component<
         onClick={this.handleItemSelection}
         key={idx}
         disabled={menuItem.disabled}
+        className={itemsClassname}
       >
         {menuItem.name}
       </DropdownItem>
@@ -151,11 +169,4 @@ export class Dropdown<T = string> extends React.Component<
       </div>
     );
   }
-}
-
-export interface DropdownItemProps<T> {
-  children: React.ReactNode;
-  value: T;
-  onClick: (value: T) => void;
-  disabled?: boolean;
 }

--- a/packages/cluster-ui/src/sessions/sessionsTable.module.scss
+++ b/packages/cluster-ui/src/sessions/sessionsTable.module.scss
@@ -22,6 +22,10 @@
   width: 400px;
   text-decoration: none;
   cursor: pointer;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
   &:hover {
     color: $colors--link;
     text-decoration: underline;

--- a/packages/cluster-ui/src/sessions/sessionsTable.module.scss
+++ b/packages/cluster-ui/src/sessions/sessionsTable.module.scss
@@ -22,10 +22,7 @@
   width: 400px;
   text-decoration: none;
   cursor: pointer;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
+  @include line-clamp(2);
   &:hover {
     color: $colors--link;
     text-decoration: underline;

--- a/packages/cluster-ui/src/sortedtable/table.module.scss
+++ b/packages/cluster-ui/src/sortedtable/table.module.scss
@@ -1,4 +1,4 @@
-@import '../core/index.module.scss';
+@import "../core/index.module.scss";
 
 $table-cell-border: 1px solid $colors--neutral-2;
 $stats-table-td--fg: $colors--neutral-6;
@@ -19,7 +19,7 @@ $stats-table-tr--bg: $colors--neutral-0;
     border-right: 1px solid $colors--neutral-2;
     width: 250px;
   }
-  
+
   &__row {
     &--body {
       letter-spacing: 0.33px;

--- a/packages/cluster-ui/src/statementsPage/statementsPage.module.scss
+++ b/packages/cluster-ui/src/statementsPage/statementsPage.module.scss
@@ -7,7 +7,8 @@
   margin-bottom: 7px;
 }
 
-.cl-count-title, .last-cleared-title {
+.cl-count-title,
+.last-cleared-title {
   font-family: $font-family--base;
   font-size: 14px;
   padding: 0px;
@@ -50,4 +51,23 @@ h2.base-heading {
 .root {
   flex-grow: 0;
   width: 100%;
+}
+
+.app-filter-dropdown {
+  /* 
+    we are truncating the text in the filter, 
+    but need to constrain to a width
+  */
+  max-width: 75ch;
+}
+
+.app-filter-dropdown-item {
+  /*
+    Truncating and constrainging the width of the 
+    items in the app filter dropdown
+  */
+  max-width: 80ch;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 }

--- a/packages/cluster-ui/src/statementsPage/statementsPage.module.scss
+++ b/packages/cluster-ui/src/statementsPage/statementsPage.module.scss
@@ -67,7 +67,5 @@ h2.base-heading {
     items in the app filter dropdown
   */
   max-width: 80ch;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow: hidden;
+  @include text-overflow;
 }

--- a/packages/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/packages/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -5,6 +5,8 @@ import moment from "moment";
 import Helmet from "react-helmet";
 import classNames from "classnames/bind";
 
+import { Text } from "@cockroachlabs/ui-components";
+
 import {
   Dropdown,
   Loading,
@@ -14,8 +16,6 @@ import {
   Search,
   Pagination,
   ResultsPerPageLabel,
-  Text,
-  TextTypes,
 } from "src/index";
 import { DATE_FORMAT, appAttr, getMatchParamByName } from "src/util";
 import {
@@ -253,8 +253,16 @@ export class StatementsPage extends React.Component<
             />
           </PageConfigItem>
           <PageConfigItem>
-            <Dropdown items={appOptions} onChange={this.selectApp}>
-              <Text textType={TextTypes.BodyStrong}>
+            <Dropdown
+              items={appOptions}
+              onChange={this.selectApp}
+              itemsClassname={cx("app-filter-dropdown-item")}
+            >
+              <Text
+                type="body-strong"
+                noWrap={true}
+                className={cx("app-filter-dropdown")}
+              >
                 {`App: ${decodeURIComponent(currentOption.name)}`}
               </Text>
             </Dropdown>

--- a/packages/cluster-ui/src/statementsTable/statementsTable.module.scss
+++ b/packages/cluster-ui/src/statementsTable/statementsTable.module.scss
@@ -1,4 +1,4 @@
-@import 'src/core/index.module';
+@import "src/core/index.module";
 
 .statements-table__col-time {
   white-space: nowrap;
@@ -18,13 +18,16 @@
   }
 }
 
-.statements-table__col-rows, .statements-table__col-latency {
+.statements-table__col-rows,
+.statements-table__col-latency {
   &--bar-chart {
     min-width: 150px;
   }
 }
 
-.statements-table__col-count, .statements-table__col-retries, .statements-table__col-rows {
+.statements-table__col-count,
+.statements-table__col-retries,
+.statements-table__col-rows {
   &--bar-chart {
     margin-left: 0;
 
@@ -42,5 +45,9 @@
   width: 400px;
   div {
     font-size: $font-size--small;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
   }
 }

--- a/packages/cluster-ui/src/statementsTable/statementsTable.module.scss
+++ b/packages/cluster-ui/src/statementsTable/statementsTable.module.scss
@@ -45,9 +45,6 @@
   width: 400px;
   div {
     font-size: $font-size--small;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
+    @include line-clamp(2);
   }
 }

--- a/packages/cluster-ui/src/statementsTable/statementsTableContent.module.scss
+++ b/packages/cluster-ui/src/statementsTable/statementsTableContent.module.scss
@@ -1,4 +1,4 @@
-@import 'src/core/index.module';
+@import "src/core/index.module";
 
 .cl-table-link__description {
   font-size: $font-size--small;
@@ -6,6 +6,10 @@
   color: $colors--neutral-1;
   white-space: pre-wrap;
   margin-bottom: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 15;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .cl-table-link__statement-tooltip--fixed-width {
@@ -54,7 +58,7 @@
   align-items: center;
 
   .activate-diagnostic-link {
-    width: auto!important;
+    width: auto !important;
   }
 
   .activate-diagnostic-dropdown {

--- a/packages/cluster-ui/src/statementsTable/statementsTableContent.module.scss
+++ b/packages/cluster-ui/src/statementsTable/statementsTableContent.module.scss
@@ -6,10 +6,7 @@
   color: $colors--neutral-1;
   white-space: pre-wrap;
   margin-bottom: 0;
-  display: -webkit-box;
-  -webkit-line-clamp: 15;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
+  @include line-clamp(15);
 }
 
 .cl-table-link__statement-tooltip--fixed-width {

--- a/packages/cluster-ui/src/transactionsTable/transactionsCells/transactionsCells.module.scss
+++ b/packages/cluster-ui/src/transactionsTable/transactionsCells/transactionsCells.module.scss
@@ -6,10 +6,7 @@
   font-family: $font-family--monospace;
   font-size: $font-size--small;
   color: $colors--neutral-6;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
+  @include line-clamp(2);
 }
 
 .hover-area:hover {

--- a/packages/cluster-ui/src/transactionsTable/transactionsCells/transactionsCells.module.scss
+++ b/packages/cluster-ui/src/transactionsTable/transactionsCells/transactionsCells.module.scss
@@ -1,4 +1,4 @@
-@import '../../core/index.module.scss';
+@import "../../core/index.module.scss";
 
 .hover-area {
   white-space: pre-line;
@@ -6,6 +6,10 @@
   font-family: $font-family--monospace;
   font-size: $font-size--small;
   color: $colors--neutral-6;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .hover-area:hover {


### PR DESCRIPTION
# Truncating long queries

In this PR I'm truncating long queries in several places where they are displayed in tabular form through DB Console. There are a couple of CSS techniques that come into play (see commit messages and / or code for details) and there was not uniform place to make a unifying change. 

**Statements**
![Screen Shot 2021-01-28 at 14 08 34](https://user-images.githubusercontent.com/397448/106188008-6693e080-6174-11eb-9564-d8962d8a4843.png)

**Statements Application Filter**
![Screen Shot 2021-01-28 at 14 07 30](https://user-images.githubusercontent.com/397448/106188038-71e70c00-6174-11eb-87e4-9fd5e99752ca.png)

**Transactions**
![Screen Shot 2021-01-28 at 14 09 16](https://user-images.githubusercontent.com/397448/106187973-5a0f8800-6174-11eb-92e9-b4b04e03f43e.png)

**Sessions**
![Screen Shot 2021-01-28 at 14 10 09](https://user-images.githubusercontent.com/397448/106187940-4f54f300-6174-11eb-8c80-82ff17cda996.png)
