### PR TITLE
cluster-ui: provide ordered list of diagnostics to statements page

### DIFF
--- a/packages/cluster-ui/src/statementsPage/statementsPage.selectors.ts
+++ b/packages/cluster-ui/src/statementsPage/statementsPage.selectors.ts
@@ -15,7 +15,8 @@ import { RouteComponentProps } from "react-router-dom";
 
 import { AppState } from "src/store";
 import { StatementsState } from "../store/statements";
-import { selectLastDiagnosticsReportPerStatement } from "../store/statementDiagnostics";
+import { selectDiagnosticsReportsPerStatement } from "../store/statementDiagnostics";
+import { AggregateStatistics } from "../statementsTable";
 
 type ICollectedStatementStatistics = cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
 
@@ -100,12 +101,12 @@ export const selectLastReset = createSelector(statementsSelector, state => {
 export const selectStatements = createSelector(
   statementsSelector,
   (_: AppState, props: RouteComponentProps) => props,
-  selectLastDiagnosticsReportPerStatement,
+  selectDiagnosticsReportsPerStatement,
   (
     state: StatementsState,
     props: RouteComponentProps<any>,
-    lastDiagnosticsReportPerStatement,
-  ) => {
+    diagnosticsReportsPerStatement,
+  ): AggregateStatistics[] => {
     if (!state.data) {
       return null;
     }
@@ -154,7 +155,7 @@ export const selectStatements = createSelector(
         label: stmt.statement,
         implicitTxn: stmt.implicitTxn,
         stats: combineStatementStats(stmt.stats),
-        diagnosticsReport: lastDiagnosticsReportPerStatement[stmt.statement],
+        diagnosticsReports: diagnosticsReportsPerStatement[stmt.statement],
       };
     });
   },

--- a/packages/cluster-ui/src/store/statementDiagnostics/statementDiagnostics.sagas.spec.ts
+++ b/packages/cluster-ui/src/store/statementDiagnostics/statementDiagnostics.sagas.spec.ts
@@ -57,6 +57,7 @@ describe("statementsDiagnostics sagas", () => {
     });
 
     it("failed request", () => {
+      const error = new Error("Failed request");
       expectSaga(
         createDiagnosticsReportSaga,
         actions.createReport(statementFingerprint),
@@ -64,11 +65,11 @@ describe("statementsDiagnostics sagas", () => {
         .provide([
           [
             call(createStatementDiagnosticsReport, statementFingerprint),
-            throwError(new Error("Failed request")),
+            throwError(error),
           ],
           [call(getStatementDiagnosticsReports), reportsResponse],
         ])
-        .put(actions.createReportFailed())
+        .put(actions.createReportFailed(error))
         .run();
     });
   });

--- a/packages/cluster-ui/src/store/statementDiagnostics/statementDiagnostics.selectors.spec.ts
+++ b/packages/cluster-ui/src/store/statementDiagnostics/statementDiagnostics.selectors.spec.ts
@@ -1,0 +1,43 @@
+import { assert } from "chai";
+import { selectDiagnosticsReportsPerStatement } from "./statementDiagnostics.selectors";
+import Long from "long";
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import IStatementDiagnosticsReport = cockroach.server.serverpb.IStatementDiagnosticsReport;
+
+const reports: IStatementDiagnosticsReport[] = [
+  {
+    id: Long.fromNumber(1),
+    completed: false,
+    statement_fingerprint: "SHOW database",
+    statement_diagnostics_id: Long.fromNumber(594413981435920385),
+    requested_at: { seconds: Long.fromNumber(100), nanos: 737251000 },
+  },
+  {
+    id: Long.fromNumber(2),
+    completed: true,
+    statement_fingerprint: "SHOW database",
+    statement_diagnostics_id: Long.fromNumber(594413281435920385),
+    requested_at: { seconds: Long.fromNumber(200), nanos: 737251000 },
+  },
+  {
+    id: Long.fromNumber(3),
+    completed: true,
+    statement_fingerprint: "SHOW database",
+    statement_diagnostics_id: Long.fromNumber(594413281435920385),
+    requested_at: { seconds: Long.fromNumber(300), nanos: 737251000 },
+  },
+];
+
+describe("statementDiagnostics selectors", () => {
+  describe("selectDiagnosticsReportsPerStatement", () => {
+    it("returns diagnostics reports sorted in descending order", () => {
+      const diagnosticsPerStatement = selectDiagnosticsReportsPerStatement.resultFunc(
+        reports,
+      );
+      assert.deepEqual(
+        diagnosticsPerStatement["SHOW database"][0].id,
+        Long.fromNumber(3),
+      );
+    });
+  });
+});

--- a/packages/cluster-ui/src/store/statementDiagnostics/statementDiagnostics.selectors.ts
+++ b/packages/cluster-ui/src/store/statementDiagnostics/statementDiagnostics.selectors.ts
@@ -1,5 +1,5 @@
 import { createSelector } from "reselect";
-import { chain, last, sortBy } from "lodash";
+import { chain, orderBy } from "lodash";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { AppState } from "../reducers";
 
@@ -16,19 +16,23 @@ export const selectStatementDiagnosticsReports = createSelector(
 );
 
 type StatementDiagnosticsDictionary = {
-  [statementFingerprint: string]: IStatementDiagnosticsReport;
+  [statementFingerprint: string]: IStatementDiagnosticsReport[];
 };
 
-export const selectLastDiagnosticsReportPerStatement = createSelector(
+export const selectDiagnosticsReportsPerStatement = createSelector(
   selectStatementDiagnosticsReports,
   (
     diagnosticsReports: IStatementDiagnosticsReport[],
   ): StatementDiagnosticsDictionary =>
     chain(diagnosticsReports)
       .groupBy(diagnosticsReport => diagnosticsReport.statement_fingerprint)
-      // Perform ASC sorting and take the last item
+      // Perform DESC sorting to get latest report on top
       .mapValues(diagnostics =>
-        last(sortBy(diagnostics, d => d.requested_at.seconds.toNumber())),
+        orderBy(
+          diagnostics,
+          [d => d.requested_at.seconds.toNumber()],
+          ["desc"],
+        ),
       )
       .value(),
 );


### PR DESCRIPTION
Due to missed type definition for returned type for
`selectDiagnosticsReportsPerStatement` selector, it caused
a regression issue when instead of returning the list of all
diagnostics reports per statement, this selector returned only last report
(according to previous and outdated requirements).

Now, return type is explicitly defined for `selectDiagnosticsReportsPerStatement`
 selector and it returns aggregated statement stats with all diagnostics reports
 per statement.

We need all reports on Statements page to show dropdown list with current state
for recently requested diagnostics and links for previously generated reports.

Before:
<img width="1203" alt="Screen Shot 2021-01-26 at 4 30 36 PM" src="https://user-images.githubusercontent.com/3106437/105858657-3de4dd00-5ff4-11eb-8c51-ec52c3272f00.png">

After:
<img width="1199" alt="Screen Shot 2021-01-26 at 4 28 44 PM" src="https://user-images.githubusercontent.com/3106437/105858696-4806db80-5ff4-11eb-93e5-075f1a2eae0a.png">
