### PR TITLE
cluster-ui: update transactions page with execution stats

### DIFF
--- a/packages/cluster-ui/package.json
+++ b/packages/cluster-ui/package.json
@@ -26,7 +26,7 @@
   "keywords": [],
   "license": "MIT",
   "dependencies": {
-    "@cockroachlabs/crdb-protobuf-client": "^0.0.5",
+    "@cockroachlabs/crdb-protobuf-client": "^0.0.6",
     "@cockroachlabs/icons": "0.3.0",
     "@cockroachlabs/ui-components": "0.2.14-alpha.0",
     "@popperjs/core": "^2.4.0",

--- a/packages/cluster-ui/src/barCharts/barCharts.tsx
+++ b/packages/cluster-ui/src/barCharts/barCharts.tsx
@@ -54,10 +54,10 @@ const retryBars = [
 ];
 
 const rowsReadStdDev = bar(cx("rows-read-dev"), (d: StatementStatistics) =>
-  stdDevLong(d.stats.rows_read, d.stats.exec_stat_collection_count),
+  stdDevLong(d.stats.rows_read, d.stats.count),
 );
 const bytesReadStdDev = bar(cx("rows-read-dev"), (d: StatementStatistics) =>
-  stdDevLong(d.stats.bytes_read, d.stats.exec_stat_collection_count),
+  stdDevLong(d.stats.bytes_read, d.stats.count),
 );
 const latencyStdDev = bar(
   cx("bar-chart__overall-dev"),

--- a/packages/cluster-ui/src/statementsTable/statementsTableContent.tsx
+++ b/packages/cluster-ui/src/statementsTable/statementsTableContent.tsx
@@ -111,30 +111,6 @@ export const StatementTableTitle = {
       Execution Count
     </Tooltip>
   ),
-  rowsAffected: (
-    <Tooltip
-      placement="bottom"
-      title={
-        <div className={cx("tooltip__table--title")}>
-          <p>
-            {
-              "Average number of rows returned while executing statements with this fingerprint within the last hour or specified "
-            }
-            <Anchor href={statementsTimeInterval} target="_blank">
-              time interval
-            </Anchor>
-            .
-          </p>
-          <p>
-            The gray bar indicates the mean number of rows returned. The blue
-            bar indicates one standard deviation from the mean.
-          </p>
-        </div>
-      }
-    >
-      Rows Affected
-    </Tooltip>
-  ),
   rowsRead: (
     <Tooltip
       placement="bottom"

--- a/packages/cluster-ui/src/transactionsPage/utils.ts
+++ b/packages/cluster-ui/src/transactionsPage/utils.ts
@@ -9,6 +9,7 @@ import { aggregateNumericStats, FixLong } from "../util";
 type Statement = protos.cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
 type TransactionStats = protos.cockroach.sql.ITransactionStatistics;
 type Transaction = protos.cockroach.server.serverpb.StatementsResponse.IExtendedCollectedTransactionStatistics;
+type ExecStats = protos.cockroach.sql.IExecStats;
 
 export const getTrxAppFilterOptions = (
   transactions: Transaction[],
@@ -124,12 +125,52 @@ const withFingerprint = function(
   };
 };
 
+function addExecStats(a: ExecStats, b: ExecStats): Required<ExecStats> {
+  let execStatCountA = FixLong(a.count).toInt();
+  const execStatCountB = FixLong(b.count).toInt();
+  if (execStatCountA === 0 && execStatCountB === 0) {
+    // If both counts are zero, artificially set the one count to one to avoid
+    // division by zero when calculating the mean in addNumericStats.
+    execStatCountA = 1;
+  }
+  return {
+    count: a.count.add(b.count),
+    network_bytes:
+      a.network_bytes && b.network_bytes
+        ? aggregateNumericStats(
+            a.network_bytes,
+            b.network_bytes,
+            execStatCountA,
+            execStatCountB,
+          )
+        : null,
+    max_mem_usage:
+      a.max_mem_usage && b.max_mem_usage
+        ? aggregateNumericStats(
+            a.max_mem_usage,
+            b.max_mem_usage,
+            execStatCountA,
+            execStatCountB,
+          )
+        : null,
+    contention_time:
+      a.contention_time && b.contention_time
+        ? aggregateNumericStats(
+            a.contention_time,
+            b.contention_time,
+            execStatCountA,
+            execStatCountB,
+          )
+        : null,
+  };
+}
+
 // addTransactionStats adds together two stat objects into one using their counts to compute a new
 // average for the numeric statistics. It's modeled after the similar `addStatementStats` function
 function addTransactionStats(
   a: TransactionStats,
   b: TransactionStats,
-): TransactionStats {
+): Required<TransactionStats> {
   const countA = FixLong(a.count).toInt();
   const countB = FixLong(b.count).toInt();
   return {
@@ -151,6 +192,14 @@ function addTransactionStats(
       countA,
       countB,
     ),
+    rows_read: aggregateNumericStats(a.rows_read, b.rows_read, countA, countB),
+    bytes_read: aggregateNumericStats(
+      a.bytes_read,
+      b.bytes_read,
+      countA,
+      countB,
+    ),
+    exec_stats: addExecStats(a.exec_stats, b.exec_stats),
   };
 }
 

--- a/packages/cluster-ui/src/transactionsTable/transactionsTableClasses.ts
+++ b/packages/cluster-ui/src/transactionsTable/transactionsTableClasses.ts
@@ -17,17 +17,6 @@ export const tableClasses = {
       },
     },
   },
-  RowsAffectedClasses: {
-    column: statementsTableCx("statements-table__col-rows"),
-    barChart: {
-      classes: {
-        root: statementsTableCx("statements-table__col-rows--bar-chart"),
-        label: statementsTableCx(
-          "statements-table__col-rows--bar-chart__label",
-        ),
-      },
-    },
-  },
 };
 
 export const statisticsClasses = {

--- a/packages/cluster-ui/src/util/appStats.spec.ts
+++ b/packages/cluster-ui/src/util/appStats.spec.ts
@@ -12,6 +12,8 @@ import {
 } from "./appStats";
 import IExplainTreePlanNode = protos.cockroach.sql.IExplainTreePlanNode;
 import ISensitiveInfo = protos.cockroach.sql.ISensitiveInfo;
+import { random } from "d3";
+import { exec } from "child_process";
 
 // record is implemented here so we can write the below test as a direct
 // analog of the one in pkg/roachpb/app_stats_test.go.  It's here rather
@@ -157,11 +159,14 @@ function randomStat(scale = 1): NumericStat {
   };
 }
 
-function randomStats(sensitiveInfo?: ISensitiveInfo): StatementStatistics {
+function randomStats(
+  sensitiveInfo?: ISensitiveInfo,
+): Required<StatementStatistics> {
   const count = randomInt(1000);
   // tslint:disable:variable-name
   const first_attempt_count = randomInt(count);
   const max_retries = randomInt(count - first_attempt_count);
+  const exec_stat_collection_count = randomInt(count);
   // tslint:enable:variable-name
 
   return {
@@ -174,7 +179,15 @@ function randomStats(sensitiveInfo?: ISensitiveInfo): StatementStatistics {
     run_lat: randomStat(),
     service_lat: randomStat(),
     overhead_lat: randomStat(),
+    bytes_read: randomStat(),
+    rows_read: randomStat(),
     sensitive_info: sensitiveInfo || makeSensitiveInfo(null, null),
+    legacy_last_err: "",
+    legacy_last_err_redacted: "",
+    bytes_sent_over_network: randomStat(),
+    max_mem_usage: randomStat(),
+    exec_stat_collection_count: Long.fromNumber(exec_stat_collection_count),
+    contention_time: randomStat(),
   };
 }
 


### PR DESCRIPTION
This PR has https://github.com/cockroachdb/cockroach/pull/59761 as a dependency. I'll just wait for that to go in before updating with the new protobuf version number.

This PR, similarly to #178, changes the transactions page to what we've designed for 21.1 (@Annebirzin). This is the result:

![image](https://user-images.githubusercontent.com/10560359/106916110-1a621680-6707-11eb-8f1b-92f981ab6865.png)

#### Checklist
- [x] I have written or updated test for the changes I made
- [x] I have updated the README of the package I'm working in to reflect my changes
- [x] I have added or updated Storybook if appropriate for my changes

cc @awoods187 

Closes https://github.com/cockroachdb/cockroach/issues/59295