### PR TITLE
cluster-ui: fix link on statement diagnostics bundle

### DIFF
--- a/packages/cluster-ui/src/statementsTable/statementsTableContent.tsx
+++ b/packages/cluster-ui/src/statementsTable/statementsTableContent.tsx
@@ -26,6 +26,7 @@ import { shortStatement } from "./statementsTable";
 import styles from "./statementsTableContent.module.scss";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { Download } from "@cockroachlabs/icons";
+import { getBasePath } from "../api";
 
 export type NodeNames = { [nodeId: string]: string };
 const cx = classNames.bind(styles);
@@ -345,7 +346,9 @@ export const StatementTableCell = {
                 name: (
                   <a
                     className={cx("download-diagnostics-link")}
-                    href={`/_admin/v1/stmtbundle/${dr.statement_diagnostics_id}`}
+                    href={`${getBasePath()}/_admin/v1/stmtbundle/${
+                      dr.statement_diagnostics_id
+                    }`}
                   >
                     {`${TimestampToMoment(dr.requested_at).format(
                       "ll [at] LT [diagnostic]",


### PR DESCRIPTION
Before, cluster-ui base path was defined as '/' root path and
links relied on it. But now, base pack can be set to any other
path and all requests on server should append updated base path.
`getBasePath` function returns current base path or empty string
if it is not set.

This change updates the link to use `getBasePath` and build
valid URL which includes base path.
