### PR TITLE
cluster-ui: update transaction overview page with execution stats

### DIFF
--- a/packages/cluster-ui/src/sql/box.tsx
+++ b/packages/cluster-ui/src/sql/box.tsx
@@ -18,6 +18,7 @@ import * as protos from "@cockroachlabs/crdb-protobuf-client";
 export interface SqlBoxProps {
   value: string;
   zone?: protos.cockroach.server.serverpb.DatabaseDetailsResponse;
+  className?: string;
 }
 
 const cx = classNames.bind(styles);
@@ -26,7 +27,7 @@ export class SqlBox extends React.Component<SqlBoxProps> {
   preNode: React.RefObject<HTMLPreElement> = React.createRef();
   render() {
     return (
-      <div className={cx("box-highlight")}>
+      <div className={cx("box-highlight", this.props.className)}>
         <Highlight {...this.props} />
       </div>
     );

--- a/packages/cluster-ui/src/transactionDetails/transactionDetails.modules.scss
+++ b/packages/cluster-ui/src/transactionDetails/transactionDetails.modules.scss
@@ -1,0 +1,8 @@
+@import '../core/index.module.scss';
+
+.summary-columns {
+  margin-bottom: $spacing-large;
+}
+.summary-card {
+  margin-bottom: 0;
+}

--- a/packages/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/packages/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -26,6 +26,7 @@ import { Search } from "../search";
 import { Filter } from "./filter";
 
 type IStatementsResponse = protos.cockroach.server.serverpb.IStatementsResponse;
+type TransactionStats = protos.cockroach.sql.ITransactionStatistics;
 
 export interface Filters {
   app?: string;
@@ -48,6 +49,7 @@ interface TState {
   search?: string;
   filters?: Filters;
   statementIds: Long[] | null;
+  transactionStats: TransactionStats | null;
 }
 
 interface TransactionsPageProps {
@@ -78,6 +80,7 @@ export class TransactionsPage extends React.Component<
       timeUnit: this.trxSearchParams("timeUnit", defaultFilters.timeUnit),
     },
     statementIds: null,
+    transactionStats: null,
   };
 
   componentDidMount() {
@@ -173,8 +176,11 @@ export class TransactionsPage extends React.Component<
     });
   };
 
-  handleDetails = (statementIds: Long[] | null) => {
-    this.setState({ statementIds });
+  handleDetails = (
+    statementIds: Long[] | null,
+    transactionStats: TransactionStats,
+  ) => {
+    this.setState({ statementIds, transactionStats });
   };
 
   lastReset = () => {
@@ -286,6 +292,7 @@ export class TransactionsPage extends React.Component<
     return (
       <TransactionDetails
         statements={transactionDetails}
+        transactionStats={this.state.transactionStats}
         lastReset={this.lastReset()}
         handleDetails={this.handleDetails}
         error={this.props.error}

--- a/packages/cluster-ui/src/transactionsTable/transactionsCells/transactionsCells.tsx
+++ b/packages/cluster-ui/src/transactionsTable/transactionsCells/transactionsCells.tsx
@@ -1,3 +1,4 @@
+import * as protos from "@cockroachlabs/crdb-protobuf-client";
 import React from "react";
 import { getHighlightedText } from "src/highlightedText";
 import { Anchor } from "src/anchor";
@@ -21,16 +22,23 @@ const overlayClassName = statementsCx(
 const textWrapper = ownCellStyles("text-wrapper");
 const hoverAreaClassName = ownCellStyles("hover-area");
 
+type TransactionStats = protos.cockroach.sql.ITransactionStatistics;
+
 interface TextCellProps {
   transactionText: string;
   transactionIds: Long[];
-  handleDetails: (transactionIds: Long[]) => void;
+  transactionStats: TransactionStats;
+  handleDetails: (
+    transactionIds: Long[],
+    transactionStats: TransactionStats,
+  ) => void;
   search: string;
 }
 
 export const textCell = ({
   transactionText,
   transactionIds,
+  transactionStats,
   handleDetails,
   search,
 }: TextCellProps) => {
@@ -48,7 +56,7 @@ export const textCell = ({
       >
         <div className={textWrapper}>
           <div
-            onClick={() => handleDetails(transactionIds)}
+            onClick={() => handleDetails(transactionIds, transactionStats)}
             className={hoverAreaClassName}
           >
             {getHighlightedText(

--- a/packages/cluster-ui/src/transactionsTable/transactionsTable.tsx
+++ b/packages/cluster-ui/src/transactionsTable/transactionsTable.tsx
@@ -25,13 +25,17 @@ import classNames from "classnames/bind";
 import statementsPageStyles from "src/statementsTable/statementsTableContent.module.scss";
 
 type Transaction = protos.cockroach.server.serverpb.StatementsResponse.IExtendedCollectedTransactionStatistics;
+type TransactionStats = protos.cockroach.sql.ITransactionStatistics;
 type Statement = protos.cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
 
 interface TransactionsTable {
   transactions: Transaction[];
   sortSetting: SortSetting;
   onChangeSortSetting: (ss: SortSetting) => void;
-  handleDetails: (statementIds: Long[] | null) => void;
+  handleDetails: (
+    statementIds: Long[] | null,
+    transactionStats: TransactionStats,
+  ) => void;
   pagination: ISortedTablePagination;
   statements: Statement[];
   search?: string;
@@ -83,6 +87,7 @@ export const TransactionsTable: React.FC<TransactionsTable> = props => {
             getStatementsById(item.stats_data.statement_ids, statements),
           ),
           transactionIds: item.stats_data.statement_ids,
+          transactionStats: item.stats_data.stats,
           handleDetails,
           search,
         }),


### PR DESCRIPTION
This PR implements the design of the transaction overview page. I modified some things from the original design and got to:

![image](https://user-images.githubusercontent.com/10560359/107506167-018db100-6b9e-11eb-9c7b-f83d6064d50d.png)

@Annebirzin / @awoods187 I'd like an answer specifically to:
- [x] I changed the "total" labels in the design to "mean" which I think is what we want, right? Total would be count of times this fingerprint was executed * mean latency, while mean latency is just mean latency and it doesn't matter how many times you ran the statement (the other would grow each time you run a statement, which I don't think makes sense)
- [x] I removed some data that seemed to be repeated in the design. PTAL and let me know if that's ok.

I also left a TODO to add temporary disk max usage, which requires a change on the backend.

Some CSS issues I need help with from @dhartunian or someone on the CC observability team:
- [x] How to display the new summary card on the same horizontal line as the sql statements. I tried to use `Row/Col` from `antd` but no change.
- [x] The idea is to make Mean Transaction Time larger than other stats (e.g. mean rows/bytes read) and reduce the size of Transaction resource usage. Should I use a summary card label for the latter with no value? The thing is that it seems that `h3/h4` sizes are ignored if used as labels.

Closes https://github.com/cockroachdb/cockroach/issues/59297

#### Checklist
- [x] I have written or updated test for the changes I made
- [x] I have updated the README of the package I'm working in to reflect my changes
- [x] I have added or updated Storybook if appropriate for my changes

