### PR TITLE
cluster-ui: multiple component versions

### DIFF
--- a/packages/cluster-ui/src/barCharts/barCharts.tsx
+++ b/packages/cluster-ui/src/barCharts/barCharts.tsx
@@ -16,6 +16,10 @@ const countBars = [
   ),
 ];
 
+const rowsBars = [
+  bar("rows", (d: StatementStatistics) => d.stats.num_rows.mean),
+];
+
 const rowsReadBars = [
   bar("rows-read", (d: StatementStatistics) => d.stats.rows_read.mean),
 ];
@@ -63,6 +67,9 @@ const latencyStdDev = bar(
   cx("bar-chart__overall-dev"),
   (d: StatementStatistics) => stdDevLong(d.stats.service_lat, d.stats.count),
 );
+const rowsStdDev = bar(cx("rows-dev"), (d: StatementStatistics) =>
+  stdDevLong(d.stats.num_rows, d.stats.count),
+);
 const maxMemUsageStdDev = bar(
   cx("max-mem-usage-dev"),
   (d: StatementStatistics) =>
@@ -90,6 +97,13 @@ export const bytesReadBarChart = barChartFactory(
   bytesReadBars,
   Bytes,
   bytesReadStdDev,
+);
+export const rowsBarChart = barChartFactory(
+  "grey",
+  rowsBars,
+  approximify,
+  rowsStdDev,
+  formatTwoPlaces,
 );
 export const latencyBarChart = barChartFactory(
   "grey",

--- a/packages/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/packages/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -37,6 +37,7 @@ import {
 import {
   AggregateStatistics,
   makeNodesColumns,
+  makeNodesColumns_20_2,
   StatementsSortedTable,
 } from "src/statementsTable";
 import { DiagnosticsView } from "./diagnostics/diagnosticsView";
@@ -840,6 +841,598 @@ export class StatementDetails extends React.Component<
               className={cx("statements-table")}
               data={statsByNode}
               columns={makeNodesColumns(statsByNode, this.props.nodeNames)}
+              sortSetting={this.state.sortSetting}
+              onChangeSortSetting={this.changeSortSetting}
+              firstCellBordered
+            />
+          </SummaryCard>
+        </TabPane>
+      </Tabs>
+    );
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/class-name-casing
+export class StatementDetails_20_2 extends React.Component<
+  StatementDetailsProps,
+  StatementDetailsState
+> {
+  constructor(props: StatementDetailsProps) {
+    super(props);
+    const searchParams = new URLSearchParams(props.history.location.search);
+    this.state = {
+      sortSetting: {
+        sortKey: 5, // Latency
+        ascending: false,
+      },
+      currentTab: searchParams.get("tab") || "overview",
+    };
+  }
+
+  static defaultProps: Partial<StatementDetailsProps> = {
+    onDiagnosticBundleDownload: _.noop,
+  };
+
+  changeSortSetting = (ss: SortSetting) => {
+    this.setState({
+      sortSetting: ss,
+    });
+  };
+
+  componentDidMount() {
+    this.props.refreshStatements();
+    this.props.refreshStatementDiagnosticsRequests();
+    this.props.refreshNodes();
+    this.props.refreshNodesLiveness();
+  }
+
+  componentDidUpdate() {
+    this.props.refreshStatements();
+    this.props.refreshStatementDiagnosticsRequests();
+    this.props.refreshNodes();
+    this.props.refreshNodesLiveness();
+  }
+
+  onTabChange = (tabId: string) => {
+    const { history } = this.props;
+    const searchParams = new URLSearchParams(history.location.search);
+    searchParams.set("tab", tabId);
+    history.replace({
+      ...history.location,
+      search: searchParams.toString(),
+    });
+    this.setState({
+      currentTab: tabId,
+    });
+    this.props.onTabChanged && this.props.onTabChanged(tabId);
+  };
+
+  render() {
+    const app = getMatchParamByName(this.props.match, appAttr);
+    return (
+      <div>
+        <Helmet title={`Details | ${app ? `${app} App |` : ""} Statements`} />
+        <div className={cx("section", "page--header")}>
+          <Button
+            onClick={() => this.props.history.push("/statements")}
+            type="unstyled-link"
+            size="small"
+            icon={<ArrowLeft fontSize={"10px"} />}
+            iconPosition="left"
+          >
+            Statements
+          </Button>
+          <h1 className={cx("base-heading", "page--header__title")}>
+            Statement Details
+          </h1>
+        </div>
+        <section className={cx("section", "section--container")}>
+          <Loading
+            loading={_.isNil(this.props.statement)}
+            error={this.props.statementsError}
+            render={this.renderContent}
+          />
+        </section>
+      </div>
+    );
+  }
+
+  renderContent = () => {
+    const {
+      createStatementDiagnosticsReport,
+      diagnosticsReports,
+      dismissStatementDiagnosticsAlertMessage,
+      onDiagnosticBundleDownload,
+    } = this.props;
+    const { currentTab } = this.state;
+
+    if (!this.props.statement) {
+      return null;
+    }
+    const {
+      stats,
+      statement,
+      app,
+      distSQL,
+      vec,
+      opt,
+      failed,
+      implicit_txn,
+    } = this.props.statement;
+
+    if (!stats) {
+      const sourceApp = getMatchParamByName(this.props.match, appAttr);
+      const listUrl = "/statements" + (sourceApp ? "/" + sourceApp : "");
+
+      return (
+        <React.Fragment>
+          <section className={cx("section")}>
+            <SqlBox value={statement} />
+          </section>
+          <section className={cx("section")}>
+            <h3>Unable to find statement</h3>
+            There are no execution statistics for this statement.{" "}
+            <Link className={cx("back-link")} to={listUrl}>
+              Back to Statements
+            </Link>
+          </section>
+        </React.Fragment>
+      );
+    }
+
+    const count = FixLong(stats.count).toInt();
+
+    const { rowsBarChart } = rowsBreakdown(this.props.statement);
+    const {
+      parseBarChart,
+      planBarChart,
+      runBarChart,
+      overheadBarChart,
+      overallBarChart,
+    } = latencyBreakdown(this.props.statement);
+
+    const totalCountBarChart = longToInt(this.props.statement.stats.count);
+    const firstAttemptsBarChart = longToInt(
+      this.props.statement.stats.first_attempt_count,
+    );
+    const retriesBarChart = totalCountBarChart - firstAttemptsBarChart;
+    const maxRetriesBarChart = longToInt(
+      this.props.statement.stats.max_retries,
+    );
+
+    const statsByNode = this.props.statement.byNode;
+    const logicalPlan =
+      stats.sensitive_info && stats.sensitive_info.most_recent_plan_description;
+    const duration = (v: number) => Duration(v * 1e9);
+    const hasDiagnosticReports = diagnosticsReports.length > 0;
+    return (
+      <Tabs
+        defaultActiveKey="1"
+        className={cx("cockroach--tabs")}
+        onChange={this.onTabChange}
+        activeKey={currentTab}
+      >
+        <TabPane tab="Overview" key="overview">
+          <Row gutter={16}>
+            <Col className="gutter-row" span={16}>
+              <SqlBox value={statement} />
+            </Col>
+            <Col className="gutter-row" span={8}>
+              <SummaryCard>
+                <Row>
+                  <Col span={12}>
+                    <div
+                      className={summaryCardStylesCx("summary--card__counting")}
+                    >
+                      <h3
+                        className={summaryCardStylesCx(
+                          "summary--card__counting--value",
+                        )}
+                      >
+                        {formatNumberForDisplay(
+                          count * stats.service_lat.mean,
+                          duration,
+                        )}
+                      </h3>
+                      <p
+                        className={summaryCardStylesCx(
+                          "summary--card__counting--label",
+                        )}
+                      >
+                        Total Time
+                      </p>
+                    </div>
+                  </Col>
+                  <Col span={12}>
+                    <div
+                      className={summaryCardStylesCx("summary--card__counting")}
+                    >
+                      <h3
+                        className={summaryCardStylesCx(
+                          "summary--card__counting--value",
+                        )}
+                      >
+                        {formatNumberForDisplay(
+                          stats.service_lat.mean,
+                          duration,
+                        )}
+                      </h3>
+                      <p
+                        className={summaryCardStylesCx(
+                          "summary--card__counting--label",
+                        )}
+                      >
+                        Mean Service Latency
+                      </p>
+                    </div>
+                  </Col>
+                </Row>
+                <p className={summaryCardStylesCx("summary--card__divider")} />
+                <div
+                  className={summaryCardStylesCx("summary--card__item")}
+                  style={{ justifyContent: "flex-start" }}
+                >
+                  <h4
+                    className={summaryCardStylesCx(
+                      "summary--card__item--label",
+                    )}
+                  >
+                    App:
+                  </h4>
+                  <p
+                    className={summaryCardStylesCx(
+                      "summary--card__item--value",
+                    )}
+                  >
+                    {intersperse<ReactNode>(
+                      app.map(a => <AppLink app={a} key={a} />),
+                      ", ",
+                    )}
+                  </p>
+                </div>
+                <div className={summaryCardStylesCx("summary--card__item")}>
+                  <h4
+                    className={summaryCardStylesCx(
+                      "summary--card__item--label",
+                    )}
+                  >
+                    Transaction Type
+                  </h4>
+                  <p
+                    className={summaryCardStylesCx(
+                      "summary--card__item--value",
+                    )}
+                  >
+                    {renderTransactionType(implicit_txn)}
+                  </p>
+                </div>
+                <div className={summaryCardStylesCx("summary--card__item")}>
+                  <h4
+                    className={summaryCardStylesCx(
+                      "summary--card__item--label",
+                    )}
+                  >
+                    Distributed execution?
+                  </h4>
+                  <p
+                    className={summaryCardStylesCx(
+                      "summary--card__item--value",
+                    )}
+                  >
+                    {renderBools(distSQL)}
+                  </p>
+                </div>
+                <div className={summaryCardStylesCx("summary--card__item")}>
+                  <h4
+                    className={summaryCardStylesCx(
+                      "summary--card__item--label",
+                    )}
+                  >
+                    Vectorized execution?
+                  </h4>
+                  <p
+                    className={summaryCardStylesCx(
+                      "summary--card__item--value",
+                    )}
+                  >
+                    {renderBools(vec)}
+                  </p>
+                </div>
+                <div className={summaryCardStylesCx("summary--card__item")}>
+                  <h4
+                    className={summaryCardStylesCx(
+                      "summary--card__item--label",
+                    )}
+                  >
+                    Used cost-based optimizer?
+                  </h4>
+                  <p
+                    className={summaryCardStylesCx(
+                      "summary--card__item--value",
+                    )}
+                  >
+                    {renderBools(opt)}
+                  </p>
+                </div>
+                <div className={summaryCardStylesCx("summary--card__item")}>
+                  <h4
+                    className={summaryCardStylesCx(
+                      "summary--card__item--label",
+                    )}
+                  >
+                    Failed?
+                  </h4>
+                  <p
+                    className={summaryCardStylesCx(
+                      "summary--card__item--value",
+                    )}
+                  >
+                    {renderBools(failed)}
+                  </p>
+                </div>
+              </SummaryCard>
+              <SummaryCard>
+                <h2
+                  className={classNames(
+                    cx("base-heading"),
+                    summaryCardStylesCx("summary--card__title"),
+                  )}
+                >
+                  Execution Count
+                </h2>
+                <div className={summaryCardStylesCx("summary--card__item")}>
+                  <h4
+                    className={summaryCardStylesCx(
+                      "summary--card__item--label",
+                    )}
+                  >
+                    First Attempts
+                  </h4>
+                  <p
+                    className={summaryCardStylesCx(
+                      "summary--card__item--value",
+                    )}
+                  >
+                    {firstAttemptsBarChart}
+                  </p>
+                </div>
+                <div className={summaryCardStylesCx("summary--card__item")}>
+                  <h4
+                    className={summaryCardStylesCx(
+                      "summary--card__item--label",
+                    )}
+                  >
+                    Retries
+                  </h4>
+                  <p
+                    className={summaryCardStylesCx(
+                      "summary--card__item--value",
+                      {
+                        "summary--card__item--value-red": retriesBarChart > 0,
+                      },
+                    )}
+                  >
+                    {retriesBarChart}
+                  </p>
+                </div>
+                <div className={summaryCardStylesCx("summary--card__item")}>
+                  <h4
+                    className={summaryCardStylesCx(
+                      "summary--card__item--label",
+                    )}
+                  >
+                    Max Retries
+                  </h4>
+                  <p
+                    className={summaryCardStylesCx(
+                      "summary--card__item--value",
+                      {
+                        "summary--card__item--value-red":
+                          maxRetriesBarChart > 0,
+                      },
+                    )}
+                  >
+                    {maxRetriesBarChart}
+                  </p>
+                </div>
+                <div className={summaryCardStylesCx("summary--card__item")}>
+                  <h4
+                    className={summaryCardStylesCx(
+                      "summary--card__item--label",
+                    )}
+                  >
+                    Total
+                  </h4>
+                  <p
+                    className={summaryCardStylesCx(
+                      "summary--card__item--value",
+                    )}
+                  >
+                    {totalCountBarChart}
+                  </p>
+                </div>
+                <p className={summaryCardStylesCx("summary--card__divider")} />
+                <h2
+                  className={classNames(
+                    cx("base-heading"),
+                    summaryCardStylesCx("summary--card__title"),
+                  )}
+                >
+                  Rows Affected
+                </h2>
+                <div className={summaryCardStylesCx("summary--card__item")}>
+                  <h4
+                    className={summaryCardStylesCx(
+                      "summary--card__item--label",
+                    )}
+                  >
+                    Mean Rows
+                  </h4>
+                  <p
+                    className={summaryCardStylesCx(
+                      "summary--card__item--value",
+                    )}
+                  >
+                    {rowsBarChart(true)}
+                  </p>
+                </div>
+                <div className={summaryCardStylesCx("summary--card__item")}>
+                  <h4
+                    className={summaryCardStylesCx(
+                      "summary--card__item--label",
+                    )}
+                  >
+                    Standard Deviation
+                  </h4>
+                  <p
+                    className={summaryCardStylesCx(
+                      "summary--card__item--value",
+                    )}
+                  >
+                    {rowsBarChart()}
+                  </p>
+                </div>
+              </SummaryCard>
+            </Col>
+          </Row>
+        </TabPane>
+        <TabPane
+          tab={`Diagnostics ${
+            hasDiagnosticReports ? `(${diagnosticsReports.length})` : ""
+          }`}
+          key="diagnostics"
+        >
+          <DiagnosticsView
+            activate={createStatementDiagnosticsReport}
+            diagnosticsReports={diagnosticsReports}
+            dismissAlertMessage={dismissStatementDiagnosticsAlertMessage}
+            hasData={hasDiagnosticReports}
+            statementFingerprint={statement}
+            onDownloadDiagnosticBundleClick={onDiagnosticBundleDownload}
+          />
+        </TabPane>
+        <TabPane tab="Logical Plan" key="logical-plan">
+          <SummaryCard>
+            <PlanView title="Logical Plan" plan={logicalPlan} />
+          </SummaryCard>
+        </TabPane>
+        <TabPane tab="Execution Stats" key="execution-stats">
+          <SummaryCard>
+            <h2
+              className={classNames(
+                cx("base-heading"),
+                summaryCardStylesCx("summary--card__title"),
+              )}
+            >
+              Execution Latency By Phase
+              <div className={cx("numeric-stats-table__tooltip")}>
+                <Tooltip text="The execution latency of this statement, broken down by phase.">
+                  <div
+                    className={cx("numeric-stats-table__tooltip-hover-area")}
+                  >
+                    <div className={cx("numeric-stats-table__info-icon")}>
+                      i
+                    </div>
+                  </div>
+                </Tooltip>
+              </div>
+            </h2>
+            <NumericStatTable
+              title="Phase"
+              measure="Latency"
+              count={count}
+              format={(v: number) => Duration(v * 1e9)}
+              rows={[
+                { name: "Parse", value: stats.parse_lat, bar: parseBarChart },
+                { name: "Plan", value: stats.plan_lat, bar: planBarChart },
+                { name: "Run", value: stats.run_lat, bar: runBarChart },
+                {
+                  name: "Overhead",
+                  value: stats.overhead_lat,
+                  bar: overheadBarChart,
+                },
+                {
+                  name: "Overall",
+                  summary: true,
+                  value: stats.service_lat,
+                  bar: overallBarChart,
+                },
+              ]}
+            />
+          </SummaryCard>
+          <SummaryCard>
+            <h2
+              className={classNames(
+                cx("base-heading"),
+                summaryCardStylesCx("summary--card__title"),
+              )}
+            >
+              Other Execution Statistics
+            </h2>
+            <NumericStatTable
+              title="Stat"
+              measure="Quantity"
+              count={count}
+              format={d3Format(".2f")}
+              rows={[
+                {
+                  name: "Rows Read",
+                  value: stats.rows_read,
+                  bar: genericBarChart(stats.rows_read, stats.count),
+                },
+                {
+                  name: "Disk Bytes Read",
+                  value: stats.bytes_read,
+                  bar: genericBarChart(stats.bytes_read, stats.count, Bytes),
+                  format: Bytes,
+                },
+                {
+                  name: "Network Bytes Sent",
+                  value: stats.bytes_sent_over_network,
+                  bar: genericBarChart(
+                    stats.bytes_sent_over_network,
+                    stats.count,
+                    Bytes,
+                  ),
+                  format: Bytes,
+                },
+              ].filter(function(r) {
+                if (
+                  r.name === "Network Bytes Sent" &&
+                  r.value &&
+                  r.value.mean === 0
+                ) {
+                  // Omit if empty.
+                  return false;
+                }
+                return r.value;
+              })}
+            />
+          </SummaryCard>
+          <SummaryCard>
+            <h2
+              className={classNames(
+                cx("base-heading"),
+                summaryCardStylesCx("summary--card__title"),
+              )}
+            >
+              Stats By Node
+              <div className={cx("numeric-stats-table__tooltip")}>
+                <Tooltip text="Execution statistics for this statement per gateway node.">
+                  <div
+                    className={cx("numeric-stats-table__tooltip-hover-area")}
+                  >
+                    <div className={cx("numeric-stats-table__info-icon")}>
+                      i
+                    </div>
+                  </div>
+                </Tooltip>
+              </div>
+            </h2>
+            <StatementsSortedTable
+              className={cx("statements-table")}
+              data={statsByNode}
+              columns={makeNodesColumns_20_2(statsByNode, this.props.nodeNames)}
               sortSetting={this.state.sortSetting}
               onChangeSortSetting={this.changeSortSetting}
               firstCellBordered

--- a/packages/cluster-ui/src/statementDetails/statementDetailsConnected.ts
+++ b/packages/cluster-ui/src/statementDetails/statementDetailsConnected.ts
@@ -2,6 +2,7 @@ import { withRouter } from "react-router-dom";
 import { connect } from "react-redux";
 import {
   StatementDetails,
+  StatementDetails_20_2,
   StatementDetailsDispatchProps,
   StatementDetailsProps,
   StatementDetailsStateProps,
@@ -61,4 +62,8 @@ const mapDispatchToProps: StatementDetailsDispatchProps = {
 
 export const ConnectedStatementDetailsPage = withRouter(
   connect(mapStateToProps, mapDispatchToProps)(StatementDetails),
+);
+
+export const ConnectedStatementDetailsPage_20_2 = withRouter(
+  connect(mapStateToProps, mapDispatchToProps)(StatementDetails_20_2),
 );

--- a/packages/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/packages/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -19,6 +19,7 @@ import {
   AggregateStatistics,
   makeStatementsColumns,
   StatementsSortedTable,
+  makeStatementsColumns_20_2,
 } from "../statementsTable";
 import {
   ActivateStatementDiagnosticsModal,
@@ -283,6 +284,270 @@ export class StatementsPage extends React.Component<
             className="statements-table"
             data={data}
             columns={makeStatementsColumns(
+              statements,
+              selectedApp,
+              search,
+              this.activateDiagnosticsRef,
+              onDiagnosticsReportDownload,
+            )}
+            sortSetting={this.state.sortSetting}
+            onChangeSortSetting={this.changeSortSetting}
+            renderNoResult={
+              <EmptyStatementsPlaceholder
+                isEmptySearchResults={isEmptySearchResults}
+              />
+            }
+            pagination={pagination}
+          />
+        </section>
+        <Pagination
+          pageSize={pagination.pageSize}
+          current={pagination.current}
+          total={data.length}
+          onChange={this.onChangePage}
+        />
+      </div>
+    );
+  };
+
+  render() {
+    const {
+      match,
+      refreshStatementDiagnosticsRequests,
+      onActivateStatementDiagnostics,
+      onDiagnosticsModalOpen,
+    } = this.props;
+    const app = getMatchParamByName(match, appAttr);
+    return (
+      <div className={cx("root")}>
+        <Helmet title={app ? `${app} App | Statements` : "Statements"} />
+
+        <section className={cx("section")}>
+          <h1 className={cx("base-heading")}>Statements</h1>
+        </section>
+
+        <Loading
+          loading={isNil(this.props.statements)}
+          error={this.props.statementsError}
+          render={this.renderStatements}
+        />
+        <ActivateStatementDiagnosticsModal
+          ref={this.activateDiagnosticsRef}
+          activate={onActivateStatementDiagnostics}
+          refreshDiagnosticsReports={refreshStatementDiagnosticsRequests}
+          onOpenModal={onDiagnosticsModalOpen}
+        />
+      </div>
+    );
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/class-name-casing
+export class StatementsPage_20_2 extends React.Component<
+  StatementsPageProps,
+  StatementsPageState
+> {
+  activateDiagnosticsRef: React.RefObject<ActivateDiagnosticsModalRef>;
+
+  constructor(props: StatementsPageProps) {
+    super(props);
+    const defaultState = {
+      sortSetting: {
+        sortKey: 3, // Sort by Execution Count column as default option
+        ascending: false,
+      },
+      pagination: {
+        pageSize: 20,
+        current: 1,
+      },
+      search: "",
+    };
+
+    const stateFromHistory = this.getStateFromHistory();
+    this.state = merge(defaultState, stateFromHistory);
+    this.activateDiagnosticsRef = React.createRef();
+  }
+
+  getStateFromHistory = (): Partial<StatementsPageState> => {
+    const { history } = this.props;
+    const searchParams = new URLSearchParams(history.location.search);
+    const sortKey = searchParams.get("sortKey") || undefined;
+    const ascending = searchParams.get("ascending") || undefined;
+    const searchQuery = searchParams.get("q") || undefined;
+
+    return {
+      sortSetting: {
+        sortKey,
+        ascending: Boolean(ascending),
+      },
+      search: searchQuery,
+    };
+  };
+
+  syncHistory = (params: Record<string, string | undefined>) => {
+    const { history } = this.props;
+    const currentSearchParams = new URLSearchParams(history.location.search);
+
+    forIn(params, (value, key) => {
+      if (!value) {
+        currentSearchParams.delete(key);
+      } else {
+        currentSearchParams.set(key, value);
+      }
+    });
+
+    history.location.search = currentSearchParams.toString();
+    history.replace(history.location);
+  };
+
+  changeSortSetting = (ss: SortSetting) => {
+    this.setState({
+      sortSetting: ss,
+    });
+
+    this.syncHistory({
+      sortKey: ss.sortKey,
+      ascending: Boolean(ss.ascending).toString(),
+    });
+    this.props.onSortingChange(
+      "statements-table",
+      ss.columnTitle,
+      ss.ascending,
+    );
+  };
+
+  selectApp = (value: string) => {
+    const { history } = this.props;
+    history.location.pathname = `/statements/${encodeURIComponent(value)}`;
+    history.replace(history.location);
+    this.resetPagination();
+  };
+
+  resetPagination = () => {
+    this.setState(prevState => {
+      return {
+        pagination: {
+          current: 1,
+          pageSize: prevState.pagination.pageSize,
+        },
+      };
+    });
+  };
+
+  componentDidMount() {
+    this.props.refreshStatements();
+    this.props.refreshStatementDiagnosticsRequests();
+  }
+
+  componentDidUpdate = (
+    __: StatementsPageProps,
+    prevState: StatementsPageState,
+  ) => {
+    if (this.state.search && this.state.search !== prevState.search) {
+      this.props.onSearchComplete(this.filteredStatementsData());
+    }
+    this.props.refreshStatements();
+    this.props.refreshStatementDiagnosticsRequests();
+  };
+
+  componentWillUnmount() {
+    this.props.dismissAlertMessage();
+  }
+
+  onChangePage = (current: number) => {
+    const { pagination } = this.state;
+    this.setState({ pagination: { ...pagination, current } });
+    this.props.onPageChanged(current);
+  };
+
+  onSubmitSearchField = (search: string) => {
+    this.setState({ search });
+    this.resetPagination();
+    this.syncHistory({
+      q: search,
+    });
+  };
+
+  onClearSearchField = () => {
+    this.setState({ search: "" });
+    this.syncHistory({
+      q: undefined,
+    });
+  };
+
+  filteredStatementsData = () => {
+    const { search } = this.state;
+    const { statements } = this.props;
+    return statements.filter(statement =>
+      search
+        .split(" ")
+        .every(val =>
+          statement.label.toLowerCase().includes(val.toLowerCase()),
+        ),
+    );
+  };
+
+  renderLastCleared = () => {
+    const { lastReset } = this.props;
+    return `Last cleared ${moment.utc(lastReset).format(DATE_FORMAT)}`;
+  };
+
+  renderStatements = () => {
+    const { pagination, search } = this.state;
+    const { statements, match, onDiagnosticsReportDownload } = this.props;
+    const appAttrValue = getMatchParamByName(match, appAttr);
+    const selectedApp = appAttrValue || "";
+    const appOptions = [{ value: "", name: "All" }];
+    this.props.apps.forEach(app => appOptions.push({ value: app, name: app }));
+    const currentOption = appOptions.find(o => o.value === selectedApp);
+    const data = this.filteredStatementsData();
+    const totalCount = data.length;
+    const isEmptySearchResults = statements?.length > 0 && search?.length > 0;
+
+    return (
+      <div>
+        <PageConfig>
+          <PageConfigItem>
+            <Search
+              onSubmit={this.onSubmitSearchField as any}
+              onClear={this.onClearSearchField}
+              defaultValue={search}
+            />
+          </PageConfigItem>
+          <PageConfigItem>
+            <Dropdown
+              items={appOptions}
+              onChange={this.selectApp}
+              itemsClassname={cx("app-filter-dropdown-item")}
+            >
+              <Text
+                type="body-strong"
+                noWrap={true}
+                className={cx("app-filter-dropdown")}
+              >
+                {`App: ${decodeURIComponent(currentOption.name)}`}
+              </Text>
+            </Dropdown>
+          </PageConfigItem>
+        </PageConfig>
+        <section className={sortableTableCx("cl-table-container")}>
+          <div className={cx("cl-table-statistic")}>
+            <h4 className={cx("cl-count-title")}>
+              <ResultsPerPageLabel
+                pagination={{ ...pagination, total: totalCount }}
+                pageName={"statements"}
+                selectedApp={selectedApp}
+                search={search}
+              />
+            </h4>
+            <h4 className={cx("last-cleared-title")}>
+              {this.renderLastCleared()}
+            </h4>
+          </div>
+          <StatementsSortedTable
+            className="statements-table"
+            data={data}
+            columns={makeStatementsColumns_20_2(
               statements,
               selectedApp,
               search,

--- a/packages/cluster-ui/src/statementsPage/statementsPageConnected.tsx
+++ b/packages/cluster-ui/src/statementsPage/statementsPageConnected.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 
@@ -8,6 +9,7 @@ import { actions as analyticsActions } from "src/store/analytics";
 import { actions as localStorageActions } from "src/store/localStorage";
 import {
   StatementsPage,
+  StatementsPage_20_2,
   StatementsPageDispatchProps,
   StatementsPageOuterProps,
   StatementsPageProps,
@@ -24,49 +26,60 @@ import { AggregateStatistics } from "../statementsTable";
 
 type OwnProps = StatementsPageOuterProps & RouteComponentProps;
 
-export const ConnectedStatementsPage = withRouter(
-  connect<StatementsPageStateProps, StatementsPageDispatchProps, OwnProps>(
-    (state: AppState, props: StatementsPageProps) => ({
-      statements: selectStatements(state, props),
-      statementsError: selectStatementsLastError(state),
-      apps: selectApps(state),
-      totalFingerprints: selectTotalFingerprints(state),
-      lastReset: selectLastReset(state),
-    }),
-    {
-      refreshStatements: statementActions.refresh,
-      refreshStatementDiagnosticsRequests: statementDiagnosticsActions.refresh,
-      dismissAlertMessage: () =>
-        localStorageActions.update({
-          key: "adminUi/showDiagnosticsModal",
-          value: false,
-        }),
-      onActivateStatementDiagnostics: statementDiagnosticsActions.createReport,
-      onDiagnosticsModalOpen: (statementFingerprint: string) =>
-        analyticsActions.activateDiagnostics({
-          page: "statements",
-          value: statementFingerprint,
-        }),
-      onSearchComplete: (results: AggregateStatistics[]) =>
-        analyticsActions.search({
-          page: "statements",
-          value: results?.length || 0,
-        }),
-      onPageChanged: (pageNum: number) =>
-        analyticsActions.pagination({ page: "statements", value: pageNum }),
-      onSortingChange: (
-        tableName: string,
-        columnName: string,
-        ascending: boolean,
-      ) =>
-        analyticsActions.sorting({
-          page: "statements",
-          value: {
-            tableName,
-            columnName,
-            ascending,
-          },
-        }),
-    },
-  )(StatementsPage),
+const connectedStatementsPageFactory = (Component: React.ComponentClass) =>
+  withRouter(
+    connect<StatementsPageStateProps, StatementsPageDispatchProps, OwnProps>(
+      (state: AppState, props: StatementsPageProps) => ({
+        statements: selectStatements(state, props),
+        statementsError: selectStatementsLastError(state),
+        apps: selectApps(state),
+        totalFingerprints: selectTotalFingerprints(state),
+        lastReset: selectLastReset(state),
+      }),
+      {
+        refreshStatements: statementActions.refresh,
+        refreshStatementDiagnosticsRequests:
+          statementDiagnosticsActions.refresh,
+        dismissAlertMessage: () =>
+          localStorageActions.update({
+            key: "adminUi/showDiagnosticsModal",
+            value: false,
+          }),
+        onActivateStatementDiagnostics:
+          statementDiagnosticsActions.createReport,
+        onDiagnosticsModalOpen: (statementFingerprint: string) =>
+          analyticsActions.activateDiagnostics({
+            page: "statements",
+            value: statementFingerprint,
+          }),
+        onSearchComplete: (results: AggregateStatistics[]) =>
+          analyticsActions.search({
+            page: "statements",
+            value: results?.length || 0,
+          }),
+        onPageChanged: (pageNum: number) =>
+          analyticsActions.pagination({ page: "statements", value: pageNum }),
+        onSortingChange: (
+          tableName: string,
+          columnName: string,
+          ascending: boolean,
+        ) =>
+          analyticsActions.sorting({
+            page: "statements",
+            value: {
+              tableName,
+              columnName,
+              ascending,
+            },
+          }),
+      },
+    )(Component),
+  );
+
+export const ConnectedStatementsPage = connectedStatementsPageFactory(
+  StatementsPage,
+);
+
+export const ConnectedStatementsPage_20_2 = connectedStatementsPageFactory(
+  StatementsPage_20_2,
 );

--- a/packages/cluster-ui/src/statementsTable/statementsTable.module.scss
+++ b/packages/cluster-ui/src/statementsTable/statementsTable.module.scss
@@ -4,12 +4,30 @@
   white-space: nowrap;
 }
 
+.statements-table__col-count--bar-chart {
+  width: 100px;
+}
+
+.statements-table__col-retries--bar-chart {
+  width: 80px;
+}
+
 .numeric-stats-table {
   .bar-chart {
     width: 200px;
   }
 }
 
+.statements-table__col-rows,
+.statements-table__col-latency {
+  &--bar-chart {
+    min-width: 150px;
+  }
+}
+
+.statements-table__col-count,
+.statements-table__col-retries,
+.statements-table__col-rows,
 .statements-table__col {
   &--bar-chart {
     margin-left: 0;

--- a/packages/cluster-ui/src/statementsTable/statementsTableContent.tsx
+++ b/packages/cluster-ui/src/statementsTable/statementsTableContent.tsx
@@ -269,6 +269,172 @@ export const StatementTableTitle = {
   ),
 };
 
+// eslint-disable-next-line @typescript-eslint/camelcase
+export const StatementTableTitle_20_2 = {
+  statements: (
+    <Tooltip
+      placement="bottom"
+      title={
+        <div className={cx("tooltip__table--title")}>
+          <p>
+            {"SQL statement "}
+            <Anchor href={statementsSql} target="_blank">
+              fingerprint.
+            </Anchor>
+          </p>
+          <p>
+            To view additional details of a SQL statement fingerprint, click
+            this to open the Statement Details page.
+          </p>
+        </div>
+      }
+    >
+      Statements
+    </Tooltip>
+  ),
+  txtType: (
+    <Tooltip
+      placement="bottom"
+      title={
+        <div className={cx("tooltip__table--title")}>
+          <p>
+            {
+              "Type of transaction (implicit or explicit). Explicit transactions refer to statements that are wrapped by "
+            }
+            <code>BEGIN</code>
+            {" and "}
+            <code>COMMIT</code>
+            {" statements by the client. Explicit transactions employ "}
+            <Anchor href={transactionalPipelining} target="_blank">
+              transactional pipelining
+            </Anchor>
+            {
+              " and therefore report latencies that do not account for replication."
+            }
+          </p>
+          <p>
+            For statements not in explicit transactions, CockroachDB wraps each
+            statement in individual implicit transactions.
+          </p>
+        </div>
+      }
+    >
+      TXN Type
+    </Tooltip>
+  ),
+  diagnostics: (
+    <Tooltip
+      placement="bottom"
+      title={
+        <div className={cx("tooltip__table--title")}>
+          <p>
+            {"Option to activate "}
+            <Anchor href={statementDiagnostics} target="_blank">
+              diagnostics
+            </Anchor>
+            {
+              " for each statement. If activated, this displays the status of diagnostics collection ("
+            }
+            <code>WAITING</code>, <code>READY</code>, OR <code>ERROR</code>).
+          </p>
+        </div>
+      }
+    >
+      Diagnostics
+    </Tooltip>
+  ),
+  retries: (
+    <Tooltip
+      placement="bottom"
+      title={
+        <div className={cx("tooltip__table--title")}>
+          <p>
+            {"Cumulative number of "}
+            <Anchor href={statementsRetries} target="_blank">
+              retries
+            </Anchor>
+            {
+              " of statements with this fingerprint within the last hour or specified time interval."
+            }
+          </p>
+        </div>
+      }
+    >
+      Retries
+    </Tooltip>
+  ),
+  executionCount: (
+    <Tooltip
+      placement="bottom"
+      title={
+        <div className={cx("tooltip__table--title")}>
+          <p>
+            {
+              "Cumulative number of executions of statements with this fingerprint within the last hour or specified "
+            }
+            <Anchor href={statementsTimeInterval} target="_blank">
+              time interval
+            </Anchor>
+            .
+          </p>
+          <p>
+            {"The bar indicates the ratio of runtime success (gray) to "}
+            <Anchor href={statementsRetries} target="_blank">
+              retries
+            </Anchor>
+            {" (red) for the SQL statement fingerprint."}
+          </p>
+        </div>
+      }
+    >
+      Execution Count
+    </Tooltip>
+  ),
+  rowsAffected: (
+    <Tooltip
+      placement="bottom"
+      title={
+        <div className={cx("tooltip__table--title")}>
+          <p>
+            {
+              "Average number of rows returned while executing statements with this fingerprint within the last hour or specified "
+            }
+            <Anchor href={statementsTimeInterval} target="_blank">
+              time interval
+            </Anchor>
+            .
+          </p>
+          <p>
+            The gray bar indicates the mean number of rows returned. The blue
+            bar indicates one standard deviation from the mean.
+          </p>
+        </div>
+      }
+    >
+      Rows Affected
+    </Tooltip>
+  ),
+  latency: (
+    <Tooltip
+      placement="bottom"
+      title={
+        <div className={cx("tooltip__table--title")}>
+          <p>
+            Average service latency of statements with this fingerprint within
+            the last hour or specified time interval.
+          </p>
+          <p>
+            The gray bar indicates the mean latency. The blue bar indicates one
+            standard deviation from the mean.
+          </p>
+        </div>
+      }
+    >
+      Latency
+    </Tooltip>
+  ),
+};
+
 export const StatementTableCell = {
   statements: (search?: string, selectedApp?: string) => (stmt: any) => (
     <StatementLink


### PR DESCRIPTION
Components for different versions of CockroachDb are incompatible
and the latest version of `cluster-ui` package doesn't allow to
use components with previous (older) versions of CockroachDb.

This change splits down statements and statement details pages
into two versions where components for previous (20.2) version
have suffix `_20_2` and components without prefix - are targeted
to the latest CRDB version.

Maintaining several versions are needed in CC where cluster can
be spun up with arbitrary CRDB version and it has to conditionally
load components depending on cluster version.

This approach has obvious **disadvantages**:
- code duplication
- multiple versions of components don't inherit common logic
- version changes are tracked in code instead of VCS

Component duplicates have very small changes - most of the time it's
a one line change.
 