### PR TITLE
cluster-ui: bump cluster-ui to 0.2.x version

### DIFF
--- a/.github/workflows/publish-cluster-ui.yml
+++ b/.github/workflows/publish-cluster-ui.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - cluster-ui-20.2
     paths:
       - "packages/cluster-ui/**"
 jobs:

--- a/packages/cluster-ui/package.json
+++ b/packages/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "0.1.51",
+  "version": "0.2.0",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Latest changes to cluster-ui introduced incompatibility
between CRDB version 20.2 and ongoing development for 21.1.

Changes related to CockroachDb 21.x versions have to be
added to 0.2.x version and 0.1.x version will be targeted
to CockroachDb 20.2 version (for hotfixes, etc)

cluster-ui@0.1.x ver can be published from `cluster-ui-20.2`
branch.
