### PR TITLE
cluster-ui: bump to the latest 0.1.x version in cluster-ui-20.2 branch

### DIFF
--- a/.github/workflows/publish-cluster-ui.yml
+++ b/.github/workflows/publish-cluster-ui.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - cluster-ui-20.2
     paths:
       - "packages/cluster-ui/**"
 jobs:

--- a/packages/cluster-ui/package.json
+++ b/packages/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "0.1.52",
+  "version": "0.1.53",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",

--- a/packages/cluster-ui/package.json
+++ b/packages/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "0.1.46-crdb-20.2",
+  "version": "0.1.52",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
cluster-ui-20.2 branch has to maintain the changes for 0.1.x version,
but it was not branched out from the latest version and now its version
has to be updated manually.

```
master     |---- 0.1.46 ---- 0.1.51 --- 0.2.x --->
cluster-ui-20.2     \---- 0.1.52 ---->
```
`master` branch includes 0.1.51 version - latest 0.1.x version on
that branch, and then the minor version incremented to 0.2.x

Depends on: https://github.com/cockroachdb/ui/pull/210