### PR TITLE
ui-components: 'reasonable' spelling was corrected

### DIFF
--- a/packages/storybook-ui-components/stories/Tooltip.stories.tsx
+++ b/packages/storybook-ui-components/stories/Tooltip.stories.tsx
@@ -12,7 +12,7 @@ export default {
 export const Example = () => {
   const text = (
     <span>
-      reasonble tooltip text,
+      reasonable tooltip text,
       <br />
       some more text
     </span>


### PR DESCRIPTION
'Reasonable' spelling was corrected on the tooltip storybook




