### PR TITLE
cluster-ui: sessions, terminate modal notifications

### DIFF
--- a/packages/cluster-ui/src/sessions/sessionDetails.tsx
+++ b/packages/cluster-ui/src/sessions/sessionDetails.tsx
@@ -40,10 +40,11 @@ import {
   NodeLink,
   StatementLinkTarget,
 } from "src/statementsTable/statementsTableContent";
+
 import {
-  CancelQueryRequestMessage,
-  CancelSessionRequestMessage,
-} from "src/api/terminateQueryApi";
+  ICancelQueryRequest,
+  ICancelSessionRequest,
+} from "src/store/terminateQuery";
 interface OwnProps {
   id?: string;
   nodeNames: { [nodeId: string]: string };
@@ -52,8 +53,8 @@ interface OwnProps {
   refreshSessions: () => void;
   refreshNodes: () => void;
   refreshNodesLiveness: () => void;
-  cancelSession: (req: CancelSessionRequestMessage) => void;
-  cancelQuery: (req: CancelQueryRequestMessage) => void;
+  cancelSession: (payload: ICancelSessionRequest) => void;
+  cancelQuery: (payload: ICancelQueryRequest) => void;
 }
 
 const cx = classNames.bind(styles);

--- a/packages/cluster-ui/src/sessions/sessionsDetailsConnected.stories.tsx
+++ b/packages/cluster-ui/src/sessions/sessionsDetailsConnected.stories.tsx
@@ -16,7 +16,7 @@ import {
   Store,
 } from "redux";
 import { SessionDetailsPageConnected } from "./sessionDetailsConnected";
-import { AppState, rootReducer, sagas } from "../store";
+import { AppState, sagas, rootReducer } from "../store";
 import { Route } from "react-router-dom";
 
 const TEST_ID = "165f9819-2feb-40f0-0000-000000000001";

--- a/packages/cluster-ui/src/sessions/sessionsPage.tsx
+++ b/packages/cluster-ui/src/sessions/sessionsPage.tsx
@@ -39,20 +39,22 @@ import TerminateSessionModal, {
 } from "./terminateSessionModal";
 
 import {
-  CancelSessionRequestMessage,
-  CancelQueryRequestMessage,
-} from "src/api/terminateQueryApi";
+  ICancelSessionRequest,
+  ICancelQueryRequest,
+} from "src/store/terminateQuery";
 
 import sortedTableStyles from "src/sortedtable/sortedtable.module.scss";
 import styles from "src/statementsPage/statementsPage.module.scss";
+
 const sortableTableCx = classNames.bind(sortedTableStyles);
 const cx = classNames.bind(styles);
+
 interface OwnProps {
   sessions: SessionInfo[];
   sessionsError: Error | Error[];
   refreshSessions: () => void;
-  cancelSession: (req: CancelSessionRequestMessage) => void;
-  cancelQuery: (req: CancelQueryRequestMessage) => void;
+  cancelSession: (payload: ICancelSessionRequest) => void;
+  cancelQuery: (payload: ICancelQueryRequest) => void;
   onPageChanged?: (newPage: number) => void;
 }
 

--- a/packages/cluster-ui/src/sessions/terminateQueryModal.tsx
+++ b/packages/cluster-ui/src/sessions/terminateQueryModal.tsx
@@ -16,23 +16,15 @@ import React, {
 } from "react";
 import { Modal } from "../modal";
 import { Text } from "../text";
-
-// import {cockroach} from "src/js/protos";
-// import {trackTerminateQuery} from "src/util/analytics/trackTerminate";
-
-// import ICancelQueryRequest = cockroach.server.serverpb.ICancelQueryRequest;
-type ICancelQueryRequest = any;
-
+import { ICancelQueryRequest } from "src/store/terminateQuery";
 export interface TerminateQueryModalRef {
   showModalFor: (req: ICancelQueryRequest) => void;
 }
 
 interface TerminateQueryModalProps {
-  //cancel: (req: ICancelQueryRequest) => void;
-  cancel?: (req: ICancelQueryRequest) => void;
+  cancel: (payload: ICancelQueryRequest) => void;
 }
 
-// tslint:disable-next-line:variable-name
 const TerminateQueryModal = (
   props: TerminateQueryModalProps,
   ref: React.RefObject<TerminateQueryModalRef>,
@@ -43,7 +35,6 @@ const TerminateQueryModal = (
 
   const onOkHandler = useCallback(() => {
     cancel(req);
-    //trackTerminateQuery();
     setVisible(false);
   }, [req, cancel]);
 

--- a/packages/cluster-ui/src/sessions/terminateSessionModal.tsx
+++ b/packages/cluster-ui/src/sessions/terminateSessionModal.tsx
@@ -14,24 +14,18 @@ import React, {
   useImperativeHandle,
   useState,
 } from "react";
+import { ICancelSessionRequest } from "src/store/terminateQuery";
 import { Modal } from "../modal";
 import { Text } from "../text";
-
-//import {cockroach} from "src/js/protos";
-//import ICancelSessionRequest = cockroach.server.serverpb.ICancelSessionRequest;
-type ICancelSessionRequest = any;
-//import {trackTerminateSession} from "src/util/analytics/trackTerminate";
 
 export interface TerminateSessionModalRef {
   showModalFor: (req: ICancelSessionRequest) => void;
 }
 
 interface TerminateSessionModalProps {
-  //cancel: (req: ICancelSessionRequest) => void;
-  cancel?: (req: ICancelSessionRequest) => void;
+  cancel: (payload: ICancelSessionRequest) => void;
 }
 
-// tslint:disable-next-line:variable-name
 const TerminateSessionModal = (
   props: TerminateSessionModalProps,
   ref: React.RefObject<TerminateSessionModalRef>,
@@ -42,7 +36,6 @@ const TerminateSessionModal = (
 
   const onOkHandler = useCallback(() => {
     cancel(req);
-    //trackTerminateSession();
     setVisible(false);
   }, [req, cancel]);
 

--- a/packages/cluster-ui/src/store/index.ts
+++ b/packages/cluster-ui/src/store/index.ts
@@ -1,2 +1,3 @@
 export { sagas } from "./sagas";
+export { notificationAction } from "./notifications";
 export { rootReducer, AppState } from "./reducers";

--- a/packages/cluster-ui/src/store/notifications/index.ts
+++ b/packages/cluster-ui/src/store/notifications/index.ts
@@ -1,0 +1,1 @@
+export * from "./notifications.sagas";

--- a/packages/cluster-ui/src/store/notifications/notifications.sagas.ts
+++ b/packages/cluster-ui/src/store/notifications/notifications.sagas.ts
@@ -1,0 +1,71 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { createAction } from "@reduxjs/toolkit";
+import { all, put, takeEvery } from "redux-saga/effects";
+
+import { actions as terminateQueryActions } from "src/store/terminateQuery/terminateQuery.reducer";
+
+export const notificationAction = createAction(
+  "adminUI/notification",
+  (type: NotificationType, text: string) => ({
+    payload: {
+      type,
+      text,
+    },
+  }),
+);
+
+export enum NotificationType {
+  Success = "success",
+  Error = "error",
+}
+
+export type SendNotification = (
+  type: NotificationType,
+  message: string,
+) => void;
+
+export function* notifificationsSaga() {
+  // ***************************** //
+  // Terminate Query notifications //
+  // ***************************** //
+  yield all([
+    takeEvery(terminateQueryActions.terminateSessionCompleted, function*() {
+      yield put(
+        notificationAction(NotificationType.Success, "Session terminated."),
+      );
+    }),
+
+    takeEvery(terminateQueryActions.terminateSessionFailed, function*() {
+      yield put(
+        notificationAction(
+          NotificationType.Error,
+          "There was an error terminating the session",
+        ),
+      );
+    }),
+
+    takeEvery(terminateQueryActions.terminateQueryCompleted, function*() {
+      yield put(
+        notificationAction(NotificationType.Success, "Query terminated."),
+      );
+    }),
+
+    takeEvery(terminateQueryActions.terminateQueryFailed, function*() {
+      yield put(
+        notificationAction(
+          NotificationType.Error,
+          "There was an error terminating the query.",
+        ),
+      );
+    }),
+  ]);
+}

--- a/packages/cluster-ui/src/store/sagas.ts
+++ b/packages/cluster-ui/src/store/sagas.ts
@@ -7,6 +7,7 @@ import { nodesSaga } from "./nodes";
 import { livenessSaga } from "./liveness";
 import { sessionsSaga } from "./sessions";
 import { terminateSaga } from "./terminateQuery";
+import { notifificationsSaga } from "./notifications";
 
 export function* sagas(cacheInvalidationPeriod?: number) {
   yield all([
@@ -17,5 +18,6 @@ export function* sagas(cacheInvalidationPeriod?: number) {
     fork(livenessSaga, cacheInvalidationPeriod),
     fork(sessionsSaga),
     fork(terminateSaga),
+    fork(notifificationsSaga),
   ]);
 }

--- a/packages/cluster-ui/src/store/terminateQuery/terminateQuery.sagas.ts
+++ b/packages/cluster-ui/src/store/terminateQuery/terminateQuery.sagas.ts
@@ -11,19 +11,16 @@
 import { PayloadAction } from "@reduxjs/toolkit";
 import { all, call, put, takeEvery } from "redux-saga/effects";
 
-// TODO: (vlad) originaly this calls triggered popup message with error\success message.
-// need to come up with api to recreate this behavier with client specific popup components
-// import {terminateQueryAlertLocalSetting, terminateSessionAlertLocalSetting} from "src/redux/alerts";
-
 import { terminateQuery, terminateSession } from "src/api/terminateQueryApi";
 import { actions as sessionsActions } from "src/store/sessions";
 import { actions as terminateQueryActions } from "./terminateQuery.reducer";
 
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+
 const CancelSessionRequest = cockroach.server.serverpb.CancelSessionRequest;
 const CancelQueryRequest = cockroach.server.serverpb.CancelQueryRequest;
-export type ICancelSessionRequest = cockroach.server.serverpb.CancelSessionRequest;
-export type ICancelQueryRequest = cockroach.server.serverpb.CancelQueryRequest;
+export type ICancelSessionRequest = cockroach.server.serverpb.ICancelSessionRequest;
+export type ICancelQueryRequest = cockroach.server.serverpb.ICancelQueryRequest;
 
 export function* terminateSessionSaga(
   action: PayloadAction<ICancelSessionRequest>,
@@ -34,10 +31,8 @@ export function* terminateSessionSaga(
     yield put(terminateQueryActions.terminateSessionCompleted());
     yield put(sessionsActions.invalidated());
     yield put(sessionsActions.refresh());
-    //yield put(terminateSessionAlertLocalSetting.set({ show: true, status: "SUCCESS"}));
   } catch (e) {
     yield put(terminateQueryActions.terminateSessionFailed(e));
-    //yield put(terminateSessionAlertLocalSetting.set({ show: true, status: "FAILED"}));
   }
 }
 
@@ -50,10 +45,8 @@ export function* terminateQuerySaga(
     yield put(terminateQueryActions.terminateQueryCompleted());
     yield put(sessionsActions.invalidated());
     yield put(sessionsActions.refresh());
-    //yield put(terminateQueryAlertLocalSetting.set({ show: true, status: "SUCCESS"}));
   } catch (e) {
     yield put(terminateQueryActions.terminateQueryFailed(e));
-    //yield put(terminateQueryAlertLocalSetting.set({ show: true, status: "FAILED"}));
   }
 }
 


### PR DESCRIPTION
provide separate notifications saga and expose its action, so consumer
app can build around it its own notification handlers. small cleanups.