### PR TITLE
cluster-ui: add execution stats to statement details page

### DIFF
--- a/packages/cluster-ui/src/statementDetails/statementDetails.module.scss
+++ b/packages/cluster-ui/src/statementDetails/statementDetails.module.scss
@@ -1,4 +1,5 @@
 @import "src/core/index.module";
+@import "~@cockroachlabs/design-tokens/dist/web/tokens";
 
 $max-window-width: 1350px;
 
@@ -141,5 +142,12 @@ h2.base-heading {
   &__col-query-text {
     font-family: $font-family--monospace;
     white-space: pre-wrap;
+  }
+}
+
+.summary-card {
+  color: $colors--neutral-7;
+  h5 {
+    color: $colors--neutral-7;
   }
 }


### PR DESCRIPTION
Closes https://github.com/cockroachdb/cockroach/issues/59296

First commit is #197 so please only review the second one. That PR should go in before this. This PR updates the statement details page with currently available execution stats. This looks like:
![image](https://user-images.githubusercontent.com/10560359/108381896-8dd84d80-7208-11eb-8933-42ca7210a646.png)

I followed the `Heading/Text` pattern for all labels/values. I do need some CSS help to:
- [x] Make sure that the "Resource usage" summary card details aren't bunched up on multiple lines. cc @koorosh wondering if you could give me a helping hand here.
- [x] I did not change the className for `Retries` and `Max Retries` to not get rid of the behavior where they turn red if the number > 1. Is this correct or does this not work with the `Text` component?

@Annebirzin some notes:
- The design gets rid of the distributed execution label. This SGTM but just want to double check it's intentional.
- We can't add the "Executed as follower read" and "Estimated network round trips" because we don't have that data. We could add the *actual* round trips with a bit of plumbing in another pass if that's something we'd like to show.
- I was about to write network bytes is repeated, but we've already touched upon this in #197. Will update this PR with what we agreed there (i.e. putting network bytes in the left "Resource usage" column).

@dhartunian putting you as the lead reviewer for this, let me know if someone else is better suited.

cc @awoods187 