### PR TITLE
storybook: link ui-components dependencies

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -40,8 +40,11 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - name: Install dependencies and build packages
+        run: yarn && yarn lerna run build
+
       - name: Build storybook
-        run: yarn && npm run build-storybook
+        run: yarn build-storybook
         working-directory: ./packages/storybook-ui-components
 
       - name: Deploy

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # ui
 Published assets for Cockroach Labs user interfaces
 
-Commands for local setup:
-
-`npm run init` - for initial run, will install top level dependencies, package level ones, run lerna link
-`npm start` - run in root of the project to run dev servers for all sub packages.<br/>
+## Development setup
+- Install all dependencies with Yarn (it resolves dependencies for nested workspaces and links them if necessary)
+- Run `build` command for all packages to have generated assets in place (needed for `icons` and `design-tokens` workspaces)
+```shell
+yarn install && yarn lerna run build
+```

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "lerna": "^3.20.2"
   },
   "scripts": {
-    "init": "yarn install --pure-lockfile && lerna bootstrap --force-local && lerna link",
+    "init": "yarn install && yarn lerna run build",
     "start": "lerna run start --parallel"
   },
   "resolutions": {

--- a/packages/storybook-ui-components/package.json
+++ b/packages/storybook-ui-components/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/cockroachdb/ui#readme",
   "dependencies": {
     "@cockroachlabs/icons": "^0.4.0",
-    "@cockroachlabs/ui-components": "next"
+    "@cockroachlabs/ui-components": "link:packages/ui-components"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1488,7 +1488,7 @@
   resolved "https://registry.yarnpkg.com/@cockroachlabs/icons/-/icons-0.3.0.tgz#160573074396f266e92fcbe5e520c5ba1d8750f9"
   integrity sha512-GJxhlXy8Z3/PYFb9C3iM1dvU9wajGoaA/+VCj0an2ipfbkI2fhToq+h0b33vu7JuZ3dS4QMRjfVE4uhlyIUH2Q==
 
-"@cockroachlabs/ui-components@0.2.14-alpha.0", "@cockroachlabs/ui-components@next":
+"@cockroachlabs/ui-components@0.2.14-alpha.0":
   version "0.2.14-alpha.0"
   resolved "https://registry.yarnpkg.com/@cockroachlabs/ui-components/-/ui-components-0.2.14-alpha.0.tgz#d90a7ce6fbede9d8b177d9a940f24218c262d267"
   integrity sha512-8zOZswstmBbJQxXmQ7yfEXEOEUJ4JT5xlzGQ5FD7z8sjy67UDXFoe6FMqFXrkpiFwlCrkK2Vd36LKhLvGY2xkA==
@@ -1496,6 +1496,10 @@
     "@cockroachlabs/icons" "^0.3.0"
     "@popperjs/core" "^2.4.3"
     react-popper "^2.2.3"
+
+"@cockroachlabs/ui-components@link:packages/storybook-ui-components/packages/ui-components":
+  version "0.0.0"
+  uid ""
 
 "@egoist/vue-to-react@^1.1.0":
   version "1.1.0"
@@ -14534,9 +14538,9 @@ pretty-time@^1.1.0:
   integrity sha512-28iF6xPQrP8Oa6uxE6a1biz+lWeTOAPKggvjB8HAs6nVMKZwf5bG++632Dx614hIWgUPkgivRfG+a8uAXGTIbA==
 
 prismjs@^1.8.4:
-  version "1.22.0"
-  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.22.0.tgz#73c3400afc58a823dd7eed023f8e1ce9fd8977fa"
-  integrity sha512-lLJ/Wt9yy0AiSYBf212kK3mM5L8ycwlyTlSxHBAneXLR0nzFMlZ5y7riFPF3E33zXOF2IH95xdY5jIyZbM9z/w==
+  version "1.23.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.23.0.tgz#d3b3967f7d72440690497652a9d40ff046067f33"
+  integrity sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==
   optionalDependencies:
     clipboard "^2.0.0"
 


### PR DESCRIPTION
# storybook-ui-components // link ui-components dependencies

`storybook-ui-components` package always depends on the latest
version of `ui-components` package and during development Storybook
has to apply all local changes.
To achieve this, `storybook-ui-components` installs `ui-components`
package as a linked dependency so it always has latest version.

Before, it relied on "next" tag that didn't work as expected and
it was a reason when local installs failed.

