### PR TITLE
cluster-ui: miscellaneous fixes and additions to statements/transactions page/details

### DIFF
--- a/packages/cluster-ui/src/barCharts/barCharts.module.scss
+++ b/packages/cluster-ui/src/barCharts/barCharts.module.scss
@@ -60,7 +60,7 @@
     border-radius: 3px;
   }
 
-  .rows-dev, .rows-read-dev, .bytes-read-dev, .max-mem-usage-dev, .network-bytes-dev {
+  .rows-dev, .rows-read-dev, .bytes-read-dev, .contention-dev, .max-mem-usage-dev, .network-bytes-dev {
     background-color: $colors--primary-blue-3;
   }
 

--- a/packages/cluster-ui/src/barCharts/barCharts.tsx
+++ b/packages/cluster-ui/src/barCharts/barCharts.tsx
@@ -34,6 +34,13 @@ const latencyBars = [
   ),
 ];
 
+const contentionBars = [
+  bar(
+    "contention",
+    (d: StatementStatistics) => d.stats.exec_stats.contention_time?.mean,
+  ),
+];
+
 const maxMemUsageBars = [
   bar(
     "max-mem-usage",
@@ -66,6 +73,9 @@ const latencyStdDev = bar(
   cx("bar-chart__overall-dev"),
   (d: StatementStatistics) => stdDevLong(d.stats.service_lat, d.stats.count),
 );
+const contentionStdDev = bar(cx("contention-dev"), (d: StatementStatistics) =>
+  stdDevLong(d.stats.exec_stats.contention_time, d.stats.exec_stats.count),
+);
 const maxMemUsageStdDev = bar(
   cx("max-mem-usage-dev"),
   (d: StatementStatistics) =>
@@ -96,6 +106,12 @@ export const latencyBarChart = barChartFactory(
   latencyBars,
   v => Duration(v * 1e9),
   latencyStdDev,
+);
+export const contentionBarChart = barChartFactory(
+  "grey",
+  contentionBars,
+  v => Duration(v * 1e9),
+  contentionStdDev,
 );
 export const maxMemUsageBarChart = barChartFactory(
   "grey",

--- a/packages/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/packages/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -493,6 +493,15 @@ export class StatementDetails extends React.Component<
                         )}
                       </Text>
                     </div>
+                    <div className={summaryCardStylesCx("summary--card__item")}>
+                      <Text type="body-strong">Max scratch disk usage</Text>
+                      <Text>
+                        {formatNumberForDisplay(
+                          stats.exec_stats.max_disk_usage.mean,
+                          Bytes,
+                        )}
+                      </Text>
+                    </div>
                   </Col>
                 </Row>
               </SummaryCard>

--- a/packages/cluster-ui/src/statementsPage/statementsPage.spec.tsx
+++ b/packages/cluster-ui/src/statementsPage/statementsPage.spec.tsx
@@ -26,7 +26,7 @@ describe("StatementsPage", () => {
       > = rootWrapper.find(StatementsPage).first();
       const statementsPageInstance = statementsPageWrapper.instance();
 
-      assert.equal(statementsPageInstance.state.sortSetting.sortKey, 3);
+      assert.equal(statementsPageInstance.state.sortSetting.sortKey, 1);
       assert.equal(statementsPageInstance.state.sortSetting.ascending, false);
     });
   });

--- a/packages/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/packages/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -88,7 +88,8 @@ export class StatementsPage extends React.Component<
     super(props);
     const defaultState = {
       sortSetting: {
-        sortKey: 3, // Sort by Execution Count column as default option
+        // Sort by Execution Count column as default option.
+        sortKey: 1,
         ascending: false,
       },
       pagination: {

--- a/packages/cluster-ui/src/statementsTable/statementsTable.module.scss
+++ b/packages/cluster-ui/src/statementsTable/statementsTable.module.scss
@@ -1,9 +1,5 @@
 @import "src/core/index.module";
 
-.statements-table__col-time {
-  white-space: nowrap;
-}
-
 .numeric-stats-table {
   .bar-chart {
     width: 200px;

--- a/packages/cluster-ui/src/statementsTable/statementsTable.tsx
+++ b/packages/cluster-ui/src/statementsTable/statementsTable.tsx
@@ -146,13 +146,6 @@ export function makeStatementsColumns(
       cell: StatementTableCell.statements(search, selectedApp),
       sort: stmt => stmt.label,
     },
-    {
-      name: "txtType",
-      title: StatementTableTitle.txtType,
-      className: cx("statements-table__col-time"),
-      cell: stmt => (stmt.implicitTxn ? "Implicit" : "Explicit"),
-      sort: stmt => (stmt.implicitTxn ? "Implicit" : "Explicit"),
-    },
   ];
   columns.push(...makeCommonColumns(statements));
 

--- a/packages/cluster-ui/src/statementsTable/statementsTable.tsx
+++ b/packages/cluster-ui/src/statementsTable/statementsTable.tsx
@@ -70,7 +70,7 @@ function makeCommonColumns(
     },
     {
       name: "latency",
-      title: StatementTableTitle.latency,
+      title: StatementTableTitle.statementTime,
       className: cx("statements-table__col-latency"),
       cell: latencyBar,
       sort: stmt => stmt.stats.service_lat.mean,

--- a/packages/cluster-ui/src/statementsTable/statementsTable.tsx
+++ b/packages/cluster-ui/src/statementsTable/statementsTable.tsx
@@ -8,6 +8,7 @@ import {
   rowsReadBarChart,
   bytesReadBarChart,
   latencyBarChart,
+  contentionBarChart,
   maxMemUsageBarChart,
   networkBytesBarChart,
   retryBarChart,
@@ -42,6 +43,7 @@ function makeCommonColumns(
   const rowsReadBar = rowsReadBarChart(statements, barChartOptions);
   const bytesReadBar = bytesReadBarChart(statements, barChartOptions);
   const latencyBar = latencyBarChart(statements, barChartOptions);
+  const contentionBar = contentionBarChart(statements, barChartOptions);
   const maxMemUsageBar = maxMemUsageBarChart(statements, barChartOptions);
   const networkBytesBar = networkBytesBarChart(statements, barChartOptions);
   const retryBar = retryBarChart(statements, barChartOptions);
@@ -64,7 +66,6 @@ function makeCommonColumns(
     {
       name: "bytesRead",
       title: StatementTableTitle.bytesRead,
-      className: cx("statements-table__col-bytes-read"),
       cell: bytesReadBar,
       sort: stmt => FixLong(Number(stmt.stats.bytes_read.mean)),
     },
@@ -76,16 +77,20 @@ function makeCommonColumns(
       sort: stmt => stmt.stats.service_lat.mean,
     },
     {
+      name: "contention",
+      title: StatementTableTitle.contention,
+      cell: contentionBar,
+      sort: stmt => FixLong(Number(stmt.stats.exec_stats.contention_time.mean)),
+    },
+    {
       name: "maxMemoryUsage",
       title: StatementTableTitle.maxMemUsage,
-      className: cx("statements-table__col-max-mem-usage"),
       cell: maxMemUsageBar,
       sort: stmt => FixLong(Number(stmt.stats.exec_stats.max_mem_usage.mean)),
     },
     {
       name: "networkBytes",
       title: StatementTableTitle.networkBytes,
-      className: cx("statements-table__col-network-bytes"),
       cell: networkBytesBar,
       sort: stmt => FixLong(Number(stmt.stats.exec_stats.network_bytes.mean)),
     },

--- a/packages/cluster-ui/src/statementsTable/statementsTableContent.tsx
+++ b/packages/cluster-ui/src/statementsTable/statementsTableContent.tsx
@@ -129,7 +129,7 @@ export const StatementTableTitle = {
       Bytes Read
     </Tooltip>
   ),
-  latency: (
+  statementTime: (
     <Tooltip
       placement="bottom"
       title={
@@ -145,7 +145,26 @@ export const StatementTableTitle = {
         </div>
       }
     >
-      Latency
+      Statement Time
+    </Tooltip>
+  ),
+  transactionTime: (
+    <Tooltip
+      placement="bottom"
+      title={
+        <div className={cx("tooltip__table--title")}>
+          <p>
+            Average service latency of transactions with this fingerprint within
+            the last hour or specified time interval.
+          </p>
+          <p>
+            The gray bar indicates the mean latency. The blue bar indicates one
+            standard deviation from the mean.
+          </p>
+        </div>
+      }
+    >
+      Transaction Time
     </Tooltip>
   ),
   maxMemUsage: (

--- a/packages/cluster-ui/src/statementsTable/statementsTableContent.tsx
+++ b/packages/cluster-ui/src/statementsTable/statementsTableContent.tsx
@@ -167,6 +167,30 @@ export const StatementTableTitle = {
       Transaction Time
     </Tooltip>
   ),
+  contention: (
+    <Tooltip
+      placement="bottom"
+      title={
+        <div className={cx("tooltip__table--title")}>
+          <p>
+            {
+              "Average time statements with this fingerprint spent contending on other queries within the last hour or specified "
+            }
+            <Anchor href={statementsTimeInterval} target="_blank">
+              time interval
+            </Anchor>
+            .
+          </p>
+          <p>
+            The gray bar indicates mean contention time. The blue bar indicates
+            one standard deviation from the mean.
+          </p>
+        </div>
+      }
+    >
+      Contention
+    </Tooltip>
+  ),
   maxMemUsage: (
     <Tooltip
       placement="bottom"
@@ -182,8 +206,8 @@ export const StatementTableTitle = {
             .
           </p>
           <p>
-            The gray bar indicates the mean number of rows returned. The blue
-            bar indicates one standard deviation from the mean.
+            The gray bar indicates the average max memory usage. The blue bar
+            indicates one standard deviation from the mean.
           </p>
         </div>
       }
@@ -206,8 +230,9 @@ export const StatementTableTitle = {
             .
           </p>
           <p>
-            The gray bar indicates the mean number of rows returned. The blue
-            bar indicates one standard deviation from the mean.
+            The gray bar indicates the mean number of bytes sent over the
+            network. The blue bar indicates one standard deviation from the
+            mean.
           </p>
         </div>
       }

--- a/packages/cluster-ui/src/statementsTable/statementsTableContent.tsx
+++ b/packages/cluster-ui/src/statementsTable/statementsTableContent.tsx
@@ -54,36 +54,6 @@ export const StatementTableTitle = {
       Statements
     </Tooltip>
   ),
-  txtType: (
-    <Tooltip
-      placement="bottom"
-      title={
-        <div className={cx("tooltip__table--title")}>
-          <p>
-            {
-              "Type of transaction (implicit or explicit). Explicit transactions refer to statements that are wrapped by "
-            }
-            <code>BEGIN</code>
-            {" and "}
-            <code>COMMIT</code>
-            {" statements by the client. Explicit transactions employ "}
-            <Anchor href={transactionalPipelining} target="_blank">
-              transactional pipelining
-            </Anchor>
-            {
-              " and therefore report latencies that do not account for replication."
-            }
-          </p>
-          <p>
-            For statements not in explicit transactions, CockroachDB wraps each
-            statement in individual implicit transactions.
-          </p>
-        </div>
-      }
-    >
-      TXN Type
-    </Tooltip>
-  ),
   executionCount: (
     <Tooltip
       placement="bottom"

--- a/packages/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/packages/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -26,6 +26,7 @@ import summaryCardStyles from "../summaryCard/summaryCard.module.scss";
 import transactionDetailsStyles from "./transactionDetails.modules.scss";
 import { Col, Row } from "antd";
 import { Text, Heading } from "@cockroachlabs/ui-components";
+import { formatTwoPlaces } from "../barCharts";
 
 const { containerClass } = tableClasses;
 
@@ -150,6 +151,7 @@ export class TransactionDetails extends React.Component<
                           <Text>
                             {formatNumberForDisplay(
                               transactionStats.rows_read.mean,
+                              formatTwoPlaces,
                             )}
                             {" / "}
                             {formatNumberForDisplay(

--- a/packages/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/packages/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -184,7 +184,17 @@ export class TransactionDetails extends React.Component<
                             )}
                           </Text>
                         </div>
-                        {/* TODO(asubiotto): Add temporary disk usage */}
+                        <div
+                          className={summaryCardStylesCx("summary--card__item")}
+                        >
+                          <Text type="body-strong">Max scratch disk usage</Text>
+                          <Text>
+                            {formatNumberForDisplay(
+                              transactionStats.exec_stats.max_disk_usage.mean,
+                              Bytes,
+                            )}
+                          </Text>
+                        </div>
                       </SummaryCard>
                     </Col>
                   </Row>

--- a/packages/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/packages/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -57,7 +57,8 @@ export class TransactionDetails extends React.Component<
 > {
   state: TState = {
     sortSetting: {
-      sortKey: 2,
+      // Sort by statement latency as default column.
+      sortKey: 4,
       ascending: false,
     },
     pagination: {

--- a/packages/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/packages/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -66,7 +66,8 @@ export class TransactionsPage extends React.Component<
 
   state: TState = {
     sortSetting: {
-      sortKey: 3,
+      // Sort by Execution Count column as default option.
+      sortKey: 1,
       ascending: false,
     },
     pagination: {

--- a/packages/cluster-ui/src/transactionsTable/transactionsBarCharts.ts
+++ b/packages/cluster-ui/src/transactionsTable/transactionsBarCharts.ts
@@ -44,6 +44,18 @@ const latencyBar = [
 const latencyStdDev = bar(cx("bar-chart__overall-dev"), (d: Transaction) =>
   stdDevLong(d.stats_data.stats.service_lat, d.stats_data.stats.count),
 );
+const contentionBar = [
+  bar(
+    "contention",
+    (d: Transaction) => d.stats_data.stats.exec_stats.contention_time?.mean,
+  ),
+];
+const contentionStdDev = bar(cx("contention-dev"), (d: Transaction) =>
+  stdDevLong(
+    d.stats_data.stats.exec_stats.contention_time,
+    d.stats_data.stats.exec_stats.count,
+  ),
+);
 const maxMemUsageBar = [
   bar("max-mem-usage", (d: Transaction) =>
     longToInt(d.stats_data.stats.exec_stats.max_mem_usage?.mean),
@@ -94,6 +106,12 @@ export const transactionsLatencyBarChart = barChartFactory(
   latencyBar,
   v => Duration(v * 1e9),
   latencyStdDev,
+);
+export const transactionsContentionBarChart = barChartFactory(
+  "grey",
+  contentionBar,
+  v => Duration(v * 1e9),
+  contentionStdDev,
 );
 export const transactionsMaxMemUsageBarChart = barChartFactory(
   "grey",

--- a/packages/cluster-ui/src/transactionsTable/transactionsTable.tsx
+++ b/packages/cluster-ui/src/transactionsTable/transactionsTable.tsx
@@ -6,6 +6,7 @@ import {
   transactionsRowsReadBarChart,
   transactionsBytesReadBarChart,
   transactionsLatencyBarChart,
+  transactionsContentionBarChart,
   transactionsMaxMemUsageBarChart,
   transactionsNetworkBytesBarChart,
   transactionsRetryBarChart,
@@ -68,6 +69,10 @@ export const TransactionsTable: React.FC<TransactionsTable> = props => {
     transactions,
     latencyClasses.barChart,
   );
+  const contentionBar = transactionsContentionBarChart(
+    transactions,
+    barChartOptions,
+  );
   const maxMemUsageBar = transactionsMaxMemUsageBarChart(
     transactions,
     barChartOptions,
@@ -124,6 +129,14 @@ export const TransactionsTable: React.FC<TransactionsTable> = props => {
       cell: latencyBar,
       className: latencyClasses.column,
       sort: (item: Transaction) => item.stats_data.stats.service_lat.mean,
+    },
+    {
+      name: "contention",
+      title: StatementTableTitle.contention,
+      cell: contentionBar,
+      className: cx("statements-table__col-contention"),
+      sort: (item: Transaction) =>
+        FixLong(Number(item.stats_data.stats.exec_stats.contention_time?.mean)),
     },
     {
       name: "max memory",

--- a/packages/cluster-ui/src/transactionsTable/transactionsTable.tsx
+++ b/packages/cluster-ui/src/transactionsTable/transactionsTable.tsx
@@ -120,7 +120,7 @@ export const TransactionsTable: React.FC<TransactionsTable> = props => {
     },
     {
       name: "latency",
-      title: StatementTableTitle.latency,
+      title: StatementTableTitle.transactionTime,
       cell: latencyBar,
       className: latencyClasses.column,
       sort: (item: Transaction) => item.stats_data.stats.service_lat.mean,


### PR DESCRIPTION
The first commit in this PR is #220, which should go in before this.

This PR addresses a lot of the nits observed in @awoods187' testing outlined in https://github.com/cockroachdb/cockroach/issues/60001.

The last two commits add contention and max disk usage information to the pages based on previously agreed on designs by @Annebirzin. Here are some visuals:

## Contention Time
![image](https://user-images.githubusercontent.com/10560359/108920331-7c28e880-7602-11eb-86d4-ef42f949d175.png)

## Max scratch disk usage
![image](https://user-images.githubusercontent.com/10560359/108920383-91057c00-7602-11eb-9b45-c3b0a8e49d09.png)