### PR TITLE
cluster-ui: add workflow_dispatch to pub action

### DIFF
--- a/.github/workflows/publish-cluster-ui.yml
+++ b/.github/workflows/publish-cluster-ui.yml
@@ -7,6 +7,7 @@ on:
       - cluster-ui-20.2
     paths:
       - "packages/cluster-ui/**"
+  workflow_dispatch:
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This action allows the manual triggering of the GitHub action from the
GitHub UI. Useful to retrigger builds from master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/ui/224)
<!-- Reviewable:end -->
