### PR TITLE
cluster-ui: clean up unused CSS import

### DIFF
--- a/packages/cluster-ui/src/statementDetails/statementDetails.module.scss
+++ b/packages/cluster-ui/src/statementDetails/statementDetails.module.scss
@@ -1,5 +1,4 @@
 @import "src/core/index.module";
-@import "~@cockroachlabs/design-tokens/dist/web/tokens";
 
 $max-window-width: 1350px;
 


### PR DESCRIPTION
cluster-ui had `design-tokens` import which
wasn't installed as dependency and caused failure
 during publishing.
