### PR TITLE
Refractor avatar unit tests to use react testing library

### DIFF
--- a/packages/ui-components/jest.testing.config.js
+++ b/packages/ui-components/jest.testing.config.js
@@ -5,7 +5,10 @@ module.exports = {
     "\\.(css|scss)$": "identity-obj-proxy",
   },
   roots: ["<rootDir>/src"],
-  setupFilesAfterEnv: ["jest-enzyme"],
+  setupFilesAfterEnv: [
+    "@testing-library/jest-dom/extend-expect",
+    "jest-enzyme",
+  ],
   testEnvironment: "enzyme",
   testRegex: "(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$",
   transform: {

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -15,7 +15,7 @@
     "build:watch": "webpack --watch",
     "ci": "jest --ci -i",
     "clean": "rm -rf  ./dist/*",
-    "lint": "eslint ./src/**/*.{tsx,ts,js} --format=codeframe",
+    "lint": "eslint \"src/**/*.{tsx,ts,js}\" --format=codeframe",
     "prepublishOnly": "npm-run-all clean build",
     "test": "jest --watch",
     "test:version": "npm version prerelease --preid='alpha'",

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -41,6 +41,8 @@
     "@babel/preset-typescript": "^7.8.0",
     "@cockroachlabs/design-tokens": "^0.3.0",
     "@cockroachlabs/eslint-config": "^0.1.11",
+    "@testing-library/jest-dom": "^5.11.9",
+    "@testing-library/react": "^11.2.5",
     "@types/classnames": "^2.2.9",
     "@types/enzyme": "^3.10.5",
     "@types/jest": "^25.1.2",

--- a/packages/ui-components/src/Avatar/Avatar.test.tsx
+++ b/packages/ui-components/src/Avatar/Avatar.test.tsx
@@ -56,14 +56,12 @@ describe("Avatar", () => {
   describe("Content rendering", () => {
     it("renders with string passed as children", () => {
       render(<Avatar>foo bar</Avatar>);
-      const textContent = screen.getByTestId("avatar").textContent;
-      expect(textContent).toBe("foo bar");
+      expect(screen.getByTestId("avatar")).toHaveTextContent("foo bar");
     });
 
     it("renders with empty content", () => {
       render(<Avatar />);
-      const textContent = screen.getByTestId("avatar").textContent;
-      expect(textContent).toBe("");
+      expect(screen.getByTestId("avatar")).toHaveTextContent("");
     });
 
     it("renders with svg passed as children", () => {

--- a/packages/ui-components/src/Avatar/Avatar.test.tsx
+++ b/packages/ui-components/src/Avatar/Avatar.test.tsx
@@ -1,7 +1,13 @@
 import React from "react";
 import { render, fireEvent, screen } from "@testing-library/react";
 
-import Avatar, { AvatarIntent, AvatarSize } from "./Avatar";
+import UiAvatar, { AvatarIntent, AvatarSize, AvatarProps } from "./Avatar";
+
+const Avatar: React.FC<AvatarProps> = ({ children, ...props }) => (
+  <UiAvatar data-testid="avatar" {...props}>
+    {children}
+  </UiAvatar>
+);
 
 describe("Avatar", () => {
   describe("Default props", () => {

--- a/packages/ui-components/src/Avatar/Avatar.test.tsx
+++ b/packages/ui-components/src/Avatar/Avatar.test.tsx
@@ -7,12 +7,15 @@ describe("Avatar", () => {
   describe("Default props", () => {
     it("assigns default style classes based on props", () => {
       render(<Avatar>CL</Avatar>);
-      const className = screen.getByTestId("avatar").className;
-      expect(className).toContain("intent-default");
-      expect(className).toContain("size-default");
-      expect(className).toContain("transformCase-uppercase");
-      expect(className).not.toContain("disabled");
-      expect(className).not.toContain("selectable");
+      expect(screen.getByTestId("avatar")).toHaveClass(
+        "intent-default",
+        "size-default",
+        "transformCase-uppercase",
+      );
+      expect(screen.getByTestId("avatar")).not.toHaveClass(
+        "disabled",
+        "selectable",
+      );
     });
   });
 
@@ -20,16 +23,19 @@ describe("Avatar", () => {
     it("appends user provided className", () => {
       const testClass = "nathan-test-stuff";
       render(<Avatar className={testClass}>NS</Avatar>);
-      const className = screen.getByTestId("avatar").className;
-      expect(className).toContain(testClass);
-      expect(className).toContain("intent-default");
+      expect(screen.getByTestId("avatar")).toHaveClass(
+        testClass,
+        "intent-default",
+      );
     });
 
     it("accepts data attributes", () => {
       const datatest = "nathan-data";
       render(<Avatar data-test={datatest}>NS</Avatar>);
-      const result = screen.getByTestId("avatar").dataset["test"];
-      expect(result).toBe(datatest);
+      expect(screen.getByTestId("avatar")).toHaveAttribute(
+        "data-test",
+        datatest,
+      );
     });
   });
 
@@ -89,8 +95,8 @@ describe("Avatar", () => {
     intents.forEach(intent => {
       it("applies correct classNames depending on intent", () => {
         expect(
-          render(<Avatar intent={intent} />).getByTestId("avatar").className,
-        ).toContain(`intent-${intent}`);
+          render(<Avatar intent={intent} />).getByTestId("avatar"),
+        ).toHaveClass(`intent-${intent}`);
       });
     });
   });
@@ -101,25 +107,23 @@ describe("Avatar", () => {
     sizes.forEach(size => {
       it("applies correct classNames depending on size", () => {
         expect(
-          render(<Avatar size={size} />).getByTestId("avatar").className,
-        ).toContain(`size-${size}`);
+          render(<Avatar size={size} />).getByTestId("avatar"),
+        ).toHaveClass(`size-${size}`);
       });
     });
   });
 
   describe("Disabled prop", () => {
     it("excludes intent className", () => {
-      const { getByTestId } = render(<Avatar intent="invalid" disabled />);
-      const className = getByTestId("avatar").className;
-      expect(className.includes("disabled")).toBeTruthy();
-      expect(className.includes("intent-invalid")).toBeFalsy();
+      render(<Avatar intent="invalid" disabled />);
+      expect(screen.getByTestId("avatar")).toHaveClass("disabled");
+      expect(screen.getByTestId("avatar")).not.toHaveClass("intent-invalid");
     });
 
     it("excludes selectable className", () => {
-      const { getByTestId } = render(<Avatar disabled selectable />);
-      const className = getByTestId("avatar").className;
-      expect(className.includes("disabled")).toBeTruthy();
-      expect(className.includes("selectable")).toBeFalsy();
+      render(<Avatar disabled selectable />);
+      expect(screen.getByTestId("avatar")).toHaveClass("disabled");
+      expect(screen.getByTestId("avatar")).not.toHaveClass("selectable");
     });
   });
 });

--- a/packages/ui-components/src/Avatar/Avatar.test.tsx
+++ b/packages/ui-components/src/Avatar/Avatar.test.tsx
@@ -1,13 +1,13 @@
 import React from "react";
-import { shallow } from "enzyme";
+import { render, fireEvent, screen } from "@testing-library/react";
 
 import Avatar, { AvatarIntent, AvatarSize } from "./Avatar";
 
 describe("Avatar", () => {
   describe("Default props", () => {
     it("assigns default style classes based on props", () => {
-      const wrapper = shallow(<Avatar>CL</Avatar>);
-      const className = wrapper.prop("className");
+      render(<Avatar>CL</Avatar>);
+      const className = screen.getByTestId("avatar").className;
       expect(className).toContain("intent-default");
       expect(className).toContain("size-default");
       expect(className).toContain("transformCase-uppercase");
@@ -19,57 +19,69 @@ describe("Avatar", () => {
   describe("Native element props", () => {
     it("appends user provided className", () => {
       const testClass = "nathan-test-stuff";
-      const wrapper = shallow(<Avatar className={testClass}>NS</Avatar>);
-      const className = wrapper.prop("className");
+      render(<Avatar className={testClass}>NS</Avatar>);
+      const className = screen.getByTestId("avatar").className;
       expect(className).toContain(testClass);
       expect(className).toContain("intent-default");
     });
 
     it("accepts data attributes", () => {
       const datatest = "nathan-data";
-      const wrapper = shallow(<Avatar data-test={datatest}>NS</Avatar>);
-      const result = wrapper.prop("data-test");
+      render(<Avatar data-test={datatest}>NS</Avatar>);
+      const result = screen.getByTestId("avatar").dataset["test"];
       expect(result).toBe(datatest);
     });
   });
 
   describe("Handle onClick prop", () => {
     it("calls callback function on element click", () => {
-      const onClickSpy = jasmine.createSpy();
-      const wrapper = shallow(<Avatar onClick={onClickSpy}>CL</Avatar>);
-      wrapper.simulate("click");
+      const onClickSpy = jest.fn();
+      render(<Avatar onClick={onClickSpy}>CL</Avatar>);
+      fireEvent.click(screen.getByTestId("avatar"));
       expect(onClickSpy).toHaveBeenCalled();
     });
 
     it("does not call onClick function when disabled prop is True", () => {
-      const onClickSpy = jasmine.createSpy();
-      const wrapper = shallow(
+      const onClickSpy = jest.fn();
+      render(
         <Avatar disabled={true} onClick={onClickSpy}>
           CL
         </Avatar>,
       );
-      wrapper.simulate("click");
+      fireEvent.click(screen.getByTestId("avatar"));
       expect(onClickSpy).not.toHaveBeenCalled();
     });
   });
 
   describe("Content rendering", () => {
     it("renders with string passed as children", () => {
-      expect(shallow(<Avatar>foo bar</Avatar>).text()).toEqual("foo bar");
+      render(<Avatar>foo bar</Avatar>);
+      const textContent = screen.getByTestId("avatar").textContent;
+      expect(textContent).toBe("foo bar");
     });
 
     it("renders with empty content", () => {
-      expect(shallow(<Avatar />).text()).toEqual("");
+      render(<Avatar />);
+      const textContent = screen.getByTestId("avatar").textContent;
+      expect(textContent).toBe("");
     });
 
     it("renders with svg passed as children", () => {
       const svg = <svg />;
-      expect(shallow(<Avatar>{svg}</Avatar>).find("svg")).toHaveLength(1);
+      expect(
+        render(<Avatar>{svg}</Avatar>)
+          .getByTestId("avatar")
+          .getElementsByTagName("svg"),
+      ).toHaveLength(1);
     });
 
     it("renders with svg passed as children", () => {
       const img = <img />;
-      expect(shallow(<Avatar>{img}</Avatar>).find("img")).toHaveLength(1);
+      expect(
+        render(<Avatar>{img}</Avatar>)
+          .getByTestId("avatar")
+          .getElementsByTagName("img"),
+      ).toHaveLength(1);
     });
   });
 
@@ -79,10 +91,8 @@ describe("Avatar", () => {
     intents.forEach(intent => {
       it("applies correct classNames depending on intent", () => {
         expect(
-          shallow(<Avatar intent={intent} />)
-            .find("div.avatar")
-            .hasClass(`intent-${intent}`),
-        ).toBeTruthy();
+          render(<Avatar intent={intent} />).getByTestId("avatar").className,
+        ).toContain(`intent-${intent}`);
       });
     });
   });
@@ -93,25 +103,25 @@ describe("Avatar", () => {
     sizes.forEach(size => {
       it("applies correct classNames depending on size", () => {
         expect(
-          shallow(<Avatar size={size} />)
-            .find("div.avatar")
-            .hasClass(`size-${size}`),
-        ).toBeTruthy();
+          render(<Avatar size={size} />).getByTestId("avatar").className,
+        ).toContain(`size-${size}`);
       });
     });
   });
 
   describe("Disabled prop", () => {
     it("excludes intent className", () => {
-      const wrapper = shallow(<Avatar intent="invalid" disabled />);
-      expect(wrapper.hasClass("disabled")).toBeTruthy();
-      expect(wrapper.hasClass("intent-invalid")).toBeFalsy();
+      const { getByTestId } = render(<Avatar intent="invalid" disabled />);
+      const className = getByTestId("avatar").className;
+      expect(className.includes("disabled")).toBeTruthy();
+      expect(className.includes("intent-invalid")).toBeFalsy();
     });
 
     it("excludes selectable className", () => {
-      const wrapper = shallow(<Avatar disabled selectable />);
-      expect(wrapper.hasClass("disabled")).toBeTruthy();
-      expect(wrapper.hasClass("selectable")).toBeFalsy();
+      const { getByTestId } = render(<Avatar disabled selectable />);
+      const className = getByTestId("avatar").className;
+      expect(className.includes("disabled")).toBeTruthy();
+      expect(className.includes("selectable")).toBeFalsy();
     });
   });
 });

--- a/packages/ui-components/src/Avatar/Avatar.tsx
+++ b/packages/ui-components/src/Avatar/Avatar.tsx
@@ -59,12 +59,7 @@ export const Avatar: React.FC<AvatarProps> = ({
   }, [onClick, disabled]);
 
   return (
-    <div
-      data-testid="avatar"
-      className={classnames}
-      onClick={onClickHandler}
-      {...rest}
-    >
+    <div className={classnames} onClick={onClickHandler} {...rest}>
       {children}
     </div>
   );

--- a/packages/ui-components/src/Avatar/Avatar.tsx
+++ b/packages/ui-components/src/Avatar/Avatar.tsx
@@ -59,7 +59,12 @@ export const Avatar: React.FC<AvatarProps> = ({
   }, [onClick, disabled]);
 
   return (
-    <div className={classnames} onClick={onClickHandler} {...rest}>
+    <div
+      data-testid="avatar"
+      className={classnames}
+      onClick={onClickHandler}
+      {...rest}
+    >
       {children}
     </div>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1373,6 +1373,14 @@
     pirates "^4.0.0"
     source-map-support "^0.5.16"
 
+"@babel/runtime-corejs3@^7.10.2":
+  version "7.13.8"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.13.8.tgz#149749463be6692e3688584130e4300beba0e93c"
+  integrity sha512-iaInhjy1BbDnqc7pZiIXAfWvBnczgWobHceR4Wkhs5tWZG8aIazBYH0Vo73lixecHKh3Vy9yqbQBqVDrmcVDlQ==
+  dependencies:
+    core-js-pure "^3.0.0"
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@7.9.0":
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.0.tgz#337eda67401f5b066a6f205a3113d4ac18ba495b"
@@ -1384,6 +1392,13 @@
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
   integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5":
+  version "7.13.8"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.8.tgz#cc886a85c072df1de23670dc1aa59fc116c4017c"
+  integrity sha512-CwQljpw6qSayc0fRG1soxHAKs1CnQMOChm4mlQP6My0kf9upVGizj/KhlTTgyUnETmHpcUXjaluNAkteRFuafg==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -3860,10 +3875,51 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
+"@testing-library/dom@^7.28.1":
+  version "7.29.6"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.29.6.tgz#eb37844fb431186db7960a7ff6749ea65a19617c"
+  integrity sha512-vzTsAXa439ptdvav/4lsKRcGpAQX7b6wBIqia7+iNzqGJ5zjswApxA6jDAsexrc6ue9krWcbh8o+LYkBXW+GCQ==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^4.2.2"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.4"
+    lz-string "^1.4.4"
+    pretty-format "^26.6.2"
+
+"@testing-library/jest-dom@^5.11.9":
+  version "5.11.9"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.11.9.tgz#e6b3cd687021f89f261bd53cbe367041fbd3e975"
+  integrity sha512-Mn2gnA9d1wStlAIT2NU8J15LNob0YFBVjs2aEQ3j8rsfRQo+lAs7/ui1i2TGaJjapLmuNPLTsrm+nPjmZDwpcQ==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    "@types/testing-library__jest-dom" "^5.9.1"
+    aria-query "^4.2.2"
+    chalk "^3.0.0"
+    css "^3.0.0"
+    css.escape "^1.5.1"
+    lodash "^4.17.15"
+    redent "^3.0.0"
+
+"@testing-library/react@^11.2.5":
+  version "11.2.5"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.5.tgz#ae1c36a66c7790ddb6662c416c27863d87818eb9"
+  integrity sha512-yEx7oIa/UWLe2F2dqK0FtMF9sJWNXD+2PPtp39BvE0Kh9MJ9Kl0HrZAgEuhUJR+Lx8Di6Xz+rKwSdEPY2UV8ZQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@testing-library/dom" "^7.28.1"
+
 "@types/anymatch@*":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
   integrity sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==
+
+"@types/aria-query@^4.2.0":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.1.tgz#78b5433344e2f92e8b306c06a5622c50c245bf6b"
+  integrity sha512-S6oPal772qJZHoRZLFc/XoZW2gFvwXusYUmXPXkgxJLuEk2vOt7jc4Yo6z/vtI0EBkbPBVrJJ0B+prLIKiWqHg==
 
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.1.12"
@@ -4064,6 +4120,14 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
+"@types/jest@*":
+  version "26.0.20"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.20.tgz#cd2f2702ecf69e86b586e1f5223a60e454056307"
+  integrity sha512-9zi2Y+5USJRxd0FsahERhBwlcvFh6D2GLQnY2FH2BzK8J9s9omvNHIbvABwIluXa0fD8XVKMLTO0aOEuUfACAA==
+  dependencies:
+    jest-diff "^26.0.0"
+    pretty-format "^26.0.0"
+
 "@types/jest@^25.1.2":
   version "25.2.3"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-25.2.3.tgz#33d27e4c4716caae4eced355097a47ad363fdcaf"
@@ -4254,7 +4318,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.9.48":
+"@types/react@*", "@types/react@16.9.48", "@types/react@^16.9.48":
   version "16.9.48"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.48.tgz#d3387329f070d1b1bc0ff4a54a54ceefd5a8485c"
   integrity sha512-4ykBVswgYitPGMXFRxJCHkxJDU2rjfU3/zw67f8+dB7sNdVJXsrwqoYxz/stkAucymnEEbRPFmX7Ce5Mc/kJCw==
@@ -4321,6 +4385,13 @@
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.6.tgz#a9ca4b70a18b270ccb2bc0aaafefd1d486b7ea74"
   integrity sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==
+
+"@types/testing-library__jest-dom@^5.9.1":
+  version "5.9.5"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.5.tgz#5bf25c91ad2d7b38f264b12275e5c92a66d849b0"
+  integrity sha512-ggn3ws+yRbOHog9GxnXiEZ/35Mow6YtPZpd7Z5mKDeZS/o7zx3yAle0ov/wjhVB5QT4N2Dt+GNoGCdqkBGCajQ==
+  dependencies:
+    "@types/jest" "*"
 
 "@types/uglify-js@*":
   version "3.11.1"
@@ -5023,6 +5094,14 @@ argparse@^1.0.7:
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
+
+aria-query@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
+  integrity sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
+    "@babel/runtime-corejs3" "^7.10.2"
 
 arr-diff@^4.0.0:
   version "4.0.0"
@@ -7037,6 +7116,11 @@ core-js-compat@^3.6.2, core-js-compat@^3.8.0:
     browserslist "^4.15.0"
     semver "7.0.0"
 
+core-js-pure@^3.0.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.9.0.tgz#326cc74e1fef8b7443a6a793ddb0adfcd81f9efb"
+  integrity sha512-3pEcmMZC9Cq0D4ZBh3pe2HLtqxpGNJBLXF/kZ2YzK17RbKp94w0HFbdbSx8H8kAlZG5k76hvLrkPm57Uyef+kg==
+
 core-js-pure@^3.0.1:
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.8.1.tgz#23f84048f366fdfcf52d3fd1c68fec349177d119"
@@ -7292,6 +7376,20 @@ css-what@^3.2.1:
   version "3.4.2"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-3.4.2.tgz#ea7026fcb01777edbde52124e21f327e7ae950e4"
   integrity sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==
+
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
+
+css@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css/-/css-3.0.0.tgz#4447a4d58fdd03367c516ca9f64ae365cee4aa5d"
+  integrity sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==
+  dependencies:
+    inherits "^2.0.4"
+    source-map "^0.6.1"
+    source-map-resolve "^0.6.0"
 
 cssesc@^3.0.0:
   version "3.0.0"
@@ -7706,6 +7804,11 @@ diff-sequences@^25.2.6:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-25.2.6.tgz#5f467c00edd35352b7bca46d7927d60e687a76dd"
   integrity sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==
 
+diff-sequences@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
+  integrity sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==
+
 diff@^4.0.1, diff@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
@@ -7775,6 +7878,11 @@ doctypes@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/doctypes/-/doctypes-1.1.0.tgz#ea80b106a87538774e8a3a4a5afe293de489e0a9"
   integrity sha1-6oCxBqh1OHdOijpKWv4pPeSJ4Kk=
+
+dom-accessibility-api@^0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.4.tgz#b06d059cdd4a4ad9a79275f9d414a5c126241166"
+  integrity sha512-TvrjBckDy2c6v6RLxPv5QXOnU+SmF9nBII5621Ve5fu6Z/BDrENurBEvlC1f44lKEUVqOpK4w9E5Idc5/EgkLQ==
 
 dom-align@^1.7.0:
   version "1.12.0"
@@ -7887,12 +7995,26 @@ dot-case@^3.0.4:
     no-case "^3.0.4"
     tslib "^2.0.3"
 
-dot-prop@^3.0.0, dot-prop@^4.2.0, dot-prop@^4.2.1, dot-prop@^5.2.0:
+dot-prop@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-3.0.0.tgz#1b708af094a49c9a0e7dbcad790aba539dac1177"
+  integrity sha1-G3CK8JSknJoOfbyteQq6U52sEXc=
+  dependencies:
+    is-obj "^1.0.0"
+
+dot-prop@^4.2.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.1.tgz#45884194a71fc2cda71cbb4bceb3a4dd2f433ba4"
   integrity sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==
   dependencies:
     is-obj "^1.0.0"
+
+dot-prop@^5.2.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-5.3.0.tgz#90ccce708cd9cd82cc4dc8c3ddd9abdd55b20e88"
+  integrity sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==
+  dependencies:
+    is-obj "^2.0.0"
 
 dotenv-defaults@^1.0.2:
   version "1.1.1"
@@ -10852,6 +10974,11 @@ is-obj@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
   integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
 
+is-obj@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-2.0.0.tgz#473fb05d973705e3fd9620545018ca8e22ef4982"
+  integrity sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==
+
 is-object@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.2.tgz#a56552e1c665c9e950b4a025461da87e72f86fcf"
@@ -11187,6 +11314,16 @@ jest-diff@^25.2.1, jest-diff@^25.5.0:
     jest-get-type "^25.2.6"
     pretty-format "^25.5.0"
 
+jest-diff@^26.0.0:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.6.2.tgz#1aa7468b52c3a68d7d5c5fdcdfcd5e49bd164394"
+  integrity sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^26.6.2"
+    jest-get-type "^26.3.0"
+    pretty-format "^26.6.2"
+
 jest-docblock@^25.3.0:
   version "25.3.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-25.3.0.tgz#8b777a27e3477cd77a168c05290c471a575623ef"
@@ -11269,6 +11406,11 @@ jest-get-type@^25.2.6:
   version "25.2.6"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-25.2.6.tgz#0b0a32fab8908b44d508be81681487dbabb8d877"
   integrity sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==
+
+jest-get-type@^26.3.0:
+  version "26.3.0"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.3.0.tgz#e97dc3c3f53c2b406ca7afaed4493b1d099199e0"
+  integrity sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==
 
 jest-haste-map@^24.9.0:
   version "24.9.0"
@@ -12495,6 +12637,11 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
+  integrity sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
 
 macos-release@^2.2.0:
   version "2.3.0"
@@ -14527,6 +14674,16 @@ pretty-format@^25.2.1, pretty-format@^25.5.0:
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
 
+pretty-format@^26.0.0, pretty-format@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
+  integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==
+  dependencies:
+    "@jest/types" "^26.6.2"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^17.0.1"
+
 pretty-hrtime@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
@@ -15644,6 +15801,11 @@ react-is@^16.12.0, react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^17.0.1:
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
+  integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
 
 react-lazy-load@^3.0.13:
   version "3.1.13"
@@ -17400,6 +17562,14 @@ source-map-resolve@^0.5.0:
     resolve-url "^0.2.1"
     source-map-url "^0.4.0"
     urix "^0.1.0"
+
+source-map-resolve@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.6.0.tgz#3d9df87e236b53f16d01e58150fc7711138e5ed2"
+  integrity sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==
+  dependencies:
+    atob "^2.1.2"
+    decode-uri-component "^0.2.0"
 
 source-map-support@^0.5.11, source-map-support@^0.5.16, source-map-support@^0.5.19, source-map-support@^0.5.6, source-map-support@^0.5.7, source-map-support@~0.5.12:
   version "0.5.19"


### PR DESCRIPTION
# Refractor avatar unit tests to use react testing library

 - [x] Add `react testing library` library to package.json
 - [x] refractor `Avatar` component unit tests from to use `react testing library` and not  `enzyme`.

#### Checklist
- [x] I have written or updated the test for the changes I made
- [ ] I have updated the README of the package I'm working in to reflect my changes
- [ ] I have added or updated Storybook if appropriate for my changes

Fixes #81