### PR TITLE
[WIP] ui: add filter component to statements page

### DIFF
--- a/packages/cluster-ui/src/statementsPage/utils.ts
+++ b/packages/cluster-ui/src/statementsPage/utils.ts
@@ -1,0 +1,41 @@
+import { Filters } from "./";
+import { AggregateStatistics } from "../statementsTable";
+
+function getTimeValue(timeNumber: string, timeUnit: string): number | "empty" {
+  if (arguments.length < 2 || timeNumber === "0") return "empty";
+  return timeUnit === "seconds"
+    ? Number(timeNumber)
+    : Number(timeNumber) / 1000;
+}
+
+export const filterTransactions = (
+  data: AggregateStatistics[],
+  filters: Filters,
+): { statements: AggregateStatistics[]; activeFilters: number } => {
+  if (!filters)
+    return {
+      statements: data,
+      activeFilters: 0,
+    };
+  const { timeNumber, timeUnit } = filters;
+  const timeValue = getTimeValue(timeNumber, timeUnit);
+  const filtersStatus = [
+    timeValue && timeValue !== "empty",
+    filters.app !== "All",
+  ];
+  const activeFilters = filtersStatus.filter(f => f).length;
+
+  const filteredStatements = data.filter((t: AggregateStatistics) => {
+    const filterIsSetToAll = filters.app === "All";
+    const validateTransaction = [
+      filterIsSetToAll,
+      t.stats.service_lat.mean >= timeValue || timeValue === "empty",
+    ];
+    return validateTransaction.every(f => f);
+  });
+
+  return {
+    statements: filteredStatements,
+    activeFilters,
+  };
+};


### PR DESCRIPTION
Signed-off-by: Tharun <rajendrantharun@live.com>
<img width="1673" alt="Screen Shot 2021-03-04 at 11 09 49 PM" src="https://user-images.githubusercontent.com/14926492/110009065-82c20900-7d42-11eb-89cf-5708865f414c.png">


I am able to start with the basic functionality working. But, we need to extend the `ICollectedStatementStatistics` interface as same as `IExtendedCollectedTransactionStatistics` to include the `app` name to make the filtering work.

cc @dhartunian @barryhe2000 