### PR TITLE
cluster-ui: update tooltips and add "no samples" tooltip on statements/transaction pages

### DIFF
--- a/packages/cluster-ui/src/statementsTable/statementsTable.tsx
+++ b/packages/cluster-ui/src/statementsTable/statementsTable.tsx
@@ -24,6 +24,7 @@ import {
 } from "./statementsTableContent";
 
 type IStatementDiagnosticsReport = cockroach.server.serverpb.IStatementDiagnosticsReport;
+type ICollectedStatementStatistics = cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
 import styles from "./statementsTable.module.scss";
 const cx = classNames.bind(styles);
 const longToInt = (d: number | Long) => Number(FixLong(d));
@@ -31,21 +32,36 @@ const longToInt = (d: number | Long) => Number(FixLong(d));
 function makeCommonColumns(
   statements: AggregateStatistics[],
 ): ColumnDescriptor<AggregateStatistics>[] {
-  const barChartOptions = {
+  const defaultBarChartOptions = {
     classes: {
       root: cx("statements-table__col--bar-chart"),
       label: cx("statements-table__col--bar-chart__label"),
     },
   };
+  const sampledExecStatsBarChartOptions = {
+    classes: defaultBarChartOptions.classes,
+    displayNoSamples: (d: ICollectedStatementStatistics) => {
+      return longToInt(d.stats.exec_stats?.count) == 0;
+    },
+  };
 
-  const countBar = countBarChart(statements, barChartOptions);
-  const rowsReadBar = rowsReadBarChart(statements, barChartOptions);
-  const bytesReadBar = bytesReadBarChart(statements, barChartOptions);
-  const latencyBar = latencyBarChart(statements, barChartOptions);
-  const contentionBar = contentionBarChart(statements, barChartOptions);
-  const maxMemUsageBar = maxMemUsageBarChart(statements, barChartOptions);
-  const networkBytesBar = networkBytesBarChart(statements, barChartOptions);
-  const retryBar = retryBarChart(statements, barChartOptions);
+  const countBar = countBarChart(statements, defaultBarChartOptions);
+  const rowsReadBar = rowsReadBarChart(statements, defaultBarChartOptions);
+  const bytesReadBar = bytesReadBarChart(statements, defaultBarChartOptions);
+  const latencyBar = latencyBarChart(statements, defaultBarChartOptions);
+  const contentionBar = contentionBarChart(
+    statements,
+    sampledExecStatsBarChartOptions,
+  );
+  const maxMemUsageBar = maxMemUsageBarChart(
+    statements,
+    sampledExecStatsBarChartOptions,
+  );
+  const networkBytesBar = networkBytesBarChart(
+    statements,
+    sampledExecStatsBarChartOptions,
+  );
+  const retryBar = retryBarChart(statements, defaultBarChartOptions);
 
   return [
     {

--- a/packages/cluster-ui/src/statementsTable/statementsTableContent.tsx
+++ b/packages/cluster-ui/src/statementsTable/statementsTableContent.tsx
@@ -18,7 +18,10 @@ import {
   statementsRetries,
   statementsSql,
   statementsTimeInterval,
-  transactionalPipelining,
+  readFromDisk,
+  planningExecutionTime,
+  contentionTime,
+  readsAndWrites,
   summarize,
   TimestampToMoment,
 } from "src/util";
@@ -87,8 +90,12 @@ export const StatementTableTitle = {
       title={
         <div className={cx("tooltip__table--title")}>
           <p>
+            {"Aggregation of all rows "}
+            <Anchor href={readFromDisk} target="_blank">
+              read from disk
+            </Anchor>
             {
-              "Average number of rows read while executing statements with this fingerprint within the last hour or specified "
+              " across all operators for statements with this fingerprint within the last hour or specified "
             }
             <Anchor href={statementsTimeInterval} target="_blank">
               time interval
@@ -96,8 +103,8 @@ export const StatementTableTitle = {
             .
           </p>
           <p>
-            The gray bar indicates the mean number of rows returned. The blue
-            bar indicates one standard deviation from the mean.
+            The gray bar indicates the mean number of rows read from disk. The
+            blue bar indicates one standard deviation from the mean.
           </p>
         </div>
       }
@@ -111,8 +118,12 @@ export const StatementTableTitle = {
       title={
         <div className={cx("tooltip__table--title")}>
           <p>
+            {"Aggregation of all bytes "}
+            <Anchor href={readFromDisk} target="_blank">
+              read from disk
+            </Anchor>
             {
-              "Average number of bytes read while executing statements with this fingerprint within the last hour or specified "
+              " across all operators for statements with this fingerprint within the last hour or specified "
             }
             <Anchor href={statementsTimeInterval} target="_blank">
               time interval
@@ -120,8 +131,8 @@ export const StatementTableTitle = {
             .
           </p>
           <p>
-            The gray bar indicates the mean number of rows returned. The blue
-            bar indicates one standard deviation from the mean.
+            The gray bar indicates the mean number of bytes read from disk. The
+            blue bar indicates one standard deviation from the mean.
           </p>
         </div>
       }
@@ -135,8 +146,13 @@ export const StatementTableTitle = {
       title={
         <div className={cx("tooltip__table--title")}>
           <p>
-            Average service latency of statements with this fingerprint within
-            the last hour or specified time interval.
+            {"Average "}
+            <Anchor href={planningExecutionTime} target="_blank">
+              planning and execution time
+            </Anchor>
+            {
+              " of statements with this fingerprint within the last hour or specified time interval."
+            }
           </p>
           <p>
             The gray bar indicates the mean latency. The blue bar indicates one
@@ -154,8 +170,13 @@ export const StatementTableTitle = {
       title={
         <div className={cx("tooltip__table--title")}>
           <p>
-            Average service latency of transactions with this fingerprint within
-            the last hour or specified time interval.
+            {"Average "}
+            <Anchor href={planningExecutionTime} target="_blank">
+              planning and execution time
+            </Anchor>
+            {
+              " of transactions with this fingerprint within the last hour or specified time interval."
+            }
           </p>
           <p>
             The gray bar indicates the mean latency. The blue bar indicates one
@@ -173,9 +194,11 @@ export const StatementTableTitle = {
       title={
         <div className={cx("tooltip__table--title")}>
           <p>
-            {
-              "Average time statements with this fingerprint spent contending on other queries within the last hour or specified "
-            }
+            {"Average time statements with this fingerprint were "}
+            <Anchor href={contentionTime} target="_blank">
+              in contention
+            </Anchor>
+            {" with other transactions within the last hour or specified "}
             <Anchor href={statementsTimeInterval} target="_blank">
               time interval
             </Anchor>
@@ -198,7 +221,7 @@ export const StatementTableTitle = {
         <div className={cx("tooltip__table--title")}>
           <p>
             {
-              "Average of the maximum memory used while executing statements with this fingerprint within the last hour or specified "
+              "Maximum memory used by a statement with this fingerprint at any time during its execution within the last hour or specified "
             }
             <Anchor href={statementsTimeInterval} target="_blank">
               time interval
@@ -221,13 +244,20 @@ export const StatementTableTitle = {
       title={
         <div className={cx("tooltip__table--title")}>
           <p>
+            {"Amount of data "}
+            <Anchor href={readsAndWrites} target="_blank">
+              data transferred over the network
+            </Anchor>
             {
-              "Average number of bytes sent over the network while executing statements with this fingerprint within the last hour or specified "
+              " (e.g., between regions and nodes) for statements with this fingerprint within the last hour or speicifed "
             }
             <Anchor href={statementsTimeInterval} target="_blank">
               time interval
             </Anchor>
             .
+          </p>
+          <p>
+            If this value is 0, the statement was executed on a single node.
           </p>
           <p>
             The gray bar indicates the mean number of bytes sent over the

--- a/packages/cluster-ui/src/transactionsTable/transactionsTable.tsx
+++ b/packages/cluster-ui/src/transactionsTable/transactionsTable.tsx
@@ -48,10 +48,16 @@ const { latencyClasses } = tableClasses;
 const cx = classNames.bind(statementsPageStyles);
 
 export const TransactionsTable: React.FC<TransactionsTable> = props => {
-  const barChartOptions = {
+  const defaultBarChartOptions = {
     classes: {
       root: cx("statements-table__col--bar-chart"),
       label: cx("statements-table__col--bar-chart__label"),
+    },
+  };
+  const sampledExecStatsBarChartOptions = {
+    classes: defaultBarChartOptions.classes,
+    displayNoSamples: (d: Transaction) => {
+      return longToInt(d.stats_data.stats.exec_stats?.count) == 0;
     },
   };
 
@@ -59,11 +65,11 @@ export const TransactionsTable: React.FC<TransactionsTable> = props => {
   const countBar = transactionsCountBarChart(transactions);
   const rowsReadBar = transactionsRowsReadBarChart(
     transactions,
-    barChartOptions,
+    defaultBarChartOptions,
   );
   const bytesReadBar = transactionsBytesReadBarChart(
     transactions,
-    barChartOptions,
+    defaultBarChartOptions,
   );
   const latencyBar = transactionsLatencyBarChart(
     transactions,
@@ -71,15 +77,15 @@ export const TransactionsTable: React.FC<TransactionsTable> = props => {
   );
   const contentionBar = transactionsContentionBarChart(
     transactions,
-    barChartOptions,
+    sampledExecStatsBarChartOptions,
   );
   const maxMemUsageBar = transactionsMaxMemUsageBarChart(
     transactions,
-    barChartOptions,
+    sampledExecStatsBarChartOptions,
   );
   const networkBytesBar = transactionsNetworkBytesBarChart(
     transactions,
-    barChartOptions,
+    sampledExecStatsBarChartOptions,
   );
   const retryBar = transactionsRetryBarChart(transactions);
   const columns = [

--- a/packages/cluster-ui/src/util/docs.ts
+++ b/packages/cluster-ui/src/util/docs.ts
@@ -48,6 +48,16 @@ export const statementsRetries = docsURL(
 export const statementsTimeInterval = docsURL(
   "admin-ui-statements-page.html#time-interval",
 );
+export const readFromDisk = docsURL(
+  "architecture/life-of-a-distributed-transaction.html#reads-from-the-storage-layer",
+);
+export const planningExecutionTime = docsURL(
+  "architecture/sql-layer#sql-parser-planner-executor",
+);
+export const contentionTime = docsURL(
+  "performance-best-practices-overview#understanding-and-avoiding-transaction-contention",
+);
+export const readsAndWrites = docsURL("architecture/reads-and-writes-overview");
 export const capacityMetrics = docsURL(
   "admin-ui-cluster-overview.html#capacity-metrics",
 );


### PR DESCRIPTION
This PR updates the tooltip text according to this figma design: https://www.figma.com/file/MoSPFkEyJfGipCmQvvLg1a/obsrv-query-performance?node-id=1834%3A2895

Additionally, the second commit adds an option to the bar chart to display a message of "no samples" accompanied with a tooltip when a sampled execution stat has not been sampled yet. This is more user friendly as we would previously show a zero value. This is a screenshot for the second commit:

![image](https://user-images.githubusercontent.com/10560359/110492466-366b2600-80c0-11eb-8179-23e153e40f11.png)

Closes https://github.com/cockroachdb/cockroach/issues/61346
Closes https://github.com/cockroachdb/cockroach/issues/61607