### PR TITLE
cluster-ui: fix styles for execution stats tables

### DIFF
--- a/packages/cluster-ui/src/sortedtable/sortedtable.module.scss
+++ b/packages/cluster-ui/src/sortedtable/sortedtable.module.scss
@@ -1,5 +1,5 @@
-@import '../core/index.module.scss';
-@import './table.module.scss';
+@import "../core/index.module.scss";
+@import "./table.module.scss";
 
 .sort-table {
   @include table-base;
@@ -18,6 +18,86 @@
       width: 15px;
     }
   }
+
+  &__row {
+    border-top: 1px solid transparent;
+    border-bottom: 1px solid $table-border;
+
+    .cell--show-on-hover {
+      visibility: hidden;
+    }
+    &:hover .cell--show-on-hover {
+      visibility: visible;
+    }
+    &.drawer-active {
+      background-color: $background-color;
+      .cl-table-link__tooltip {
+        color: $main-blue-color;
+        text-decoration: underline;
+      }
+    }
+    &--expandable {
+      border-top: none;
+      cursor: pointer;
+    }
+  }
+
+  .sort-table__cell--header {
+    border-right: 1px solid $table-border;
+    width: 250px;
+  }
+
+  &__row--header {
+    background-color: $background-color;
+    border-bottom: 1px solid $table-border;
+    .sort-table__cell {
+      position: relative;
+      font-family: SourceSansPro-SemiBold;
+      font-size: 12px;
+      font-weight: 600;
+      line-height: 1.17;
+      letter-spacing: 1.5px;
+      color: $placeholder;
+      cursor: pointer;
+
+      .sortable__actions {
+        position: relative;
+        padding: 11px;
+
+        &:after, &:before {
+          content: "";
+          position: absolute;
+          right: 5px;
+          width: 0;
+          height: 0;
+          border-style: solid;
+        }
+        &:after {
+          top: 12px;
+          border-width: 0 3px 3.8px 3px;
+          border-color: transparent transparent $grey-light transparent;
+        }
+        &:before {
+          bottom: 12px;
+          border-width: 3.8px 3px 0 3px;
+          border-color: $grey-light transparent transparent transparent;
+        }
+      }
+      &--descending {
+        color: $body-color;
+        .sortable__actions:before {
+          border-color: $blue transparent transparent transparent;
+        }
+      }
+      &--ascending {
+        color: $body-color;
+        .sortable__actions:after {
+          border-color: transparent transparent $blue transparent;
+        }
+      }
+    }
+  }
+
 }
 
 .cl-table-container {

--- a/packages/cluster-ui/src/sortedtable/table.module.scss
+++ b/packages/cluster-ui/src/sortedtable/table.module.scss
@@ -15,7 +15,7 @@ $stats-table-tr--bg: $colors--neutral-0;
   vertical-align: top;
   color: $colors--neutral-7;
 
-  .__cell--header {
+  &__cell--header {
     border-right: 1px solid $colors--neutral-2;
     width: 250px;
   }

--- a/packages/cluster-ui/src/sortedtable/tableHead/tableHead.module.scss
+++ b/packages/cluster-ui/src/sortedtable/tableHead/tableHead.module.scss
@@ -4,7 +4,7 @@
 .head-wrapper {
   @include table-base;
 
-  .__cell--header {
+  &__cell--header {
     border-right: 1px solid $colors--neutral-2;
     width: 250px;
   }


### PR DESCRIPTION
Execution stats tab on statement details page contains several tables
that due to some regressions had broken styles and missed border colors,
header and footer backgrounds.

Current change recovers some lost styles and fixes stylus nested style rules.

- [ ] Has to be back ported to `cluster-ui-20.2` branch

### Before:
<img width="1019" alt="Screen Shot 2021-03-09 at 2 02 52 PM" src="https://user-images.githubusercontent.com/3106437/110478882-772d6400-80ed-11eb-9455-8197776b637f.png">

---
### After:
<img width="1002" alt="Screen Shot 2021-03-09 at 2 00 33 PM" src="https://user-images.githubusercontent.com/3106437/110478906-7e547200-80ed-11eb-9c78-225f96e16158.png">
