### PR TITLE
cluster-ui: ui customization parameters

### DIFF
--- a/packages/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.tsx
+++ b/packages/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.tsx
@@ -26,6 +26,7 @@ type IStatementDiagnosticsReport = cockroach.server.serverpb.IStatementDiagnosti
 export interface DiagnosticsViewStateProps {
   hasData: boolean;
   diagnosticsReports: cockroach.server.serverpb.IStatementDiagnosticsReport[];
+  showDiagnosticsViewLink?: boolean;
 }
 
 export interface DiagnosticsViewDispatchProps {
@@ -54,6 +55,9 @@ export class DiagnosticsView extends React.Component<
   DiagnosticsViewProps,
   DiagnosticsViewState
 > {
+  static defaultProps: Partial<DiagnosticsViewProps> = {
+    showDiagnosticsViewLink: true,
+  };
   columns: ColumnsConfig<IStatementDiagnosticsReport> = [
     {
       key: "activatedOn",
@@ -133,7 +137,7 @@ export class DiagnosticsView extends React.Component<
   }
 
   render() {
-    const { diagnosticsReports } = this.props;
+    const { diagnosticsReports, showDiagnosticsViewLink } = this.props;
 
     const canRequestDiagnostics = diagnosticsReports.every(
       diagnostic => diagnostic.completed,
@@ -187,11 +191,13 @@ export class DiagnosticsView extends React.Component<
           dataSource={dataSource}
           columns={this.columns}
         />
-        <div className={cx("crl-statements-diagnostics-view__footer")}>
-          <Link to="/reports/statements/diagnosticshistory">
-            All statement diagnostics
-          </Link>
-        </div>
+        {showDiagnosticsViewLink && (
+          <div className={cx("crl-statements-diagnostics-view__footer")}>
+            <Link to="/reports/statements/diagnosticshistory">
+              All statement diagnostics
+            </Link>
+          </div>
+        )}
       </SummaryCard>
     );
   }

--- a/packages/cluster-ui/src/statementDetails/statementDetails.fixture.ts
+++ b/packages/cluster-ui/src/statementDetails/statementDetails.fixture.ts
@@ -185,4 +185,7 @@ export const getStatementDetailsPropsFixture = (): StatementDetailsProps => ({
   diagnosticsReports: [],
   dismissStatementDiagnosticsAlertMessage: noop,
   createStatementDiagnosticsReport: noop,
+  uiConfig: {
+    showStatementDiagnosticsLink: true,
+  },
 });

--- a/packages/cluster-ui/src/statementDetails/statementDetails.selectors.ts
+++ b/packages/cluster-ui/src/statementDetails/statementDetails.selectors.ts
@@ -135,3 +135,8 @@ export const selectStatement = createSelector(
     };
   },
 );
+
+export const selectStatementDetailsUiConfig = createSelector(
+  (state: AppState) => state.adminUI.uiConfig.pages.statementDetails,
+  statementDetailsUiConfig => statementDetailsUiConfig,
+);

--- a/packages/cluster-ui/src/statementDetails/statementDetails.stories.tsx
+++ b/packages/cluster-ui/src/statementDetails/statementDetails.stories.tsx
@@ -50,6 +50,14 @@ storiesOf("StatementDetails", module)
     ]).toString();
     return <StatementDetails {...props} />;
   })
+  .add("Diagnostics tab with hidden Statement Diagnostics link", () => {
+    const props = getStatementDetailsPropsFixture();
+    props.history.location.search = new URLSearchParams([
+      ["tab", "diagnostics"],
+    ]).toString();
+    props.uiConfig.showStatementDiagnosticsLink = false;
+    return <StatementDetails {...props} />;
+  })
   .add("Logical Plan tab", () => {
     const props = getStatementDetailsPropsFixture();
     props.history.location.search = new URLSearchParams([

--- a/packages/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/packages/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -45,6 +45,7 @@ import sortedTableStyles from "src/sortedtable/sortedtable.module.scss";
 import summaryCardStyles from "src/summaryCard/summaryCard.module.scss";
 import styles from "./statementDetails.module.scss";
 import { NodeSummaryStats } from "../nodes";
+import { UIConfigState } from "../store/uiConfig";
 
 const { TabPane } = Tabs;
 
@@ -124,6 +125,7 @@ export interface StatementDetailsStateProps {
   statementsError: Error | null;
   nodeNames: { [nodeId: string]: string };
   diagnosticsReports: cockroach.server.serverpb.IStatementDiagnosticsReport[];
+  uiConfig: UIConfigState["pages"]["statementDetails"];
 }
 
 export type StatementDetailsOwnProps = StatementDetailsDispatchProps &
@@ -593,6 +595,9 @@ export class StatementDetails extends React.Component<
             hasData={hasDiagnosticReports}
             statementFingerprint={statement}
             onDownloadDiagnosticBundleClick={onDiagnosticBundleDownload}
+            showDiagnosticsViewLink={
+              this.props.uiConfig.showStatementDiagnosticsLink
+            }
           />
         </TabPane>
         <TabPane tab="Logical Plan" key="logical-plan">

--- a/packages/cluster-ui/src/statementDetails/statementDetailsConnected.ts
+++ b/packages/cluster-ui/src/statementDetails/statementDetailsConnected.ts
@@ -7,7 +7,10 @@ import {
   StatementDetailsStateProps,
 } from "./statementDetails";
 import { AppState } from "../store";
-import { selectStatement } from "./statementDetails.selectors";
+import {
+  selectStatement,
+  selectStatementDetailsUiConfig,
+} from "./statementDetails.selectors";
 import { nodeDisplayNameByIDSelector } from "../store/nodes";
 import { actions as statementActions } from "src/store/statements";
 import {
@@ -33,6 +36,7 @@ const mapStateToProps = (
       state,
       statementFingerprint,
     ),
+    uiConfig: selectStatementDetailsUiConfig(state),
   };
 };
 

--- a/packages/cluster-ui/src/store/reducers.ts
+++ b/packages/cluster-ui/src/store/reducers.ts
@@ -12,6 +12,7 @@ import {
   TerminateQueryState,
   reducer as terminateQuery,
 } from "./terminateQuery";
+import { UIConfigState, reducer as uiConfig } from "./uiConfig";
 
 export type AdminUiState = {
   statements: StatementsState;
@@ -21,6 +22,7 @@ export type AdminUiState = {
   liveness: LivenessState;
   sessions: SessionsState;
   terminateQuery: TerminateQueryState;
+  uiConfig: UIConfigState;
 };
 
 export type AppState = {
@@ -35,4 +37,5 @@ export const rootReducer = combineReducers<AdminUiState>({
   liveness,
   sessions,
   terminateQuery,
+  uiConfig,
 });

--- a/packages/cluster-ui/src/store/uiConfig/index.ts
+++ b/packages/cluster-ui/src/store/uiConfig/index.ts
@@ -1,0 +1,1 @@
+export * from "./uiConfig.reducer";

--- a/packages/cluster-ui/src/store/uiConfig/uiConfig.reducer.ts
+++ b/packages/cluster-ui/src/store/uiConfig/uiConfig.reducer.ts
@@ -1,0 +1,37 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { merge } from "lodash";
+import { DOMAIN_NAME } from "../utils";
+
+export type UIConfigState = {
+  pages: {
+    statementDetails: {
+      showStatementDiagnosticsLink: boolean;
+    };
+  };
+};
+
+const initialState: UIConfigState = {
+  pages: {
+    statementDetails: {
+      showStatementDiagnosticsLink: true,
+    },
+  },
+};
+
+/**
+ * `uiConfigSlice` is responsible to store configuration parameters which works as feature flags
+ * and can be set dynamically by dispatching `update` action with updated configuration.
+ * This might be useful in case client application that integrates some components or pages from
+ * `cluster-ui` and has to exclude or add some extra logic on a page.
+ **/
+const uiConfigSlice = createSlice({
+  name: `${DOMAIN_NAME}/uiConfig`,
+  initialState,
+  reducers: {
+    update: (state, action: PayloadAction<Partial<UIConfigState>>) => {
+      merge(state, action.payload);
+    },
+  },
+});
+
+export const { actions, reducer } = uiConfigSlice;


### PR DESCRIPTION
Before, it wasn't necessary to customize UI components depending
on specific runtime conditions.
But now, it has to be possible to allow some client application
code to define which components have to be hidden on UI or shown.

In this particular change, "Statement diagnostics" link has to be
hidden because an entire Statement Diagnostics page might not be
available in client's code.

UI customization is implemented within redux store as separate
slice where all required customization params can be defined
with their default values.

To change some params, client's application has to dispatch
uiConfig's "update" action with partially filled configuration that
includes only params which have to be changed.

<img width="1376" alt="Screen Shot 2021-03-15 at 6 22 07 PM" src="https://user-images.githubusercontent.com/3106437/111186233-7e57e480-85bb-11eb-812d-0e72be1d591f.png">

