### PR TITLE
packages/cluster-ui: add % of all runtime to statements

### DIFF
--- a/packages/cluster-ui/src/barCharts/barCharts.tsx
+++ b/packages/cluster-ui/src/barCharts/barCharts.tsx
@@ -1,11 +1,11 @@
-import React from "react";
 import * as protos from "@cockroachlabs/crdb-protobuf-client";
 import { stdDevLong } from "src/util";
-import { Duration, Bytes } from "src/util/format";
+import { Duration, Bytes, Percentage } from "src/util/format";
 import classNames from "classnames/bind";
 import styles from "./barCharts.module.scss";
 import { bar, formatTwoPlaces, longToInt, approximify } from "./utils";
-import { barChartFactory } from "./barChartFactory";
+import { barChartFactory, BarChartOptions } from "./barChartFactory";
+import { AggregateStatistics } from "src/statementsTable/statementsTable";
 
 type StatementStatistics = protos.cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
 const cx = classNames.bind(styles);
@@ -127,3 +127,21 @@ export const networkBytesBarChart = barChartFactory(
 );
 
 export const retryBarChart = barChartFactory("red", retryBars, approximify);
+
+export function workloadPctBarChart(
+  statements: AggregateStatistics[],
+  defaultBarChartOptions: BarChartOptions<any>,
+  totalWorkload: number,
+) {
+  return barChartFactory(
+    "grey",
+    [
+      bar(
+        "pct-workload",
+        (d: StatementStatistics) =>
+          (d.stats.service_lat.mean * longToInt(d.stats.count)) / totalWorkload,
+      ),
+    ],
+    v => Percentage(v, 1, 1),
+  )(statements, defaultBarChartOptions);
+}

--- a/packages/cluster-ui/src/statementDetails/statementDetails.module.scss
+++ b/packages/cluster-ui/src/statementDetails/statementDetails.module.scss
@@ -56,6 +56,7 @@ h2.base-heading {
 }
 
 .cockroach--tabs {
+  overflow: visible !important;
   :global(.ant-tabs-bar) {
     border-bottom: 1px solid $grey2;
   }
@@ -81,6 +82,10 @@ h2.base-heading {
     border-radius: 40px;
     background-color: $blue;
   }
+}
+
+.fit-content-width {
+  width: fit-content;
 }
 
 .table-details {

--- a/packages/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/packages/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -20,6 +20,7 @@ import {
   stdDev,
   getMatchParamByName,
   formatNumberForDisplay,
+  calculateTotalWorkload,
 } from "src/util";
 import { Loading } from "src/loading";
 import { Button } from "src/button";
@@ -408,6 +409,7 @@ export class StatementDetails extends React.Component<
     );
 
     const statsByNode = this.props.statement.byNode;
+    const totalWorkload = calculateTotalWorkload(statsByNode);
     const logicalPlan =
       stats.sensitive_info && stats.sensitive_info.most_recent_plan_description;
     const duration = (v: number) => Duration(v * 1e9);
@@ -431,8 +433,8 @@ export class StatementDetails extends React.Component<
                 <Row>
                   <Col>
                     <div className={summaryCardStylesCx("summary--card__item")}>
-                      <Heading type="h5">Statement time</Heading>
-                      <Text>
+                      <Heading type="h5">Mean statement time</Heading>
+                      <Text type="body-strong">
                         {formatNumberForDisplay(
                           stats.service_lat.mean,
                           duration,
@@ -440,7 +442,7 @@ export class StatementDetails extends React.Component<
                       </Text>
                     </div>
                     <div className={summaryCardStylesCx("summary--card__item")}>
-                      <Text type="body-strong">Planning time</Text>
+                      <Text>Planning time</Text>
                       <Text>
                         {formatNumberForDisplay(stats.plan_lat.mean, duration)}
                       </Text>
@@ -449,7 +451,7 @@ export class StatementDetails extends React.Component<
                       className={summaryCardStylesCx("summary--card__divider")}
                     />
                     <div className={summaryCardStylesCx("summary--card__item")}>
-                      <Text type="body-strong">Execution time</Text>
+                      <Text>Execution time</Text>
                       <Text>
                         {formatNumberForDisplay(stats.run_lat.mean, duration)}
                       </Text>
@@ -461,11 +463,13 @@ export class StatementDetails extends React.Component<
                 </Row>
               </SummaryCard>
               <SummaryCard className={cx("summary-card")}>
-                <Heading type="h5">Resource usage</Heading>
                 <Row>
                   <Col>
                     <div className={summaryCardStylesCx("summary--card__item")}>
-                      <Text type="body-strong">Mean rows/bytes read</Text>
+                      <Heading type="h5">Resource usage</Heading>
+                    </div>
+                    <div className={summaryCardStylesCx("summary--card__item")}>
+                      <Text>Mean rows/bytes read</Text>
                       <Text>
                         {formatNumberForDisplay(
                           stats.rows_read.mean,
@@ -476,7 +480,7 @@ export class StatementDetails extends React.Component<
                       </Text>
                     </div>
                     <div className={summaryCardStylesCx("summary--card__item")}>
-                      <Text type="body-strong">Max memory usage</Text>
+                      <Text>Max memory usage</Text>
                       <Text>
                         {formatNumberForDisplay(
                           stats.exec_stats.max_mem_usage.mean,
@@ -485,7 +489,7 @@ export class StatementDetails extends React.Component<
                       </Text>
                     </div>
                     <div className={summaryCardStylesCx("summary--card__item")}>
-                      <Text type="body-strong">Network usage</Text>
+                      <Text>Network usage</Text>
                       <Text>
                         {formatNumberForDisplay(
                           stats.exec_stats.network_bytes.mean,
@@ -494,7 +498,7 @@ export class StatementDetails extends React.Component<
                       </Text>
                     </div>
                     <div className={summaryCardStylesCx("summary--card__item")}>
-                      <Text type="body-strong">Max scratch disk usage</Text>
+                      <Text>Max scratch disk usage</Text>
                       <Text>
                         {formatNumberForDisplay(
                           stats.exec_stats.max_disk_usage.mean,
@@ -510,7 +514,7 @@ export class StatementDetails extends React.Component<
               <SummaryCard className={cx("summary-card")}>
                 <Heading type="h5">Statement details</Heading>
                 <div className={summaryCardStylesCx("summary--card__item")}>
-                  <Text type="body-strong">App</Text>
+                  <Text>App</Text>
                   <Text>
                     {intersperse<ReactNode>(
                       app.map(a => <AppLink app={a} key={a} />),
@@ -519,38 +523,41 @@ export class StatementDetails extends React.Component<
                   </Text>
                 </div>
                 <div className={summaryCardStylesCx("summary--card__item")}>
-                  <Text type="body-strong">Failed?</Text>
+                  <Text>Failed?</Text>
                   <Text>{renderBools(failed)}</Text>
                 </div>
                 <div className={summaryCardStylesCx("summary--card__item")}>
-                  <Text type="body-strong">Used cost-based optimizer?</Text>
+                  <Text>Used cost-based optimizer?</Text>
                   <Text>{renderBools(opt)}</Text>
                 </div>
                 <div className={summaryCardStylesCx("summary--card__item")}>
-                  <Text type="body-strong">Distributed execution?</Text>
+                  <Text>Distributed execution?</Text>
                   <Text>{renderBools(distSQL)}</Text>
                 </div>
                 <div className={summaryCardStylesCx("summary--card__item")}>
-                  <Text type="body-strong">Vectorized execution?</Text>
+                  <Text>Vectorized execution?</Text>
                   <Text>{renderBools(vec)}</Text>
                 </div>
                 <div className={summaryCardStylesCx("summary--card__item")}>
-                  <Text type="body-strong">Transaction type</Text>
+                  <Text>Transaction type</Text>
                   <Text>{renderTransactionType(implicit_txn)}</Text>
                 </div>
-                <p className={summaryCardStylesCx("summary--card__divider")} />
-
+                <p
+                  className={summaryCardStylesCx(
+                    "summary--card__divider--large",
+                  )}
+                />
                 <Heading type="h5">Execution counts</Heading>
                 <div className={summaryCardStylesCx("summary--card__item")}>
-                  <Text type="body-strong">First attempts</Text>
+                  <Text>First attempts</Text>
                   <Text>{firstAttemptsBarChart}</Text>
                 </div>
                 <div className={summaryCardStylesCx("summary--card__item")}>
-                  <Text type="body-strong">Total executions</Text>
+                  <Text>Total executions</Text>
                   <Text>{totalCountBarChart}</Text>
                 </div>
                 <div className={summaryCardStylesCx("summary--card__item")}>
-                  <Text type="body-strong">Retries</Text>
+                  <Text>Retries</Text>
                   <Text
                     className={summaryCardStylesCx(
                       "summary--card__item--value",
@@ -563,7 +570,7 @@ export class StatementDetails extends React.Component<
                   </Text>
                 </div>
                 <div className={summaryCardStylesCx("summary--card__item")}>
-                  <Text type="body-strong">Max retries</Text>
+                  <Text>Max retries</Text>
                   <Text
                     className={summaryCardStylesCx(
                       "summary--card__item--value",
@@ -600,7 +607,11 @@ export class StatementDetails extends React.Component<
             <PlanView title="Logical Plan" plan={logicalPlan} />
           </SummaryCard>
         </TabPane>
-        <TabPane tab="Execution Stats" key="execution-stats">
+        <TabPane
+          tab="Execution Stats"
+          key="execution-stats"
+          className={cx("fit-content-width")}
+        >
           <SummaryCard>
             <h2
               className={classNames(
@@ -693,7 +704,7 @@ export class StatementDetails extends React.Component<
               })}
             />
           </SummaryCard>
-          <SummaryCard>
+          <SummaryCard className={cx("fit-content-width")}>
             <h2
               className={classNames(
                 cx("base-heading"),
@@ -716,7 +727,11 @@ export class StatementDetails extends React.Component<
             <StatementsSortedTable
               className={cx("statements-table")}
               data={statsByNode}
-              columns={makeNodesColumns(statsByNode, this.props.nodeNames)}
+              columns={makeNodesColumns(
+                statsByNode,
+                this.props.nodeNames,
+                totalWorkload,
+              )}
               sortSetting={this.state.sortSetting}
               onChangeSortSetting={this.changeSortSetting}
               firstCellBordered

--- a/packages/cluster-ui/src/statementsPage/statementsPage.module.scss
+++ b/packages/cluster-ui/src/statementsPage/statementsPage.module.scss
@@ -53,6 +53,10 @@ h2.base-heading {
   width: 100%;
 }
 
+.table-area {
+  width: fit-content;
+}
+
 .app-filter-dropdown {
   /* 
     we are truncating the text in the filter, 

--- a/packages/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/packages/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -14,7 +14,12 @@ import { SortSetting } from "src/sortedtable";
 import { Search } from "src/search";
 import { Pagination, ResultsPerPageLabel } from "src/pagination";
 
-import { DATE_FORMAT, appAttr, getMatchParamByName } from "src/util";
+import {
+  DATE_FORMAT,
+  appAttr,
+  getMatchParamByName,
+  calculateTotalWorkload,
+} from "src/util";
 import {
   AggregateStatistics,
   makeStatementsColumns,
@@ -245,6 +250,7 @@ export class StatementsPage extends React.Component<
     this.props.apps.forEach(app => appOptions.push({ value: app, name: app }));
     const currentOption = appOptions.find(o => o.value === selectedApp);
     const data = this.filteredStatementsData();
+    const totalWorkload = calculateTotalWorkload(data);
     const totalCount = data.length;
     const isEmptySearchResults = statements?.length > 0 && search?.length > 0;
 
@@ -308,6 +314,7 @@ export class StatementsPage extends React.Component<
             columns={makeStatementsColumns(
               statements,
               selectedApp,
+              totalWorkload,
               search,
               this.activateDiagnosticsRef,
               onDiagnosticsReportDownload,
@@ -341,7 +348,7 @@ export class StatementsPage extends React.Component<
     } = this.props;
     const app = getMatchParamByName(match, appAttr);
     return (
-      <div className={cx("root")}>
+      <div className={cx("root", "table-area")}>
         <Helmet title={app ? `${app} App | Statements` : "Statements"} />
 
         <section className={cx("section")}>

--- a/packages/cluster-ui/src/statementsTable/statementsTable.stories.tsx
+++ b/packages/cluster-ui/src/statementsTable/statementsTable.stories.tsx
@@ -6,6 +6,7 @@ import {
   StatementsSortedTable,
 } from "./statementsTable";
 import statementsPagePropsFixture from "src/statementsPage/statementsPage.fixture";
+import { calculateTotalWorkload } from "src/util";
 
 const { statements } = statementsPagePropsFixture;
 
@@ -15,7 +16,11 @@ storiesOf("StatementsSortedTable", module)
     <StatementsSortedTable
       className="statements-table"
       data={statements}
-      columns={makeStatementsColumns(statements, "(internal)")}
+      columns={makeStatementsColumns(
+        statements,
+        "(internal)",
+        calculateTotalWorkload(statements),
+      )}
       sortSetting={{
         ascending: false,
         sortKey: 3,

--- a/packages/cluster-ui/src/statementsTable/statementsTableContent.tsx
+++ b/packages/cluster-ui/src/statementsTable/statementsTableContent.tsx
@@ -290,6 +290,22 @@ export const StatementTableTitle = {
       Retries
     </Tooltip>
   ),
+  workloadPct: (
+    <Tooltip
+      placement="bottom"
+      title={
+        <div className={cx("tooltip__table--title")}>
+          <p>
+            % of runtime all statements with this fingerprint represent,
+            compared to the cumulative runtime of all queries within the last
+            hour or specified time interval.
+          </p>
+        </div>
+      }
+    >
+      % of all runtime
+    </Tooltip>
+  ),
   diagnostics: (
     <Tooltip
       placement="bottom"

--- a/packages/cluster-ui/src/summaryCard/summaryCard.module.scss
+++ b/packages/cluster-ui/src/summaryCard/summaryCard.module.scss
@@ -4,13 +4,17 @@
   border-radius: 3px;
   box-shadow: 0 0 1px 0 rgba(67, 90, 111, 0.41);
   background-color: $adminui-white;
-  padding: 25px;
+  padding: 24px;
   margin-bottom: 15px;
   &__divider {
     width: 100%;
     height: 1px;
-    margin: 22px 0;
+    margin: 8px 0;
     background: $table-border;
+    &--large {
+      @extend .summary--card__divider;
+      margin: 16px 0;
+    }
   }
   &__title {
     font-family: $font-family--base;

--- a/packages/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/packages/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -290,7 +290,6 @@ export class TransactionsPage extends React.Component<
     const transactionDetails =
       statementIds && getStatementsById(statementIds, statements);
 
-    console.log(JSON.stringify(transactionDetails));
     return (
       <TransactionDetails
         statements={aggregateStatementStats(transactionDetails)}

--- a/packages/cluster-ui/src/util/format.ts
+++ b/packages/cluster-ui/src/util/format.ts
@@ -100,12 +100,21 @@ export const BytesFitScale = (scale: string) => (bytes: number) => {
 
 /**
  * Percentage creates a string representation of a fraction as a percentage.
+ * Accepts a precision parameter as optional indicating how many digits
+ * after the decimal point are desired. (e.g. precision 2 returns 8.37 %)
  */
-export function Percentage(numerator: number, denominator: number): string {
+export function Percentage(
+  numerator: number,
+  denominator: number,
+  precision?: number,
+): string {
   if (denominator === 0) {
     return "--%";
   }
-  return Math.floor((numerator / denominator) * 100).toString() + "%";
+  if (precision) {
+    return ((numerator / denominator) * 100).toFixed(precision) + " %";
+  }
+  return Math.floor((numerator / denominator) * 100).toString() + " %";
 }
 
 /**

--- a/packages/cluster-ui/src/util/index.ts
+++ b/packages/cluster-ui/src/util/index.ts
@@ -14,3 +14,4 @@ export * from "./pick";
 export * from "./find";
 export * from "./proto";
 export * from "./formatNumber";
+export * from "./totalWorkload";

--- a/packages/cluster-ui/src/util/totalWorkload.fixture.ts
+++ b/packages/cluster-ui/src/util/totalWorkload.fixture.ts
@@ -1,0 +1,112 @@
+import Long from "long";
+import { StatementStatistics } from "./appStats";
+import { ExecStats } from ".";
+
+interface AggregateStatistics {
+  label: string;
+  implicitTxn: boolean;
+  fullScan: boolean;
+  stats: StatementStatistics;
+}
+
+const execStats: Required<ExecStats> = {
+  count: Long.fromNumber(1),
+  network_bytes: {
+    mean: 4160407,
+    squared_diffs: 47880000000000,
+  },
+  max_mem_usage: {
+    mean: 4160407,
+    squared_diffs: 47880000000000,
+  },
+  contention_time: {
+    mean: 4160407,
+    squared_diffs: 47880000000000,
+  },
+  network_messages: {
+    mean: 4160407,
+    squared_diffs: 47880000000000,
+  },
+  max_disk_usage: {
+    mean: 4160407,
+    squared_diffs: 47880000000000,
+  },
+};
+
+const statementStats: any = {
+  count: 36958,
+  first_attempt_count: Long.fromNumber(36958),
+  max_retries: Long.fromNumber(0),
+  num_rows: {
+    mean: 11.651577466313078,
+    squared_diffs: 1493154.3630337175,
+  },
+  parse_lat: {
+    mean: 0,
+    squared_diffs: 0,
+  },
+  plan_lat: {
+    mean: 0.00022804377942529385,
+    squared_diffs: 0.0030062544511648935,
+  },
+  run_lat: {
+    mean: 0.00098355830943233,
+    squared_diffs: 0.04090499253784317,
+  },
+  service_lat: {
+    mean: 0.0013101634016992284,
+    squared_diffs: 0.055668241814216965,
+  },
+  overhead_lat: {
+    mean: 0.00009856131284160407,
+    squared_diffs: 0.0017520019405651047,
+  },
+  bytes_read: {
+    mean: 4160407,
+    squared_diffs: 47880000000000,
+  },
+  rows_read: {
+    mean: 7,
+    squared_diffs: 1000000,
+  },
+  sensitive_info: {
+    last_err: "",
+    most_recent_plan_description: {
+      name: "render",
+      attrs: [
+        {
+          key: "render",
+          value: "city",
+        },
+        {
+          key: "render",
+          value: "id",
+        },
+      ],
+      children: [
+        {
+          name: "scan",
+          attrs: [
+            {
+              key: "table",
+              value: "vehicles@vehicles_auto_index_fk_city_ref_users",
+            },
+            {
+              key: "spans",
+              value: "1 span",
+            },
+          ],
+          children: [],
+        },
+      ],
+    },
+  },
+  exec_stats: execStats,
+};
+
+export const aggStatFix: AggregateStatistics = {
+  label: "foo",
+  implicitTxn: false,
+  fullScan: false,
+  stats: statementStats,
+};

--- a/packages/cluster-ui/src/util/totalWorkload.spec.ts
+++ b/packages/cluster-ui/src/util/totalWorkload.spec.ts
@@ -1,0 +1,22 @@
+import { assert } from "chai";
+import { calculateTotalWorkload } from "./totalWorkload";
+import { aggStatFix } from "./totalWorkload.fixture";
+
+describe("Calculating total workload", () => {
+  it("calculating total workload with one statement", () => {
+    const result = calculateTotalWorkload([aggStatFix]);
+    // Using approximately because float handling by javascript is imprecise
+    assert.approximately(result, 48.421019, 0.0000001);
+  });
+
+  it("calculating total workload with no statements", () => {
+    const result = calculateTotalWorkload([]);
+    assert.equal(result, 0);
+  });
+
+  it("calculating total workload with multiple statements", () => {
+    const result = calculateTotalWorkload([aggStatFix, aggStatFix, aggStatFix]);
+    // Using approximately because float handling by javascript is imprecise
+    assert.approximately(result, 145.263057, 0.0000001);
+  });
+});

--- a/packages/cluster-ui/src/util/totalWorkload.ts
+++ b/packages/cluster-ui/src/util/totalWorkload.ts
@@ -1,0 +1,21 @@
+import * as protos from "@cockroachlabs/crdb-protobuf-client";
+import { longToInt } from "src/barCharts/utils";
+import { AggregateStatistics } from "src/statementsTable";
+
+type Statement = protos.cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
+type statementType = AggregateStatistics | Statement;
+type statementsType = Array<statementType>;
+
+/**
+ * Function to calculate total workload of statements
+ * Currently is recalculating every time is called, if that becames an issue
+ * on the future, consider use of cache and memoize the function
+ * @param statements array of statements (AggregateStatistics or Statement)
+ * @returns the total workload of all statements
+ */
+export function calculateTotalWorkload(statements: statementsType) {
+  return statements.reduce((totalWorkload: number, stmt: statementType) => {
+    return (totalWorkload +=
+      longToInt(stmt.stats.count) * stmt.stats.service_lat.mean);
+  }, 0);
+}


### PR DESCRIPTION
Adding new column for `% of all runtime` into statements page

`% of runtime all statements with this fingerprint represent, compared to the cumulative runtime of all queries within the last hour or specified time interval.`

Issue: https://github.com/cockroachdb/cockroach/issues/61475 

This PR also fixes some ui on details page to align with the mockup (change of weights of fonts, spacing)


