### PR TITLE
backport 20.2: correct design for empty states in statements table

### DIFF
--- a/packages/cluster-ui/src/empty/emptyPanel/emptyPanel.module.scss
+++ b/packages/cluster-ui/src/empty/emptyPanel/emptyPanel.module.scss
@@ -10,16 +10,6 @@
   background-size: contain;
   background-repeat: no-repeat;
 
-  &__title {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    font-size: $font-size--x-large;
-    color: $colors--neutral-7;
-    line-height: $line-height--x-large;
-    margin-bottom: 0;
-  }
-
   &__footer {
     margin: 20px 0 0;
   }

--- a/packages/cluster-ui/src/empty/emptyPanel/emptyPanel.tsx
+++ b/packages/cluster-ui/src/empty/emptyPanel/emptyPanel.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 import classnames from "classnames/bind";
+import { Heading, Text, Button } from "@cockroachlabs/ui-components";
 import styles from "./emptyPanel.module.scss";
-import { Text, TextTypes } from "../../text";
 import { Anchor } from "../../anchor";
-import { Button } from "../../button";
 import heroBannerLp from "../../assets/heroBannerLp.png";
 
 const cx = classnames.bind(styles);
@@ -43,15 +42,10 @@ export const EmptyPanel: React.FC<EmptyPanelProps> = ({
     className={cx("cl-empty-view")}
     style={{ backgroundImage: `url(${backgroundImage})` }}
   >
-    <Text className={cx("cl-empty-view__title")} textType={TextTypes.Heading3}>
-      {title}
-    </Text>
+    <Heading type="h2">{title}</Heading>
     <div className={cx("cl-empty-view__content")}>
       <main className={cx("cl-empty-view__main")}>
-        <Text
-          textType={TextTypes.Body}
-          className={cx("cl-empty-view__main--text")}
-        >
+        <Text>
           {description}
           {link && (
             <Anchor href={link} className={cx("cl-empty-view__main--anchor")}>
@@ -62,7 +56,7 @@ export const EmptyPanel: React.FC<EmptyPanelProps> = ({
       </main>
       <footer className={cx("cl-empty-view__footer")}>
         <Button
-          type="primary"
+          intent="primary"
           onClick={() =>
             buttonHref ? window.open(buttonHref) : onClick && onClick()
           }

--- a/packages/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.spec.tsx
+++ b/packages/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.spec.tsx
@@ -3,18 +3,16 @@ import { assert } from "chai";
 import { mount, ReactWrapper } from "enzyme";
 import sinon, { SinonSpy } from "sinon";
 import Long from "long";
-import classNames from "classnames/bind";
 import { MemoryRouter } from "react-router-dom";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import { Button } from "@cockroachlabs/ui-components";
 
 import { DiagnosticsView } from "./diagnosticsView";
 import { Table } from "src/table";
 import { TestStoreProvider } from "src/test-utils";
-import buttonStyles from "src/button.module.scss";
 
 type IStatementDiagnosticsReport = cockroach.server.serverpb.IStatementDiagnosticsReport;
 
-const cx = classNames.bind(buttonStyles);
 const sandbox = sinon.createSandbox();
 
 function generateDiagnosticsRequest(
@@ -58,9 +56,7 @@ describe("DiagnosticsView", () => {
     });
 
     it("calls activate callback with statementId when click on Activate button", () => {
-      const activateButtonComponent = wrapper
-        .find(`.${cx("crl-button")}`)
-        .first();
+      const activateButtonComponent = wrapper.find(Button).first();
       activateButtonComponent.simulate("click");
       activateFn.calledOnceWith(statementFingerprint);
     });
@@ -92,7 +88,7 @@ describe("DiagnosticsView", () => {
 
     it("calls activate callback with statementId when click on Activate button", () => {
       const activateButtonComponent = wrapper
-        .find(`.${cx("crl-button")}`)
+        .findWhere(n => n.prop("children") === "Activate")
         .first();
       activateButtonComponent.simulate("click");
       activateFn.calledOnceWith(statementFingerprint);
@@ -115,7 +111,7 @@ describe("DiagnosticsView", () => {
         </TestStoreProvider>,
       );
       const activateButtonComponent = wrapper
-        .find(".crl-statements-diagnostics-view__activate-button")
+        .findWhere(n => n.prop("children") === "Activate")
         .first();
       assert.isFalse(activateButtonComponent.exists());
     });

--- a/packages/cluster-ui/src/statementDetails/statementDetails.spec.tsx
+++ b/packages/cluster-ui/src/statementDetails/statementDetails.spec.tsx
@@ -93,11 +93,7 @@ describe("StatementDetails page", () => {
 
       wrapper
         .find(DiagnosticsView)
-        .findWhere(
-          n =>
-            n.name() === "Button" &&
-            n.prop("children") === "Activate diagnostics",
-        )
+        .findWhere(n => n.prop("children") === "Activate")
         .first()
         .simulate("click");
 

--- a/packages/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/packages/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -26,8 +26,8 @@ import {
 } from "src/statementsDiagnostics";
 import { ISortedTablePagination } from "../sortedtable";
 import styles from "./statementsPage.module.scss";
-import { EmptyStatementsPlaceholder } from "./emptyStatementsPlaceholder";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import { statementsTable } from "src/util/docs";
 
 type IStatementDiagnosticsReport = cockroach.server.serverpb.IStatementDiagnosticsReport;
 import sortableTableStyles from "src/sortedtable/sortedtable.module.scss";
@@ -291,11 +291,15 @@ export class StatementsPage extends React.Component<
             )}
             sortSetting={this.state.sortSetting}
             onChangeSortSetting={this.changeSortSetting}
-            renderNoResult={
-              <EmptyStatementsPlaceholder
-                isEmptySearchResults={isEmptySearchResults}
-              />
-            }
+            empty={data.length === 0 && search.length === 0}
+            emptyProps={{
+              title:
+                "There are no statements since this page was last cleared.",
+              description:
+                "Statements help you identify frequently executed or high latency SQL statements. Statements are cleared every hour by default, or according to your configuration.",
+              label: "Learn more",
+              buttonHref: statementsTable,
+            }}
             pagination={pagination}
           />
         </section>


### PR DESCRIPTION
#### Backport for https://github.com/cockroachdb/ui/pull/253

Statements table and statement diagnostics table display empty state
as embedded placeholder inside of table (when table header is visible).
According to new design, empty state placeholders should replace entire
table.
Current change changes placeholders in statements table and diagnostics
tables. Also some refactoring is done in Empty panel component to reuse
components from `ui-components` package and clean up hand made styles.

(cherry picked from commit 28211df72f67b76a17c1d232b09c93935d595b7d)
