### PR TITLE
backport 20.2: fix statements page styles

### DIFF
--- a/packages/cluster-ui/src/anchor/anchor.module.scss
+++ b/packages/cluster-ui/src/anchor/anchor.module.scss
@@ -1,6 +1,7 @@
 @import '../core/index.module.scss';
 
 .crl-anchor {
+  @include text--body;
   color: $colors--link;
   &:hover{
     color: $colors--info-4;

--- a/packages/cluster-ui/src/pagination/pagination.module.scss
+++ b/packages/cluster-ui/src/pagination/pagination.module.scss
@@ -33,3 +33,8 @@
     }
   }
 }
+
+.root {
+  text-align: center;
+  float: unset;
+}

--- a/packages/cluster-ui/src/pagination/pagination.tsx
+++ b/packages/cluster-ui/src/pagination/pagination.tsx
@@ -39,6 +39,7 @@ export const Pagination: React.FC<PaginationProps> = props => {
       size="small"
       itemRender={itemRenderer}
       hideOnSinglePage
+      className={cx("root")}
     />
   );
 };

--- a/packages/cluster-ui/src/search/search.module.scss
+++ b/packages/cluster-ui/src/search/search.module.scss
@@ -1,6 +1,6 @@
 @import "../core/index.module";
 
-._search-form {
+.search-form {
   width: 280px;
   height: 40px;
   :global(.ant-input-affix-wrapper) {
@@ -20,23 +20,24 @@
     border: none;
     font-size: 14px;
   }
-  ._prefix-icon {
+  .prefix-icon {
     color: $colors--neutral-6;
     width: 12px;
     &:hover {
       color: $colors--neutral-6;
     }
   }
-  ._suffix-icon {
+  .suffix-icon {
     width: 10px;
+    vertical-align: middle;
   }
-  ._clear-search {
+  .clear-search {
     color: $colors--neutral-7;
     &:hover {
       color: $colors--neutral-7;
     }
   }
-  ._submit-search {
+  .submit-search {
     font-family: $font-family--base;
     font-size: 14px;
     color: $colors--neutral-6;
@@ -60,7 +61,7 @@
       padding-right: 60px;
     }
   }
-  ._submitted {
+  .submitted {
     :global(.ant-input) {
       &:not(:first-child) {
         padding-right: 40px;

--- a/packages/cluster-ui/src/search/search.tsx
+++ b/packages/cluster-ui/src/search/search.tsx
@@ -65,9 +65,9 @@ export class Search extends React.Component<TSearchProps, ISearchState> {
           <Button
             onClick={this.onClear}
             type="default"
-            className={cx("_clear-search")}
+            className={cx("clear-search")}
           >
-            <CancelIcon className={cx("_suffix-icon")} />
+            <CancelIcon className={cx("suffix-icon")} />
           </Button>
         );
       }
@@ -75,7 +75,7 @@ export class Search extends React.Component<TSearchProps, ISearchState> {
         <Button
           type="default"
           htmlType="submit"
-          className={cx("_submit-search")}
+          className={cx("submit-search")}
         >
           Enter
         </Button>
@@ -87,16 +87,16 @@ export class Search extends React.Component<TSearchProps, ISearchState> {
   render() {
     const { value, submitted } = this.state;
     const { onClear, ...inputProps } = this.props;
-    const className = submitted ? cx("_submitted") : "";
+    const className = submitted ? cx("submitted") : "";
 
     return (
-      <Form onSubmit={this.onSubmit} className={cx("_search-form")}>
+      <Form onSubmit={this.onSubmit} className={cx("search-form")}>
         <Form.Item>
           <Input
             className={className}
             placeholder="Search Statement"
             onChange={this.onChange}
-            prefix={<SearchIcon className={cx("_prefix-icon")} />}
+            prefix={<SearchIcon className={cx("prefix-icon")} />}
             suffix={this.renderSuffix()}
             value={value}
             {...inputProps}

--- a/packages/cluster-ui/src/sortedtable/table.module.scss
+++ b/packages/cluster-ui/src/sortedtable/table.module.scss
@@ -15,7 +15,7 @@ $stats-table-tr--bg: $colors--neutral-0;
   vertical-align: top;
   color: $colors--neutral-7;
 
-  .__cell--header {
+  .cell-header {
     border-right: 1px solid $colors--neutral-2;
     width: 250px;
   }
@@ -30,13 +30,20 @@ $stats-table-tr--bg: $colors--neutral-0;
     }
 
     &--header {
-      padding: 20px;
-      font-size: $font-size--medium;
-      font-weight: bold;
-      letter-spacing: 2px;
       text-align: left;
       white-space: nowrap;
-      background-color: $stats-table-th--bg;
+      @include text--heading-6;
+      color: $colors--neutral-6;
+      background-color: $colors--neutral-1;
+      font-weight: 600;
+      font-family: $font-family--semi-bold;
+      letter-spacing: 1.5px;
+
+      tr, th {
+        padding: $spacing-base $spacing-base $spacing-base $spacing-small;
+        height: $line-height--large;
+        background-color: $colors--neutral-1;
+      }
     }
 
     &--summary {
@@ -59,7 +66,7 @@ $stats-table-tr--bg: $colors--neutral-0;
   }
 
   &__cell {
-    padding: 15px 22px 15px 11px;
+    padding: $spacing-small;
     border: none;
     font-family: $font-family--base;
     font-style: normal;

--- a/packages/cluster-ui/src/sortedtable/table.module.scss
+++ b/packages/cluster-ui/src/sortedtable/table.module.scss
@@ -15,7 +15,7 @@ $stats-table-tr--bg: $colors--neutral-0;
   vertical-align: top;
   color: $colors--neutral-7;
 
-  &__cell--header {
+  .__cell--header {
     border-right: 1px solid $colors--neutral-2;
     width: 250px;
   }
@@ -61,7 +61,6 @@ $stats-table-tr--bg: $colors--neutral-0;
   &__cell {
     padding: 15px 22px 15px 11px;
     border: none;
-    font-weight: inherit;
     font-family: $font-family--base;
     font-style: normal;
     font-weight: $font-weight--light;
@@ -73,6 +72,7 @@ $stats-table-tr--bg: $colors--neutral-0;
       color: $adminui-grey-1;
       text-decoration: none;
       cursor: pointer;
+      line-height: $line-height--small;
 
       &:hover {
         color: $colors--link;

--- a/packages/cluster-ui/src/sortedtable/tableHead/tableHead.module.scss
+++ b/packages/cluster-ui/src/sortedtable/tableHead/tableHead.module.scss
@@ -1,38 +1,38 @@
 @import '../../core/index.module.scss';
 @import '../table.module.scss';
 
+@mixin table-header-text {
+  @include text--heading-6;
+  color: $colors--neutral-6;
+  font-weight: 600;
+  font-family: $font-family--semi-bold;
+  letter-spacing: 1.5px;
+}
+
 .head-wrapper {
   @include table-base;
 
-  .__cell--header {
+  .cell-header {
     border-right: 1px solid $colors--neutral-2;
     width: 250px;
   }
   &__row--header {
     border-bottom: 1px solid $colors--neutral-3;
-    height: 48px;
+    height: $line-height--large;
+    padding: $spacing-medium-small;
+    background-color: $colors--neutral-1;
     // Display the sort direction arrow in header cells.
     .sorted__cell {
-      padding: 12.55px 10px 11.55px;
+      padding: $spacing-base $spacing-base $spacing-base $spacing-small;
       position: relative;
-      font-family: $font-family--semi-bold;
-      font-size: $font-size--medium;
-      line-height: $line-height--medium;
-      letter-spacing: 0.1px;
-      color: $colors--neutral-7;
-      text-transform: capitalize;
+      @include table-header-text;
       cursor: pointer;
       .inner-content-wrapper {
         display: flex;
         justify-content: space-between;
         align-items: center;
         > span {
-          font-family: $font-family--semi-bold;
-          font-size: $font-size--medium;
-          line-height: $line-height--medium;
-          letter-spacing: 0.1px;
-          color: $colors--neutral-7;
-          text-transform: capitalize;
+          @include table-header-text;
         }
         .sortable__actions {
           position: relative;

--- a/packages/cluster-ui/src/sortedtable/tableHead/tableHead.module.scss
+++ b/packages/cluster-ui/src/sortedtable/tableHead/tableHead.module.scss
@@ -4,7 +4,7 @@
 .head-wrapper {
   @include table-base;
 
-  &__cell--header {
+  .__cell--header {
     border-right: 1px solid $colors--neutral-2;
     width: 250px;
   }
@@ -26,6 +26,14 @@
         display: flex;
         justify-content: space-between;
         align-items: center;
+        > span {
+          font-family: $font-family--semi-bold;
+          font-size: $font-size--medium;
+          line-height: $line-height--medium;
+          letter-spacing: 0.1px;
+          color: $colors--neutral-7;
+          text-transform: capitalize;
+        }
         .sortable__actions {
           position: relative;
           margin: 0 14px 0 30px;

--- a/packages/cluster-ui/src/sortedtable/tableHead/tableHead.tsx
+++ b/packages/cluster-ui/src/sortedtable/tableHead/tableHead.tsx
@@ -59,7 +59,7 @@ export const TableHead: React.FC<TableHeadProps> = ({
             sortable && "sorted__cell--sortable",
             sortSetting.ascending && picked && "sorted__cell--ascending",
             !sortSetting.ascending && picked && "sorted__cell--descending",
-            firstCellBordered && idx === 0 && "__cell--header",
+            firstCellBordered && idx === 0 && "cell-header",
           );
 
           return (

--- a/packages/cluster-ui/src/sortedtable/tableRow/tableRow.tsx
+++ b/packages/cluster-ui/src/sortedtable/tableRow/tableRow.tsx
@@ -87,7 +87,7 @@ export const TableRow: React.FC<TableRowProps> = ({
         {columns.map((c: SortableColumn, colIndex: number) => {
           const cellClasses = cx(
             "row-wrapper__cell",
-            { "__cell--header": firstCellBordered && colIndex === 0 },
+            { "cell-header": firstCellBordered && colIndex === 0 },
             c.className,
           );
           return (

--- a/packages/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.module.scss
+++ b/packages/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.module.scss
@@ -58,6 +58,10 @@
   }
 }
 
+.anchor {
+  @include text--body;
+}
+
 .summary--card__empty-state {
   background-color: $colors--white;
   background-image: url("./emptyTracingBackground.svg");

--- a/packages/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.tsx
+++ b/packages/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.tsx
@@ -196,7 +196,10 @@ export class DiagnosticsView extends React.Component<
         <Table dataSource={dataSource} columns={this.columns} />
         {showDiagnosticsViewLink && (
           <div className={cx("crl-statements-diagnostics-view__footer")}>
-            <Link to="/reports/statements/diagnosticshistory">
+            <Link
+              to="/reports/statements/diagnosticshistory"
+              className={cx("anchor")}
+            >
               All statement diagnostics
             </Link>
           </div>

--- a/packages/cluster-ui/src/statementDetails/planView/planView.tsx
+++ b/packages/cluster-ui/src/statementDetails/planView/planView.tsx
@@ -325,7 +325,7 @@ export class PlanView extends React.Component<PlanViewProps, PlanViewState> {
     return (
       <table className={cx("plan-view-table")}>
         <thead>
-          <tr className={cx("plan-view-table__row--header")}>
+          <tr>
             <th className={cx("plan-view-table__cell")}>
               <h2 className={cx("base-heading", "summary--card__title")}>
                 {this.props.title}

--- a/packages/cluster-ui/src/statementDetails/statementDetails.module.scss
+++ b/packages/cluster-ui/src/statementDetails/statementDetails.module.scss
@@ -1,9 +1,9 @@
 @import "src/core/index.module";
 
-$max-window-width: 1350px;
-
 .app-name {
   white-space: nowrap;
+  line-height: $line-height--medium;
+  font-weight: $font-weight--bold;
 
   &__unset {
     color: $tooltip-color;
@@ -14,7 +14,6 @@ $max-window-width: 1350px;
 .section {
   flex: 0 0 auto;
   padding: 12px 24px;
-  max-width: $max-window-width;
 
   &--heading {
     padding-top: 0;
@@ -106,13 +105,12 @@ h2.base-heading {
     width: 36px;
     height: 16px;
     display: inline-block;
-
-
     text-transform: none;
     font-weight: normal;
     white-space: normal;
     letter-spacing: normal;
     font-size: 14px;
+    vertical-align: middle;
   }
 
   &__tooltip-hover-area {
@@ -142,4 +140,9 @@ h2.base-heading {
     font-family: $font-family--monospace;
     white-space: pre-wrap;
   }
+}
+
+.root {
+  flex-grow: 0;
+  width: 100%;
 }

--- a/packages/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/packages/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -319,7 +319,7 @@ export class StatementDetails extends React.Component<
   render() {
     const app = getMatchParamByName(this.props.match, appAttr);
     return (
-      <div>
+      <div className={cx("root")}>
         <Helmet title={`Details | ${app ? `${app} App |` : ""} Statements`} />
         <div className={cx("section", "page--header")}>
           <Button

--- a/packages/cluster-ui/src/statementsPage/statementsPage.module.scss
+++ b/packages/cluster-ui/src/statementsPage/statementsPage.module.scss
@@ -25,7 +25,6 @@
 .section {
   flex: 0 0 auto;
   padding: 12px 24px;
-  max-width: 1350px;
 
   &--heading {
     padding-top: 0;
@@ -68,4 +67,11 @@ h2.base-heading {
   */
   max-width: 80ch;
   @include text-overflow;
+}
+
+.full-table-scan-label {
+  @include text--body;
+  display: inline;
+  font-size: 14px;
+  color: $colors--title;
 }

--- a/packages/cluster-ui/src/summaryCard/summaryCard.module.scss
+++ b/packages/cluster-ui/src/summaryCard/summaryCard.module.scss
@@ -72,6 +72,14 @@
       &-red {
         color: $alert-color;
       }
+      a, span {
+        font-family: $font-family--base;
+        font-size: 14px;
+        font-weight: 600;
+        line-height: 1.71;
+        letter-spacing: 0.1px;
+        margin-bottom: 0;
+      }
     }
   }
 }

--- a/packages/cluster-ui/src/table/table.module.scss
+++ b/packages/cluster-ui/src/table/table.module.scss
@@ -1,25 +1,32 @@
 @import "src/core/index.module";
+@import "src/sortedtable/tableHead/tableHead.module";
 
 .crl-table-wrapper {
-  .ant-table {
+  :global(.ant-table) {
     color: $colors--primary-text;
   }
 
   // Table header
-  .ant-table-thead {
+  :global(.ant-table-thead) {
     background-color: $colors--neutral-1;
-    @include text--heading-6;
+    @include table-header-text;
   }
 
-  .ant-table-thead > tr > th {
-    padding: $spacing-base $spacing-base;
+  :global(.ant-table-thead) > tr > th {
+    padding: $spacing-base $spacing-base $spacing-base $spacing-small;
     color: $colors--neutral-6;
-    font-family: $font-family--semi-bold;
-    font-weight: $font-weight--bold;
-    letter-spacing: 1.5px;
+    background-color: $colors--neutral-1;
+    &, span {
+      @include table-header-text;
+    }
 
-    .ant-table-column-sorter {
+    :global(.ant-table-column-sorter) {
       vertical-align: baseline;
+    }
+    :global{
+      .ant-table-header-column .ant-table-column-sorters:hover::before {
+        background-color: $colors--neutral-1;
+      }
     }
   }
   // END: Table header
@@ -31,63 +38,65 @@
   // END: Table Column
 
   // Expand/Collapse icon
-  .ant-table-row-expand-icon {
+  :global(.ant-table-row-expand-icon) {
     border: none;
     background-color: transparent;
   }
 
-  .ant-table-row-collapsed::after {
+  :global(.ant-table-row-collapsed)::after {
     content: '▶';
     font-size: 8px;
   }
 
-  .ant-table-row-expanded::after {
+  :global(.ant-table-row-expanded)::after {
     content: '▼';
     font-size: 8px;
   }
   // END: Expand/Collapse icon
 
   // Table row
-  .ant-table-row {
+  :global(.ant-table-row) {
     @include text--body;
   }
 
-  .ant-table-row .cell--show-on-hover {
+  :global(.ant-table-row) .cell--show-on-hover {
     visibility: hidden;
   }
 
-  .ant-table-row:hover .cell--show-on-hover {
+  :global(.ant-table-row):hover .cell--show-on-hover {
     visibility: visible;
   }
   // END: Table row
 
   // Table cell
-  .ant-table-tbody > tr > td {
+  :global(.ant-table-tbody) > tr > td {
     padding: $spacing-smaller $spacing-smaller;
     border-bottom-color: $colors--neutral-3;
   }
 
   // Increase right padding for columns aligned by right
-  .ant-table-tbody > tr > td.column--align-right {
+  :global(.ant-table-tbody) > tr > td.column--align-right {
     padding-right: $spacing-mid-large;
   }
 
   // show column with right border
-  .ant-table-tbody > tr > td.column--border-right {
+  :global(.ant-table-tbody) > tr > td.column--border-right {
     border-right: $colors--neutral-3 solid 1px;
   }
   // END: Table cell
 
   // Table cell on hover
-  .ant-table-thead > tr.ant-table-row-hover:not(.ant-table-expanded-row):not(.ant-table-row-selected) > td,
-  .ant-table-tbody > tr.ant-table-row-hover:not(.ant-table-expanded-row):not(.ant-table-row-selected) > td,
-  .ant-table-thead > tr:hover:not(.ant-table-expanded-row):not(.ant-table-row-selected) > td,
-  .ant-table-tbody > tr:hover:not(.ant-table-expanded-row):not(.ant-table-row-selected) > td {
-    background: $colors--neutral-1;
+  :global {
+    .ant-table-thead > tr.ant-table-row-hover:not(.ant-table-expanded-row):not(.ant-table-row-selected) > td,
+    .ant-table-tbody > tr.ant-table-row-hover:not(.ant-table-expanded-row):not(.ant-table-row-selected) > td,
+    .ant-table-thead > tr:hover:not(.ant-table-expanded-row):not(.ant-table-row-selected) > td,
+    .ant-table-tbody > tr:hover:not(.ant-table-expanded-row):not(.ant-table-row-selected) > td {
+      background: $colors--neutral-1;
+    }
   }
   // END: Table cell on hover
 
-  .ant-table-placeholder {
+  :global(.ant-table-placeholder) {
     border: $colors--neutral-1 solid 1px;
   }
 
@@ -96,13 +105,8 @@
     text-align: center;
   }
 
-  .ant-pagination.ant-table-pagination {
-    text-align: center;
-    float: unset;
-  }
-
   &__empty {
-    .ant-table-placeholder {
+    :global(.ant-table-placeholder) {
       border: none;
     }
   }

--- a/packages/cluster-ui/src/table/table.tsx
+++ b/packages/cluster-ui/src/table/table.tsx
@@ -33,7 +33,7 @@ export function Table<T>(props: TableProps<T>) {
   return (
     <ConfigProvider renderEmpty={customizeRenderEmpty(noDataMessage)}>
       <AntTable<T>
-        className={cx(`crl-table-wrapper ${className}`, {
+        className={cx("crl-table-wrapper", className, {
           "crl-table-wrapper__empty": dataSource.length === 0,
         })}
         columns={columns}


### PR DESCRIPTION
#### Backport for https://github.com/cockroachdb/ui/pull/250

Different pages use different implementations of table component
with their very own styles or override default styles with custom.
It caused styles mismatching.

Current change doesn't try to unify all components/styles but
locally fixes styles and somehow reuses it. It'll allow to
backport changes for older versions with less stress.