### PR TITLE
cluster-ui: re-export uiConfiguration actions

### DIFF
--- a/packages/cluster-ui/src/store/index.ts
+++ b/packages/cluster-ui/src/store/index.ts
@@ -1,3 +1,4 @@
 export { sagas } from "./sagas";
 export { notificationAction } from "./notifications";
+export { actions as uiConfigActions, UIConfigState } from "./uiConfig";
 export { rootReducer, AppState, rootActions } from "./reducers";


### PR DESCRIPTION
cluster-ui package has to re-export uiConfig actions to allow external apps
to change the reducers state in type-safe way - with action creator and
provided types.
