### PR TITLE
backport 20.2: reset redux state action

### DIFF
--- a/packages/cluster-ui/src/store/index.ts
+++ b/packages/cluster-ui/src/store/index.ts
@@ -1,3 +1,3 @@
 export { sagas } from "./sagas";
 export { notificationAction } from "./notifications";
-export { rootReducer, AppState } from "./reducers";
+export { rootReducer, AppState, rootActions } from "./reducers";

--- a/packages/cluster-ui/src/store/reducers.spec.ts
+++ b/packages/cluster-ui/src/store/reducers.spec.ts
@@ -1,0 +1,22 @@
+import { assert } from "chai";
+import { createStore } from "redux";
+import { rootActions, rootReducer } from "./reducers";
+import { actions as statementsActions } from "./statements";
+
+describe("rootReducer", () => {
+  it("resets redux state on RESET_STATE action", () => {
+    const store = createStore(rootReducer);
+    const initState = store.getState();
+    const error = new Error("oops!");
+    store.dispatch(statementsActions.failed(error));
+    const changedState = store.getState();
+    store.dispatch(rootActions.resetState());
+    const resetState = store.getState();
+
+    assert.deepEqual(initState, resetState);
+    assert.notDeepEqual(
+      resetState.statements.lastError,
+      changedState.statements.lastError,
+    );
+  });
+});

--- a/packages/cluster-ui/src/store/reducers.ts
+++ b/packages/cluster-ui/src/store/reducers.ts
@@ -1,4 +1,5 @@
-import { combineReducers } from "redux";
+import { combineReducers, createStore } from "redux";
+import { createAction, createReducer } from "@reduxjs/toolkit";
 import { StatementsState, reducer as statements } from "./statements";
 import { LocalStorageState, reducer as localStorage } from "./localStorage";
 import {
@@ -13,6 +14,7 @@ import {
   reducer as terminateQuery,
 } from "./terminateQuery";
 import { UIConfigState, reducer as uiConfig } from "./uiConfig";
+import { DOMAIN_NAME } from "./utils";
 
 export type AdminUiState = {
   statements: StatementsState;
@@ -29,7 +31,7 @@ export type AppState = {
   adminUI: AdminUiState;
 };
 
-export const rootReducer = combineReducers<AdminUiState>({
+export const reducers = combineReducers<AdminUiState>({
   localStorage,
   statementDiagnostics,
   statements,
@@ -38,4 +40,17 @@ export const rootReducer = combineReducers<AdminUiState>({
   sessions,
   terminateQuery,
   uiConfig,
+});
+
+export const rootActions = {
+  resetState: createAction(`${DOMAIN_NAME}/RESET_STATE`),
+};
+
+/**
+ * rootReducer consolidates reducers slices and cases for handling global actions related to entire state.
+ **/
+export const rootReducer = createReducer(undefined, builder => {
+  builder
+    .addCase(rootActions.resetState, () => createStore(reducers).getState())
+    .addDefaultCase(reducers);
 });


### PR DESCRIPTION
#### backport for https://github.com/cockroachdb/ui/pull/234

Initially, it wasn't possible to reset redux state at some point
during application life cycle.
Switching between multiple clusters that should keep their own
state in redux store requires to have ability to re-initialize
an empty redux state.

(cherry picked from commit 8e52a107eb3283c4ed60cca01499a866eeb717d4)
