### PR TITLE
cluster-ui: proper empty state design for statement diagnostics view

### DIFF
--- a/packages/cluster-ui/src/empty/emptyTable/emptyTable.module.scss
+++ b/packages/cluster-ui/src/empty/emptyTable/emptyTable.module.scss
@@ -6,8 +6,12 @@
   padding: $spacing-large;
   align-items: center;
   text-align: center;
-  max-width: 600px;
+  max-width: 750px;
   margin: 0 auto;
+}
+
+.icon-container {
+  margin-bottom: $spacing-large;
 }
 
 .title {
@@ -15,6 +19,6 @@
 }
 
 .message {
-  color: $colors--title;
+  color: $colors--secondary-text;
   margin-bottom: $spacing-medium;
 }

--- a/packages/cluster-ui/src/empty/emptyTable/emptyTable.tsx
+++ b/packages/cluster-ui/src/empty/emptyTable/emptyTable.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import classNames from "classnames/bind";
 import { isString } from "lodash";
+import { Heading, Text } from "@cockroachlabs/ui-components";
 import styles from "./emptyTable.module.scss";
-import { Text, TextTypes } from "src/text";
 
 export interface EmptyTableProps {
   icon?: string | React.ReactNode;
@@ -30,14 +30,8 @@ export const EmptyTable: React.FC<EmptyTableProps> = ({
         {isString(icon) ? <img src={icon} className={cx("icon")} /> : icon}
       </div>
     )}
-    <Text textType={TextTypes.Heading3} className={cx("title")}>
-      {title}
-    </Text>
-    {message && (
-      <Text textType={TextTypes.Body} className={cx("message")}>
-        {message}
-      </Text>
-    )}
+    <Heading type="h3">{title}</Heading>
+    {message && <Text className={cx("message")}>{message}</Text>}
     {footer && <div className={cx("footer")}>{footer}</div>}
   </div>
 );

--- a/packages/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.module.scss
+++ b/packages/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.module.scss
@@ -12,7 +12,7 @@
   }
 
   &__footer {
-    margin: $spacing-medium 0 0 $spacing-smaller;
+    margin-top: $spacing-medium;
   }
 
   &__content {
@@ -62,10 +62,20 @@
   @include text--body;
 }
 
-.summary--card__empty-state {
-  background-color: $colors--white;
-  background-image: url("./emptyTracingBackground.svg");
-  background-repeat: no-repeat;
-  background-position-x: right;
-  padding: 0;
+.empty-view {
+  &__footer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    > * {
+      margin-bottom: $spacing-medium;
+    }
+  }
+}
+
+.download-bundle-button {
+  white-space: nowrap;
+  > svg {
+    margin-right: $spacing-x-small;
+  }
 }

--- a/packages/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.spec.tsx
+++ b/packages/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.spec.tsx
@@ -88,7 +88,7 @@ describe("DiagnosticsView", () => {
 
     it("calls activate callback with statementId when click on Activate button", () => {
       const activateButtonComponent = wrapper
-        .findWhere(n => n.prop("children") === "Activate")
+        .findWhere(n => n.prop("children") === "Activate diagnostics")
         .first();
       activateButtonComponent.simulate("click");
       activateFn.calledOnceWith(statementFingerprint);
@@ -111,7 +111,7 @@ describe("DiagnosticsView", () => {
         </TestStoreProvider>,
       );
       const activateButtonComponent = wrapper
-        .findWhere(n => n.prop("children") === "Activate")
+        .findWhere(n => n.prop("children") === "Activate diagnostics")
         .first();
       assert.isFalse(activateButtonComponent.exists());
     });

--- a/packages/cluster-ui/src/statementDetails/statementDetails.spec.tsx
+++ b/packages/cluster-ui/src/statementDetails/statementDetails.spec.tsx
@@ -93,7 +93,7 @@ describe("StatementDetails page", () => {
 
       wrapper
         .find(DiagnosticsView)
-        .findWhere(n => n.prop("children") === "Activate")
+        .findWhere(n => n.prop("children") === "Activate Diagnostics")
         .first()
         .simulate("click");
 

--- a/packages/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/packages/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -31,8 +31,8 @@ import {
 } from "src/statementsDiagnostics";
 import { ISortedTablePagination } from "../sortedtable";
 import styles from "./statementsPage.module.scss";
+import { EmptyStatementsPlaceholder } from "./emptyStatementsPlaceholder";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
-import { statementsTable } from "src/util/docs";
 
 type IStatementDiagnosticsReport = cockroach.server.serverpb.IStatementDiagnosticsReport;
 import sortableTableStyles from "src/sortedtable/sortedtable.module.scss";
@@ -324,15 +324,11 @@ export class StatementsPage extends React.Component<
             )}
             sortSetting={this.state.sortSetting}
             onChangeSortSetting={this.changeSortSetting}
-            empty={data.length === 0 && search.length === 0}
-            emptyProps={{
-              title:
-                "There are no statements since this page was last cleared.",
-              description:
-                "Statements help you identify frequently executed or high latency SQL statements. Statements are cleared every hour by default, or according to your configuration.",
-              label: "Learn more",
-              buttonHref: statementsTable,
-            }}
+            renderNoResult={
+              <EmptyStatementsPlaceholder
+                isEmptySearchResults={isEmptySearchResults}
+              />
+            }
             pagination={pagination}
           />
         </section>


### PR DESCRIPTION
Several commits ago (62a6d372a55619625ae41f0b9dc4632a82ec3cee), empty state component for Statement diagnostics view has been
changed to old design and now it is rolled back.

Additional changes were made to reuse `ui-components` (`Heading`, `Text` and `Button` components).

This change fixes issue described https://github.com/cockroachdb/ui/pull/253#issuecomment-806903656

New designs:
<img width="1423" alt="Screen Shot 2021-03-26 at 9 31 05 PM" src="https://user-images.githubusercontent.com/3106437/112683919-facfaa80-8e7a-11eb-869b-e32092a1fd3f.png">



