### PR TITLE
cluster-ui: default values for statement details ui configuration

### DIFF
--- a/packages/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/packages/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -126,7 +126,7 @@ export interface StatementDetailsStateProps {
   statementsError: Error | null;
   nodeNames: { [nodeId: string]: string };
   diagnosticsReports: cockroach.server.serverpb.IStatementDiagnosticsReport[];
-  uiConfig: UIConfigState["pages"]["statementDetails"];
+  uiConfig?: UIConfigState["pages"]["statementDetails"];
 }
 
 export type StatementDetailsOwnProps = StatementDetailsDispatchProps &
@@ -282,6 +282,9 @@ export class StatementDetails extends React.Component<
 
   static defaultProps: Partial<StatementDetailsProps> = {
     onDiagnosticBundleDownload: _.noop,
+    uiConfig: {
+      showStatementDiagnosticsLink: true,
+    },
   };
 
   changeSortSetting = (ss: SortSetting) => {


### PR DESCRIPTION
Recently Statement details page were extended with `uiConfig` prop that
includes flags to tweak visibility for particular UI elements.
`uiConfig` prop should not be required, and it should be okay to
skip it to render default UI.

Current change adds default value for `uiConfig` prop and makes this
field as optional for statementDetailsProps type.
