### PR TITLE
cluster-ui: analytics tracking events

### DIFF
--- a/packages/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.tsx
+++ b/packages/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.tsx
@@ -32,6 +32,11 @@ export interface DiagnosticsViewDispatchProps {
   activate: (statementFingerprint: string) => void;
   dismissAlertMessage: () => void;
   onDownloadDiagnosticBundleClick?: (statementFingerprint: string) => void;
+  onSortingChange?: (
+    name: string,
+    columnTitle: string,
+    ascending: boolean,
+  ) => void;
 }
 
 export interface DiagnosticsViewOwnProps {
@@ -158,6 +163,12 @@ export class DiagnosticsView extends React.Component<
     this.props.dismissAlertMessage();
   }
 
+  onSortingChange = (columnName: string, ascending: boolean) => {
+    if (this.props.onSortingChange) {
+      this.props.onSortingChange("Diagnostics", columnName, ascending);
+    }
+  };
+
   render() {
     const { hasData, diagnosticsReports, showDiagnosticsViewLink } = this.props;
 
@@ -193,7 +204,11 @@ export class DiagnosticsView extends React.Component<
             </Button>
           )}
         </div>
-        <Table dataSource={dataSource} columns={this.columns} />
+        <Table
+          dataSource={dataSource}
+          columns={this.columns}
+          onSortingChange={this.onSortingChange}
+        />
         {showDiagnosticsViewLink && (
           <div className={cx("crl-statements-diagnostics-view__footer")}>
             <Link

--- a/packages/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/packages/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -116,7 +116,13 @@ export interface StatementDetailsDispatchProps {
   createStatementDiagnosticsReport: (statementFingerprint: string) => void;
   dismissStatementDiagnosticsAlertMessage?: () => void;
   onTabChanged?: (tabName: string) => void;
-  onDiagnosticBundleDownload?: (statementFingerprint: string) => void;
+  onDiagnosticBundleDownload?: (statementFingerprint?: string) => void;
+  onSortingChange?: (
+    name: string,
+    columnTitle: string,
+    ascending: boolean,
+  ) => void;
+  onBackToStatementsClick?: () => void;
 }
 
 export interface StatementDetailsStateProps {
@@ -286,6 +292,9 @@ export class StatementDetails extends React.Component<
     this.setState({
       sortSetting: ss,
     });
+    if (this.props.onSortingChange) {
+      this.props.onSortingChange("Stats By Node", ss.columnTitle, ss.ascending);
+    }
   };
 
   componentDidMount() {
@@ -316,6 +325,13 @@ export class StatementDetails extends React.Component<
     this.props.onTabChanged && this.props.onTabChanged(tabId);
   };
 
+  backToStatementsClick = () => {
+    this.props.history.push("/statements");
+    if (this.props.onBackToStatementsClick) {
+      this.props.onBackToStatementsClick();
+    }
+  };
+
   render() {
     const app = getMatchParamByName(this.props.match, appAttr);
     return (
@@ -323,7 +339,7 @@ export class StatementDetails extends React.Component<
         <Helmet title={`Details | ${app ? `${app} App |` : ""} Statements`} />
         <div className={cx("section", "page--header")}>
           <Button
-            onClick={() => this.props.history.push("/statements")}
+            onClick={this.backToStatementsClick}
             type="unstyled-link"
             size="small"
             icon={<ArrowLeft fontSize={"10px"} />}
@@ -721,6 +737,7 @@ export class StatementDetails extends React.Component<
             showDiagnosticsViewLink={
               this.props.uiConfig.showStatementDiagnosticsLink
             }
+            onSortingChange={this.props.onSortingChange}
           />
         </TabPane>
         <TabPane tab="Logical Plan" key="logical-plan">

--- a/packages/cluster-ui/src/statementsPage/statementsPageConnected.tsx
+++ b/packages/cluster-ui/src/statementsPage/statementsPageConnected.tsx
@@ -1,5 +1,6 @@
 import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
+import { Dispatch } from "redux";
 
 import { AppState } from "src/store";
 import { actions as statementActions } from "src/store/statements";
@@ -9,7 +10,6 @@ import { actions as localStorageActions } from "src/store/localStorage";
 import {
   StatementsPage,
   StatementsPageDispatchProps,
-  StatementsPageOuterProps,
   StatementsPageProps,
   StatementsPageStateProps,
 } from "./statementsPage";
@@ -22,10 +22,12 @@ import {
 } from "./statementsPage.selectors";
 import { AggregateStatistics } from "../statementsTable";
 
-type OwnProps = StatementsPageOuterProps & RouteComponentProps;
-
 export const ConnectedStatementsPage = withRouter(
-  connect<StatementsPageStateProps, StatementsPageDispatchProps, OwnProps>(
+  connect<
+    StatementsPageStateProps,
+    StatementsPageDispatchProps,
+    RouteComponentProps
+  >(
     (state: AppState, props: StatementsPageProps) => ({
       statements: selectStatements(state, props),
       statementsError: selectStatementsLastError(state),
@@ -33,40 +35,69 @@ export const ConnectedStatementsPage = withRouter(
       totalFingerprints: selectTotalFingerprints(state),
       lastReset: selectLastReset(state),
     }),
-    {
-      refreshStatements: statementActions.refresh,
-      refreshStatementDiagnosticsRequests: statementDiagnosticsActions.refresh,
+    (dispatch: Dispatch) => ({
+      refreshStatements: () => dispatch(statementActions.refresh()),
+      refreshStatementDiagnosticsRequests: () =>
+        dispatch(statementDiagnosticsActions.refresh()),
       dismissAlertMessage: () =>
-        localStorageActions.update({
-          key: "adminUi/showDiagnosticsModal",
-          value: false,
-        }),
-      onActivateStatementDiagnostics: statementDiagnosticsActions.createReport,
-      onDiagnosticsModalOpen: (statementFingerprint: string) =>
-        analyticsActions.activateDiagnostics({
-          page: "statements",
-          value: statementFingerprint,
-        }),
-      onSearchComplete: (results: AggregateStatistics[]) =>
-        analyticsActions.search({
-          page: "statements",
-          value: results?.length || 0,
-        }),
-      onPageChanged: (pageNum: number) =>
-        analyticsActions.pagination({ page: "statements", value: pageNum }),
-      onSortingChange: (
-        tableName: string,
-        columnName: string,
-        ascending: boolean,
-      ) =>
-        analyticsActions.sorting({
-          page: "statements",
-          value: {
+        dispatch(
+          localStorageActions.update({
+            key: "adminUi/showDiagnosticsModal",
+            value: false,
+          }),
+        ),
+      onActivateStatementDiagnostics: (statementFingerprint: string) => {
+        dispatch(
+          statementDiagnosticsActions.createReport(statementFingerprint),
+        );
+        dispatch(
+          analyticsActions.track({
+            name: "Statement Diagnostics Clicked",
+            page: "Statements",
+            action: "Activated",
+          }),
+        );
+      },
+      onDiagnosticsReportDownload: () =>
+        dispatch(
+          analyticsActions.track({
+            name: "Statement Diagnostics Clicked",
+            page: "Statements",
+            action: "Downloaded",
+          }),
+        ),
+      onSearchComplete: (_results: AggregateStatistics[]) =>
+        dispatch(
+          analyticsActions.track({
+            name: "Keyword Searched",
+            page: "Statements",
+          }),
+        ),
+      onFilterChange: value =>
+        dispatch(
+          analyticsActions.track({
+            name: "Filter Clicked",
+            page: "Statements",
+            filterName: "app",
+            value,
+          }),
+        ),
+      onSortingChange: (tableName: string, columnName: string) =>
+        dispatch(
+          analyticsActions.track({
+            name: "Column Sorted",
+            page: "Statements",
             tableName,
             columnName,
-            ascending,
-          },
-        }),
-    },
+          }),
+        ),
+      onStatementClick: () =>
+        dispatch(
+          analyticsActions.track({
+            name: "Statement Clicked",
+            page: "Statements",
+          }),
+        ),
+    }),
   )(StatementsPage),
 );

--- a/packages/cluster-ui/src/statementsTable/statementsTable.tsx
+++ b/packages/cluster-ui/src/statementsTable/statementsTable.tsx
@@ -121,13 +121,18 @@ export function makeStatementsColumns(
   search?: string,
   activateDiagnosticsRef?: React.RefObject<ActivateDiagnosticsModalRef>,
   onDiagnosticsDownload?: (report: IStatementDiagnosticsReport) => void,
+  onStatementClick?: (statement: string) => void,
 ): ColumnDescriptor<AggregateStatistics>[] {
   const columns: ColumnDescriptor<AggregateStatistics>[] = [
     {
       name: "statements",
       title: StatementTableTitle.statements,
       className: cx("cl-table__col-query-text"),
-      cell: StatementTableCell.statements(search, selectedApp),
+      cell: StatementTableCell.statements(
+        search,
+        selectedApp,
+        onStatementClick,
+      ),
       sort: stmt => stmt.label,
     },
     {

--- a/packages/cluster-ui/src/statementsTable/statementsTableContent.tsx
+++ b/packages/cluster-ui/src/statementsTable/statementsTableContent.tsx
@@ -198,12 +198,17 @@ export const StatementTableTitle = {
 };
 
 export const StatementTableCell = {
-  statements: (search?: string, selectedApp?: string) => (stmt: any) => (
+  statements: (
+    search?: string,
+    selectedApp?: string,
+    onStatementClick?: (statement: string) => void,
+  ) => (stmt: any) => (
     <StatementLink
       statement={stmt.label}
       implicitTxn={stmt.implicitTxn}
       search={search}
       app={selectedApp}
+      onClick={onStatementClick}
     />
   ),
   diagnostics: (
@@ -285,6 +290,7 @@ interface StatementLinkProps {
   implicitTxn: boolean;
   search: string;
   anonStatement?: string;
+  onClick?: (statement: string) => void;
 }
 
 // StatementLinkTarget returns the link to the relevant statement page, given
@@ -306,8 +312,15 @@ export const StatementLinkTarget = (props: StatementLinkProps) => {
 
 export const StatementLink = (props: StatementLinkProps) => {
   const summary = summarize(props.statement);
+  const { onClick, statement } = props;
+  const onStatementClick = React.useCallback(() => {
+    if (onClick) {
+      onClick(statement);
+    }
+  }, [onClick, statement]);
+
   return (
-    <Link to={StatementLinkTarget(props)}>
+    <Link to={StatementLinkTarget(props)} onClick={onStatementClick}>
       <div>
         <Tooltip
           placement="bottom"

--- a/packages/cluster-ui/src/store/analytics/analytics.reducer.ts
+++ b/packages/cluster-ui/src/store/analytics/analytics.reducer.ts
@@ -1,39 +1,66 @@
 import { createAction } from "@reduxjs/toolkit";
+import { DOMAIN_NAME } from "../utils";
 
-type Page =
-  | "statements"
-  | "statementDetails"
-  | "transactions"
-  | "transactionDetails";
+type Page = "Statements" | "Statement Details";
 
-type PagePayload<T> = {
+type SearchEvent = {
+  name: "Keyword Searched";
   page: Page;
-  value: T;
 };
 
-type SortingPayload = {
+type SortingEvent = {
+  name: "Column Sorted";
+  page: Page;
   tableName: string;
   columnName: string;
-  ascending?: boolean;
 };
 
-const PREFIX = "adminUI/analytics";
+type StatementDiagnosticEvent = {
+  name: "Statement Diagnostics Clicked";
+  page: Page;
+  action: "Activated" | "Downloaded";
+};
+
+type TabChangedEvent = {
+  name: "Tab Changed";
+  tabName: string;
+  page: Page;
+};
+
+type BackButtonClick = {
+  name: "Back Clicked";
+  page: Page;
+};
+
+type StatementClicked = {
+  name: "Statement Clicked";
+  page: Page;
+};
+
+type FilterEvent = {
+  name: "Filter Clicked";
+  page: Page;
+  filterName: string;
+  value: string;
+};
+
+type AnalyticsEvent =
+  | SortingEvent
+  | StatementDiagnosticEvent
+  | SearchEvent
+  | TabChangedEvent
+  | BackButtonClick
+  | FilterEvent
+  | StatementClicked;
+
+const PREFIX = `${DOMAIN_NAME}/analytics`;
 
 /**
  * actions accept payload with "page" field which specifies the page where
  * action occurs and a value expected expected by specific action.
  */
 export const actions = {
-  search: createAction<PagePayload<number>>(`${PREFIX}/search`),
-  pagination: createAction<PagePayload<number>>(`${PREFIX}/pagination`),
-  sorting: createAction<PagePayload<SortingPayload>>(`${PREFIX}/sorting`),
-  activateDiagnostics: createAction<PagePayload<string>>(
-    `${PREFIX}/activateStatementDiagnostics`,
-  ),
-  downloadStatementDiagnostics: createAction<PagePayload<string>>(
-    `${PREFIX}/downloadStatementDiagnostics`,
-  ),
-  subNavigationSelection: createAction<PagePayload<string>>(
-    `${PREFIX}/subNavigationSelection`,
-  ),
+  track: createAction(`${PREFIX}/track`, (event: AnalyticsEvent) => ({
+    payload: event,
+  })),
 };

--- a/packages/cluster-ui/src/store/index.ts
+++ b/packages/cluster-ui/src/store/index.ts
@@ -1,4 +1,5 @@
 export { sagas } from "./sagas";
 export { notificationAction } from "./notifications";
+export { actions as analyticsActions } from "./analytics";
 export { actions as uiConfigActions, UIConfigState } from "./uiConfig";
 export { rootReducer, AppState, rootActions } from "./reducers";

--- a/packages/cluster-ui/src/table/table.tsx
+++ b/packages/cluster-ui/src/table/table.tsx
@@ -13,6 +13,7 @@ export interface TableProps<T> {
   tableLayout?: "fixed" | "auto";
   pageSize?: number;
   className?: string;
+  onSortingChange?: (columnName: string, ascending: boolean) => void;
 }
 
 const cx = classnames.bind(styles);
@@ -29,6 +30,7 @@ export function Table<T>(props: TableProps<T>) {
     tableLayout = "auto",
     pageSize,
     className,
+    onSortingChange,
   } = props;
   return (
     <ConfigProvider renderEmpty={customizeRenderEmpty(noDataMessage)}>
@@ -41,6 +43,14 @@ export function Table<T>(props: TableProps<T>) {
         expandRowByClick
         tableLayout={tableLayout}
         pagination={{ hideOnSinglePage: true, pageSize }}
+        onChange={(pagination, filters, sorter) => {
+          if (onSortingChange && sorter.column) {
+            onSortingChange(
+              sorter.column?.title as string,
+              sorter.order === "ascend",
+            );
+          }
+        }}
       />
     </ConfigProvider>
   );


### PR DESCRIPTION
#### Backport for https://github.com/cockroachdb/ui/pull/267

Current change extends list of tracked events and refactors
analytics reducer to make it more generic.

Analytics reducer provides single action (`track`) that accepts
different event types - it allows extend this action to work with
new types and have single to watch in case client's app is interested
in all possible analytics events.

Event types include required `name` field that has to follow Segment's
naming conventions and the rest of optional fields can be considered as
Segments properties.

To avoid coupling of analytics events with components - all logic are
defined in Connected components. Connected components have been refactored
`mapDispatchToProps` object is defined as function to be able to dispatch
multiple events in single method (`onActivateStatementDiagnostics` method
dispatches one action to create report and next action to track analytics).

Following events tracked:
- activate statements diagnostics (from statements and statement details pages)
- download statement diagnostics archive
- click on statement row in statements table
- change App filter on Statements page
- search statement on statements page
- change tabs on statement details page
- soring by columns in tables (statements table, and statement details
tables: Diagnostics and Stats table).
- track when click `Back to statements` button on statement details page;

(cherry picked from commit 43f929bf61a86fdd32696256c2e0535385b69431)