### PR TITLE
cluster-ui: add button to reset SQL stats on statement page and txn page

### DIFF
--- a/packages/cluster-ui/package.json
+++ b/packages/cluster-ui/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.12.13",
-    "@cockroachlabs/crdb-protobuf-client": "^0.0.7",
+    "@cockroachlabs/crdb-protobuf-client": "^0.0.8",
     "@cockroachlabs/icons": "0.3.0",
     "@cockroachlabs/ui-components": "0.2.14-alpha.0",
     "@popperjs/core": "^2.4.0",

--- a/packages/cluster-ui/src/api/sqlStatsApi.ts
+++ b/packages/cluster-ui/src/api/sqlStatsApi.ts
@@ -1,0 +1,12 @@
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import { fetchData } from "src/api";
+
+const RESET_SQL_STATS_PATH = "/_status/resetsqlstats";
+
+export const resetSQLStats = (): Promise<cockroach.server.serverpb.ResetSQLStatsResponse> => {
+  return fetchData(
+    cockroach.server.serverpb.ResetSQLStatsResponse,
+    RESET_SQL_STATS_PATH,
+    cockroach.server.serverpb.ResetSQLStatsRequest,
+  );
+};

--- a/packages/cluster-ui/src/statementsPage/statementsPage.fixture.ts
+++ b/packages/cluster-ui/src/statementsPage/statementsPage.fixture.ts
@@ -501,6 +501,7 @@ const statementsPagePropsFixture: StatementsPageProps = {
   dismissAlertMessage: noop,
   refreshStatementDiagnosticsRequests: noop,
   refreshStatements: noop,
+  resetSQLStats: noop,
   onActivateStatementDiagnostics: noop,
   onDiagnosticsModalOpen: noop,
   onSearchComplete: noop,

--- a/packages/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/packages/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -47,6 +47,7 @@ const sortableTableCx = classNames.bind(sortableTableStyles);
 export interface StatementsPageDispatchProps {
   refreshStatements: () => void;
   refreshStatementDiagnosticsRequests: () => void;
+  resetSQLStats: () => void;
   dismissAlertMessage: () => void;
   onActivateStatementDiagnostics: (statement: string) => void;
   onDiagnosticsModalOpen?: (statement: string) => void;
@@ -286,6 +287,7 @@ export class StatementsPage extends React.Component<
       lastReset,
       onDiagnosticsReportDownload,
       onStatementClick,
+      resetSQLStats,
     } = this.props;
     const appAttrValue = getMatchParamByName(match, appAttr);
     const selectedApp = appAttrValue || "";
@@ -325,6 +327,7 @@ export class StatementsPage extends React.Component<
             arrayItemName="statements"
             activeFilters={activeFilters}
             onClearFilters={this.onClearFilters}
+            resetSQLStats={resetSQLStats}
           />
           <StatementsSortedTable
             className="statements-table"

--- a/packages/cluster-ui/src/statementsPage/statementsPageConnected.tsx
+++ b/packages/cluster-ui/src/statementsPage/statementsPageConnected.tsx
@@ -7,6 +7,7 @@ import { actions as statementActions } from "src/store/statements";
 import { actions as statementDiagnosticsActions } from "src/store/statementDiagnostics";
 import { actions as analyticsActions } from "src/store/analytics";
 import { actions as localStorageActions } from "src/store/localStorage";
+import { actions as resetSQLStatsActions } from "src/store/sqlStats";
 import {
   StatementsPage,
   StatementsPageDispatchProps,
@@ -39,6 +40,7 @@ export const ConnectedStatementsPage = withRouter(
       refreshStatements: () => dispatch(statementActions.refresh()),
       refreshStatementDiagnosticsRequests: () =>
         dispatch(statementDiagnosticsActions.refresh()),
+      resetSQLStats: () => dispatch(resetSQLStatsActions.request()),
       dismissAlertMessage: () =>
         dispatch(
           localStorageActions.update({

--- a/packages/cluster-ui/src/store/sagas.ts
+++ b/packages/cluster-ui/src/store/sagas.ts
@@ -8,6 +8,7 @@ import { livenessSaga } from "./liveness";
 import { sessionsSaga } from "./sessions";
 import { terminateSaga } from "./terminateQuery";
 import { notifificationsSaga } from "./notifications";
+import { sqlStatsSaga } from "./sqlStats";
 
 export function* sagas(cacheInvalidationPeriod?: number) {
   yield all([
@@ -19,5 +20,6 @@ export function* sagas(cacheInvalidationPeriod?: number) {
     fork(sessionsSaga),
     fork(terminateSaga),
     fork(notifificationsSaga),
+    fork(sqlStatsSaga),
   ]);
 }

--- a/packages/cluster-ui/src/store/sqlStats/index.ts
+++ b/packages/cluster-ui/src/store/sqlStats/index.ts
@@ -1,0 +1,2 @@
+export * from "./sqlStats.reducer";
+export * from "./sqlStats.sagas";

--- a/packages/cluster-ui/src/store/sqlStats/sqlStats.reducer.ts
+++ b/packages/cluster-ui/src/store/sqlStats/sqlStats.reducer.ts
@@ -1,0 +1,41 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import { DOMAIN_NAME, noopReducer } from "../utils";
+
+type ResetSQLStatsResponse = cockroach.server.serverpb.ResetSQLStatsResponse;
+
+export type ResetSQLStatsState = {
+  data: ResetSQLStatsResponse;
+  lastError: Error;
+  valid: boolean;
+};
+
+const initialState: ResetSQLStatsState = {
+  data: null,
+  lastError: null,
+  valid: true,
+};
+
+const resetSQLStatsSlice = createSlice({
+  name: `${DOMAIN_NAME}/resetsqlstats`,
+  initialState,
+  reducers: {
+    received: (state, action: PayloadAction<ResetSQLStatsResponse>) => {
+      state.data = action.payload;
+      state.valid = true;
+      state.lastError = null;
+    },
+    failed: (state, action: PayloadAction<Error>) => {
+      state.valid = false;
+      state.lastError = action.payload;
+    },
+    invalidated: state => {
+      state.valid = false;
+    },
+    // Define actions that don't change state
+    refresh: noopReducer,
+    request: noopReducer,
+  },
+});
+
+export const { reducer, actions } = resetSQLStatsSlice;

--- a/packages/cluster-ui/src/store/sqlStats/sqlStats.sagas.spec.ts
+++ b/packages/cluster-ui/src/store/sqlStats/sqlStats.sagas.spec.ts
@@ -1,0 +1,48 @@
+import { expectSaga } from "redux-saga-test-plan";
+import { throwError } from "redux-saga-test-plan/providers";
+import * as matchers from "redux-saga-test-plan/matchers";
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+
+import { resetSQLStatsSaga } from "./sqlStats.sagas";
+import { resetSQLStats } from "../../api/sqlStatsApi";
+import {
+  actions as sqlStatsActions,
+  reducer as sqlStatsReducers,
+  ResetSQLStatsState,
+} from "./sqlStats.reducer";
+import { actions as statementActions } from "src/store/statements/statements.reducer";
+
+describe("SQL Stats sagas", () => {
+  describe("resetSQLStatsSaga", () => {
+    const resetSQLStatsResponse = new cockroach.server.serverpb.ResetSQLStatsResponse();
+
+    it("successfully resets SQL stats", () => {
+      expectSaga(resetSQLStatsSaga)
+        .provide([[matchers.call.fn(resetSQLStats), resetSQLStatsResponse]])
+        .put(sqlStatsActions.received(resetSQLStatsResponse))
+        .put(statementActions.invalidated())
+        .put(statementActions.refresh())
+        .withReducer(sqlStatsReducers)
+        .hasFinalState<ResetSQLStatsState>({
+          data: resetSQLStatsResponse,
+          lastError: null,
+          valid: true,
+        })
+        .run();
+    });
+
+    it("returns error on failed reset", () => {
+      const err = new Error("failed to reset");
+      expectSaga(resetSQLStatsSaga)
+        .provide([[matchers.call.fn(resetSQLStats), throwError(err)]])
+        .put(sqlStatsActions.failed(err))
+        .withReducer(sqlStatsReducers)
+        .hasFinalState<ResetSQLStatsState>({
+          data: null,
+          lastError: err,
+          valid: false,
+        })
+        .run();
+    });
+  });
+});

--- a/packages/cluster-ui/src/store/sqlStats/sqlStats.sagas.ts
+++ b/packages/cluster-ui/src/store/sqlStats/sqlStats.sagas.ts
@@ -1,0 +1,19 @@
+import { all, call, put, takeEvery } from "redux-saga/effects";
+import { resetSQLStats } from "src/api/sqlStatsApi";
+import { actions as statementActions } from "src/store/statements";
+import { actions as sqlStatsActions } from "./sqlStats.reducer";
+
+export function* resetSQLStatsSaga() {
+  try {
+    const response = yield call(resetSQLStats);
+    yield put(sqlStatsActions.received(response));
+    yield put(statementActions.invalidated());
+    yield put(statementActions.refresh());
+  } catch (e) {
+    yield put(sqlStatsActions.failed(e));
+  }
+}
+
+export function* sqlStatsSaga() {
+  yield all([takeEvery(sqlStatsActions.request, resetSQLStatsSaga)]);
+}

--- a/packages/cluster-ui/src/tableStatistics/tableStatistics.module.scss
+++ b/packages/cluster-ui/src/tableStatistics/tableStatistics.module.scss
@@ -1,0 +1,8 @@
+.flex-display {
+  display: flex;
+}
+
+.tooltip-hover-area {
+  padding-top: 3px;
+  padding-right: 10px;
+}

--- a/packages/cluster-ui/src/tableStatistics/tableStatistics.tsx
+++ b/packages/cluster-ui/src/tableStatistics/tableStatistics.tsx
@@ -5,8 +5,15 @@ import { statisticsClasses } from "../transactionsPage/transactionsPageClasses";
 import { ISortedTablePagination } from "../sortedtable";
 import { Button } from "src/button";
 import { ResultsPerPageLabel } from "src/pagination";
+import { Tooltip } from "../tooltip";
+import statementStyles from "src/statementDetails/statementDetails.module.scss";
+import tableStatsStyles from "./tableStatistics.module.scss";
+import classNames from "classnames/bind";
+import { Icon } from "@cockroachlabs/ui-components";
 
 const { statistic, countTitle, lastCleared } = statisticsClasses;
+const cxStmt = classNames.bind(statementStyles);
+const cxStats = classNames.bind(tableStatsStyles);
 
 interface TableStatistics {
   pagination: ISortedTablePagination;
@@ -16,7 +23,11 @@ interface TableStatistics {
   activeFilters: number;
   search?: string;
   onClearFilters?: () => void;
+  resetSQLStats: () => void;
 }
+
+const toolTipText = `Statement history is cleared once an hour by default, which can be configured with the cluster setting
+ diagnostics.reporting.interval. Clicking ‘Clear SQL stats’ will reset SQL stats on the statements and transactions pages.`;
 
 const renderLastCleared = (lastReset: string | Date) => {
   return `Last cleared ${moment.utc(lastReset).format(DATE_FORMAT)}`;
@@ -30,6 +41,7 @@ export const TableStatistics: React.FC<TableStatistics> = ({
   arrayItemName,
   onClearFilters,
   activeFilters,
+  resetSQLStats,
 }) => {
   const resultsPerPageLabel = (
     <ResultsPerPageLabel
@@ -54,7 +66,18 @@ export const TableStatistics: React.FC<TableStatistics> = ({
       <h4 className={countTitle}>
         {activeFilters ? resultsCountAndClear : resultsPerPageLabel}
       </h4>
-      <h4 className={lastCleared}>{renderLastCleared(lastReset)}</h4>
+      <div className={cxStats("flex-display")}>
+        <Tooltip text={toolTipText}>
+          <div className={cxStats("tooltip-hover-area")}>
+            <Icon iconName={"InfoCircle"} />
+          </div>
+        </Tooltip>
+        <div className={lastCleared}>
+          {renderLastCleared(lastReset)}
+          {"  "}-{"  "}
+          <a onClick={resetSQLStats}>Clear SQL Stats</a>
+        </div>
+      </div>
     </div>
   );
 };

--- a/packages/cluster-ui/src/transactionDetails/transactionDetails.stories.tsx
+++ b/packages/cluster-ui/src/transactionDetails/transactionDetails.stories.tsx
@@ -17,6 +17,7 @@ storiesOf("Transactions Details", module)
       statements={data.statements as any}
       lastReset={Date().toString()}
       handleDetails={() => {}}
+      resetSQLStats={() => {}}
     />
   ))
   .add("with loading indicator", () => (
@@ -24,6 +25,7 @@ storiesOf("Transactions Details", module)
       statements={undefined}
       lastReset={Date().toString()}
       handleDetails={() => {}}
+      resetSQLStats={() => {}}
     />
   ))
   .add("with error alert", () => (
@@ -32,5 +34,6 @@ storiesOf("Transactions Details", module)
       error={error}
       lastReset={Date().toString()}
       handleDetails={() => {}}
+      resetSQLStats={() => {}}
     />
   ));

--- a/packages/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/packages/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -53,6 +53,7 @@ interface TransactionDetailsProps {
     transactionStats: TransactionStats | null,
   ) => void;
   error?: Error | null;
+  resetSQLStats: () => void;
 }
 
 interface TState {
@@ -88,7 +89,13 @@ export class TransactionDetails extends React.Component<
   };
 
   render() {
-    const { statements, transactionStats, handleDetails, error } = this.props;
+    const {
+      statements,
+      transactionStats,
+      handleDetails,
+      error,
+      resetSQLStats,
+    } = this.props;
     return (
       <div>
         <section className={baseHeadingClasses.wrapper}>
@@ -215,6 +222,7 @@ export class TransactionDetails extends React.Component<
                     lastReset={lastReset}
                     arrayItemName={"statements for this transaction"}
                     activeFilters={0}
+                    resetSQLStats={resetSQLStats}
                   />
                   <div className={cx("table-area")}>
                     <SortedTable

--- a/packages/cluster-ui/src/transactionsPage/transactionsPage.stories.tsx
+++ b/packages/cluster-ui/src/transactionsPage/transactionsPage.stories.tsx
@@ -16,7 +16,12 @@ storiesOf("Transactions Page", module)
     <div style={{ backgroundColor: "#F5F7FA" }}>{storyFn()}</div>
   ))
   .add("with data", () => (
-    <TransactionsPage {...routeProps} data={data} refreshData={noop} />
+    <TransactionsPage
+      {...routeProps}
+      data={data}
+      refreshData={noop}
+      resetSQLStats={noop}
+    />
   ))
   .add("without data", () => {
     return (
@@ -24,6 +29,7 @@ storiesOf("Transactions Page", module)
         {...routeProps}
         data={getEmptyData()}
         refreshData={noop}
+        resetSQLStats={noop}
       />
     );
   })
@@ -40,12 +46,18 @@ storiesOf("Transactions Page", module)
         data={getEmptyData()}
         refreshData={noop}
         history={history}
+        resetSQLStats={noop}
       />
     );
   })
   .add("with loading indicator", () => {
     return (
-      <TransactionsPage {...routeProps} data={undefined} refreshData={noop} />
+      <TransactionsPage
+        {...routeProps}
+        data={undefined}
+        refreshData={noop}
+        resetSQLStats={noop}
+      />
     );
   })
   .add("with error alert", () => {
@@ -61,6 +73,7 @@ storiesOf("Transactions Page", module)
           )
         }
         refreshData={noop}
+        resetSQLStats={noop}
       />
     );
   });

--- a/packages/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/packages/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -49,6 +49,7 @@ interface TState {
 interface TransactionsPageProps {
   data: IStatementsResponse;
   refreshData: () => void;
+  resetSQLStats: () => void;
   error?: Error | null;
   pageSize?: number;
 }
@@ -189,7 +190,7 @@ export class TransactionsPage extends React.Component<
           loading={!this.props?.data}
           error={this.props?.error}
           render={() => {
-            const { data } = this.props;
+            const { data, resetSQLStats } = this.props;
             const { pagination, search, filters } = this.state;
             const { statements, internal_app_name_prefix } = data;
             const appNames = getTrxAppFilterOptions(
@@ -245,6 +246,7 @@ export class TransactionsPage extends React.Component<
                     arrayItemName="transactions"
                     activeFilters={activeFilters}
                     onClearFilters={this.onClearFilters}
+                    resetSQLStats={resetSQLStats}
                   />
                   <TransactionsTable
                     transactions={transactionsToDisplay}
@@ -288,6 +290,7 @@ export class TransactionsPage extends React.Component<
         lastReset={this.lastReset()}
         handleDetails={this.handleDetails}
         error={this.props.error}
+        resetSQLStats={this.props.resetSQLStats}
       />
     );
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1493,10 +1493,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@cockroachlabs/crdb-protobuf-client@^0.0.7":
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/@cockroachlabs/crdb-protobuf-client/-/crdb-protobuf-client-0.0.7.tgz#b0b405f04acc56932ed698a7d532c71c0b7f43bd"
-  integrity sha512-LjpKVeeeIrUG91uxi5jq3g6AXU6oj/HgvfnhL2YJaUeVC4S12AcSVMLMQ2S06mgB7pVXBs66mH2Lt4R0s6l4Lg==
+"@cockroachlabs/crdb-protobuf-client@^0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@cockroachlabs/crdb-protobuf-client/-/crdb-protobuf-client-0.0.8.tgz#064f44664091dd23e18167c67cf1713ff7845470"
+  integrity sha512-JP6miYNX8FvFSTSZ51etCfyxO/mi/TVVyeVIFsnN/CTlbHI6QZODHJIS1OSPvzfBnfXgFwcb1tQmMrK0L9xFEA==
 
 "@cockroachlabs/icons@0.3.0", "@cockroachlabs/icons@^0.3.0":
   version "0.3.0"
@@ -4318,7 +4318,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@16.9.48", "@types/react@^16.9.48":
+"@types/react@*", "@types/react@^16.9.48":
   version "16.9.48"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.48.tgz#d3387329f070d1b1bc0ff4a54a54ceefd5a8485c"
   integrity sha512-4ykBVswgYitPGMXFRxJCHkxJDU2rjfU3/zw67f8+dB7sNdVJXsrwqoYxz/stkAucymnEEbRPFmX7Ce5Mc/kJCw==
@@ -7995,26 +7995,12 @@ dot-case@^3.0.4:
     no-case "^3.0.4"
     tslib "^2.0.3"
 
-dot-prop@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-3.0.0.tgz#1b708af094a49c9a0e7dbcad790aba539dac1177"
-  integrity sha1-G3CK8JSknJoOfbyteQq6U52sEXc=
-  dependencies:
-    is-obj "^1.0.0"
-
-dot-prop@^4.2.0:
+dot-prop@^3.0.0, dot-prop@^4.2.0, dot-prop@^4.2.1, dot-prop@^5.2.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.1.tgz#45884194a71fc2cda71cbb4bceb3a4dd2f433ba4"
   integrity sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==
   dependencies:
     is-obj "^1.0.0"
-
-dot-prop@^5.2.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-5.3.0.tgz#90ccce708cd9cd82cc4dc8c3ddd9abdd55b20e88"
-  integrity sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==
-  dependencies:
-    is-obj "^2.0.0"
 
 dotenv-defaults@^1.0.2:
   version "1.1.1"
@@ -10973,11 +10959,6 @@ is-obj@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
   integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
-
-is-obj@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-2.0.0.tgz#473fb05d973705e3fd9620545018ca8e22ef4982"
-  integrity sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==
 
 is-object@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
<!--
  Please add a title to your Pull Request with the package the changes
  occured in.
-->
cluster-ui: add button to reset SQL stats on statement page and txn page

Addresses https://github.com/cockroachdb/cockroach/issues/33315

<!--
  Please describe your changes by describing motivation, linking to issues,
  and adding screenshots or gifs to illustrate your changes for reviewers
 -->

Before: 

Stmt page
<img width="287" alt="old-stmt" src="https://user-images.githubusercontent.com/9267198/113759812-851dd700-96e3-11eb-83d3-c5e6796636cc.png">

Txn Page
<img width="247" alt="old-txn" src="https://user-images.githubusercontent.com/9267198/113759815-85b66d80-96e3-11eb-9a2f-4a8649653626.png">

After:

Stmt Page:
<img width="434" alt="new-stmt" src="https://user-images.githubusercontent.com/9267198/113759835-8a7b2180-96e3-11eb-97fb-3ba08dc43eff.png">

Txn Page:
<img width="394" alt="new-txn" src="https://user-images.githubusercontent.com/9267198/113759837-8b13b800-96e3-11eb-9f8a-9786d7b1cf62.png">

Tooltip
<img width="700" alt="new-tool-tip" src="https://user-images.githubusercontent.com/9267198/113759836-8b13b800-96e3-11eb-9150-98388cad3fc8.png">
