### PR TITLE
backport 20.2: cancel active sagas when redux state is reset

### DIFF
--- a/packages/cluster-ui/src/store/liveness/liveness.sagas.ts
+++ b/packages/cluster-ui/src/store/liveness/liveness.sagas.ts
@@ -3,6 +3,7 @@ import { getLiveness } from "src/api/livenessApi";
 import { actions } from "./liveness.reducer";
 
 import { CACHE_INVALIDATION_PERIOD, throttleWithReset } from "src/store/utils";
+import { rootActions } from "../reducers";
 
 export function* refreshLivenessSaga() {
   yield put(actions.request());
@@ -29,7 +30,7 @@ export function* livenessSaga(
     throttleWithReset(
       cacheInvalidationPeriod,
       actions.refresh,
-      [actions.invalidated, actions.failed],
+      [actions.invalidated, actions.failed, rootActions.resetState],
       refreshLivenessSaga,
     ),
     takeLatest(actions.request, requestLivenessSaga),

--- a/packages/cluster-ui/src/store/nodes/nodes.sagas.ts
+++ b/packages/cluster-ui/src/store/nodes/nodes.sagas.ts
@@ -4,6 +4,7 @@ import { actions } from "./nodes.reducer";
 
 import { CACHE_INVALIDATION_PERIOD, throttleWithReset } from "src/store/utils";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import { rootActions } from "../reducers";
 
 export function* refreshNodesSaga() {
   yield put(actions.request());
@@ -32,7 +33,7 @@ export function* nodesSaga(
     throttleWithReset(
       cacheInvalidationPeriod,
       actions.refresh,
-      [actions.invalidated, actions.failed],
+      [actions.invalidated, actions.failed, rootActions.resetState],
       refreshNodesSaga,
     ),
     takeLatest(actions.request, requestNodesSaga),

--- a/packages/cluster-ui/src/store/sessions/sessions.sagas.ts
+++ b/packages/cluster-ui/src/store/sessions/sessions.sagas.ts
@@ -1,18 +1,9 @@
-// Copyright 2020 The Cockroach Authors.
-//
-// Use of this software is governed by the Business Source License
-// included in the file licenses/BSL.txt.
-//
-// As of the Change Date specified in that file, in accordance with
-// the Business Source License, use of this software will be governed
-// by the Apache License, Version 2.0, included in the file
-// licenses/APL.txt.
-
 import { all, call, delay, put, takeLatest } from "redux-saga/effects";
 
 import { actions } from "./sessions.reducer";
 import { getSessions } from "src/api/sessionsApi";
 import { CACHE_INVALIDATION_PERIOD, throttleWithReset } from "../utils";
+import { rootActions } from "../reducers";
 
 export function* refreshSessionsSaga() {
   yield put(actions.request());
@@ -39,7 +30,7 @@ export function* sessionsSaga(
     throttleWithReset(
       cacheInvalidationPeriod,
       actions.refresh,
-      [actions.invalidated, actions.failed],
+      [actions.invalidated, actions.failed, rootActions.resetState],
       refreshSessionsSaga,
     ),
     takeLatest(actions.request, requestSessionsSaga),

--- a/packages/cluster-ui/src/store/statements/statements.sagas.ts
+++ b/packages/cluster-ui/src/store/statements/statements.sagas.ts
@@ -1,6 +1,7 @@
 import { all, call, put, delay, takeLatest } from "redux-saga/effects";
 import { getStatements } from "src/api/statementsApi";
 import { actions } from "./statements.reducer";
+import { rootActions } from "../reducers";
 
 import { CACHE_INVALIDATION_PERIOD, throttleWithReset } from "src/store/utils";
 
@@ -29,7 +30,7 @@ export function* statementsSaga(
     throttleWithReset(
       cacheInvalidationPeriod,
       actions.refresh,
-      [actions.invalidated, actions.failed],
+      [actions.invalidated, actions.failed, rootActions.resetState],
       refreshStatementsSaga,
     ),
     takeLatest(actions.request, requestStatementsSaga),


### PR DESCRIPTION
#### Backport for https://github.com/cockroachdb/ui/pull/272

Previous implementation of redux-sagas for fetching new data from server was
straightforward and didn't take into account cases such as resetting an entire
redux state, so it cause cases when request to some data is dispatched, then
redux state is reset, and after this sagas would handle returned data as
usual (which in fact causes inconsistent store state).

To avoid this cases, sagas have to be cancelled when redux state is reset
and all responses after this should be ignored. To achieve desired behavior,
most of the changes are done within custom `throttleWithReset` effect.
- now, it's behavior is changed to take and process only latest actions
instead of processing every incoming action. It guaranties that all previous
actions and forked tasks are cancelled.
- `throttleWithReset` effect doesn't buffer actions and ignores all except
current action.

Sagas, that use `throttleWithReset` effect provide one more cancellation action
pattern to watch: `rootActions.resetState`. This action is dispatched when redux
state is reset and initiates cancellation process for running saga's tasks.

To follow the same pattern, statement diagnostics sagas are refactored in the
same was as other sagas, to use `throttleWithReset` effect.
