### PR TITLE
cluster-ui: last execution time for statement

### DIFF
--- a/packages/cluster-ui/package.json
+++ b/packages/cluster-ui/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.12.13",
-    "@cockroachlabs/crdb-protobuf-client": "^0.0.9",
+    "@cockroachlabs/crdb-protobuf-client": "^0.0.10-beta.0",
     "@cockroachlabs/icons": "0.3.0",
     "@cockroachlabs/ui-components": "0.2.14-alpha.0",
     "@popperjs/core": "^2.4.0",

--- a/packages/cluster-ui/src/statementDetails/statementDetails.fixture.ts
+++ b/packages/cluster-ui/src/statementDetails/statementDetails.fixture.ts
@@ -66,6 +66,10 @@ const statementStats: any = {
     mean: 7,
     squared_diffs: 1000000,
   },
+  last_exec_timestamp: {
+    seconds: Long.fromInt(1599670292),
+    nanos: 111613000,
+  },
   sensitive_info: {
     last_err: "",
     most_recent_plan_description: {

--- a/packages/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/packages/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -47,6 +47,7 @@ import summaryCardStyles from "src/summaryCard/summaryCard.module.scss";
 import styles from "./statementDetails.module.scss";
 import { NodeSummaryStats } from "../nodes";
 import { UIConfigState } from "../store/uiConfig";
+import moment from "moment";
 
 const { TabPane } = Tabs;
 
@@ -435,6 +436,9 @@ export class StatementDetails extends React.Component<
       stats.sensitive_info && stats.sensitive_info.most_recent_plan_description;
     const duration = (v: number) => Duration(v * 1e9);
     const hasDiagnosticReports = diagnosticsReports.length > 0;
+    const lastExec = moment(stats.last_exec_timestamp.seconds.low * 1e3).format(
+      "MMM DD, YYYY HH:MM",
+    );
     return (
       <Tabs
         defaultActiveKey="1"
@@ -562,6 +566,10 @@ export class StatementDetails extends React.Component<
                 <div className={summaryCardStylesCx("summary--card__item")}>
                   <Text>Transaction type</Text>
                   <Text>{renderTransactionType(implicit_txn)}</Text>
+                </div>
+                <div className={summaryCardStylesCx("summary--card__item")}>
+                  <Text>Last execution time</Text>
+                  <Text>{lastExec}</Text>
                 </div>
                 <p
                   className={summaryCardStylesCx(

--- a/packages/cluster-ui/src/statementsPage/statementsPage.fixture.ts
+++ b/packages/cluster-ui/src/statementsPage/statementsPage.fixture.ts
@@ -77,6 +77,10 @@ const statementStats: Required<IStatementStatistics> = {
     "squared_diffs": 1,
   },
   exec_stats: execStats,
+  "last_exec_timestamp": {
+    seconds: Long.fromInt(1599670292),
+    nanos: 111613000,
+  },
   "sensitive_info": {
     "last_err": "",
     "most_recent_plan_description": {

--- a/packages/cluster-ui/src/util/appStats/appStats.fixture.ts
+++ b/packages/cluster-ui/src/util/appStats/appStats.fixture.ts
@@ -88,6 +88,10 @@ export const statementsWithSameIdButDifferentNodeId: CollectedStatementStatistic
       },
       bytes_read: { mean: 0, squared_diffs: 0 },
       rows_read: { mean: 0, squared_diffs: 0 },
+      last_exec_timestamp: {
+        seconds: Long.fromInt(1599670290),
+        nanos: 111613000,
+      },
       exec_stats: {
         count: new Long(0),
         network_bytes: { mean: 0, squared_diffs: 0 },
@@ -190,6 +194,10 @@ export const statementsWithSameIdButDifferentNodeId: CollectedStatementStatistic
       rows_read: {
         mean: 0.07999999999999999,
         squared_diffs: 3.8399999999999994,
+      },
+      last_exec_timestamp: {
+        seconds: Long.fromInt(1599670272),
+        nanos: 111613000,
       },
       exec_stats: {
         count: new Long(0),
@@ -297,6 +305,10 @@ export const statementsWithSameIdButDifferentNodeId: CollectedStatementStatistic
         mean: 0.07999999999999999,
         squared_diffs: 3.8399999999999994,
       },
+      last_exec_timestamp: {
+        seconds: Long.fromInt(1599670192),
+        nanos: 111613000,
+      },
       exec_stats: {
         count: new Long(0),
         network_bytes: { mean: 0, squared_diffs: 0 },
@@ -397,6 +409,10 @@ export const statementsWithSameIdButDifferentNodeId: CollectedStatementStatistic
       },
       bytes_read: { mean: 0, squared_diffs: 0 },
       rows_read: { mean: 0, squared_diffs: 0 },
+      last_exec_timestamp: {
+        seconds: Long.fromInt(1599670299),
+        nanos: 111613000,
+      },
       exec_stats: {
         count: new Long(0),
         network_bytes: { mean: 0, squared_diffs: 0 },
@@ -497,6 +513,10 @@ export const statementsWithSameIdButDifferentNodeId: CollectedStatementStatistic
       },
       bytes_read: { mean: 0, squared_diffs: 0 },
       rows_read: { mean: 0, squared_diffs: 0 },
+      last_exec_timestamp: {
+        seconds: Long.fromInt(1599670242),
+        nanos: 111613000,
+      },
       exec_stats: {
         count: new Long(0),
         network_bytes: { mean: 0, squared_diffs: 0 },
@@ -603,6 +623,10 @@ export const statementsWithSameIdButDifferentNodeId: CollectedStatementStatistic
         mean: 0.07999999999999999,
         squared_diffs: 3.8399999999999994,
       },
+      last_exec_timestamp: {
+        seconds: Long.fromInt(1599650292),
+        nanos: 111613000,
+      },
       exec_stats: {
         count: new Long(0),
         network_bytes: { mean: 0, squared_diffs: 0 },
@@ -708,6 +732,10 @@ export const statementsWithSameIdButDifferentNodeId: CollectedStatementStatistic
       rows_read: {
         mean: 0.07999999999999999,
         squared_diffs: 3.8399999999999994,
+      },
+      last_exec_timestamp: {
+        seconds: Long.fromInt(1599670282),
+        nanos: 111613000,
       },
       exec_stats: {
         count: new Long(0),
@@ -818,6 +846,10 @@ export const statementsWithSameIdButDifferentNodeId: CollectedStatementStatistic
         mean: 0.07999999999999999,
         squared_diffs: 3.8399999999999994,
       },
+      last_exec_timestamp: {
+        seconds: Long.fromInt(1599670257),
+        nanos: 111613000,
+      },
       exec_stats: {
         count: new Long(0),
         network_bytes: { mean: 0, squared_diffs: 0 },
@@ -920,6 +952,10 @@ export const statementsWithSameIdButDifferentNodeId: CollectedStatementStatistic
       rows_read: {
         mean: 0.07999999999999999,
         squared_diffs: 3.8399999999999994,
+      },
+      last_exec_timestamp: {
+        seconds: Long.fromInt(1599670279),
+        nanos: 111613000,
       },
       exec_stats: {
         count: new Long(0),

--- a/packages/cluster-ui/src/util/appStats/appStats.spec.ts
+++ b/packages/cluster-ui/src/util/appStats/appStats.spec.ts
@@ -200,6 +200,10 @@ function randomStats(
     legacy_last_err_redacted: "",
     exec_stats: randomExecStats(count),
     sql_type: "DDL",
+    last_exec_timestamp: {
+      seconds: Long.fromInt(1599670292),
+      nanos: 111613000,
+    },
   };
 }
 

--- a/packages/cluster-ui/src/util/appStats/appStats.ts
+++ b/packages/cluster-ui/src/util/appStats/appStats.ts
@@ -147,6 +147,10 @@ export function addStatementStats(
     legacy_last_err_redacted: "",
     exec_stats: addExecStats(a.exec_stats, b.exec_stats),
     sql_type: a.sql_type,
+    last_exec_timestamp:
+      a.last_exec_timestamp.seconds > b.last_exec_timestamp.seconds
+        ? a.last_exec_timestamp
+        : b.last_exec_timestamp,
   };
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1500,10 +1500,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@cockroachlabs/crdb-protobuf-client@^0.0.9":
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/@cockroachlabs/crdb-protobuf-client/-/crdb-protobuf-client-0.0.9.tgz#e314a0e9093dafd01eadce75d92c052926af4a85"
-  integrity sha512-oaHi9iE6Jh8inbFBocg29DFVZ77vPJtGI4pXay1t5o2Xd8dmn1NNzz03DcrN6aDhD2CYMuFivEcYDIek5aBe0Q==
+"@cockroachlabs/crdb-protobuf-client@^0.0.10-beta.0":
+  version "0.0.10-beta.0"
+  resolved "https://registry.yarnpkg.com/@cockroachlabs/crdb-protobuf-client/-/crdb-protobuf-client-0.0.10-beta.0.tgz#b1bb2283379d8cf9d75adf780ff19374b4485e65"
+  integrity sha512-FQ29hZTM7CnunHWG88a5pgWXYGy/aAFrW0tn0E0t++QG7BTGkDVEuPdPcoMSCEUcKbFpzYc7AaY050JnU27rAA==
 
 "@cockroachlabs/icons@0.3.0", "@cockroachlabs/icons@^0.3.0":
   version "0.3.0"


### PR DESCRIPTION
cluster-ui
Adding a new field for Last execution time on Statements Details page

Dependency: https://github.com/cockroachdb/cockroach/pull/63491
<img width="336" alt="Screen Shot 2021-04-13 at 9 39 01 AM" src="https://user-images.githubusercontent.com/1017486/114562010-1b01b680-9c3c-11eb-83fd-81937564428d.png">

Related to: https://github.com/cockroachdb/cockroach/issues/60974

