### PR TITLE
cluster-ui: sessions tracking events [backport 20.2]

### DIFF
--- a/packages/cluster-ui/src/sessions/sessionDetails.tsx
+++ b/packages/cluster-ui/src/sessions/sessionDetails.tsx
@@ -63,6 +63,10 @@ interface OwnProps {
   cancelSession: (payload: ICancelSessionRequest) => void;
   cancelQuery: (payload: ICancelQueryRequest) => void;
   uiConfig?: UIConfigState["pages"]["sessionDetails"];
+  onBackButtonClick?: () => void;
+  onTerminateSessionClick?: () => void;
+  onTerminateStatementClick?: () => void;
+  onStatementClick?: () => void;
 }
 
 export type SessionDetailsProps = OwnProps & RouteComponentProps;
@@ -112,7 +116,8 @@ export class SessionDetails extends React.Component<SessionDetailsProps, {}> {
   }
 
   backToSessionsPage = () => {
-    const { history, location } = this.props;
+    const { history, location, onBackButtonClick } = this.props;
+    onBackButtonClick && onBackButtonClick();
     history.push({
       ...location,
       pathname: "/sessions",
@@ -121,7 +126,13 @@ export class SessionDetails extends React.Component<SessionDetailsProps, {}> {
 
   render() {
     const sessionID = getMatchParamByName(this.props.match, sessionAttr);
-    const { sessionError, cancelSession, cancelQuery } = this.props;
+    const {
+      sessionError,
+      cancelSession,
+      cancelQuery,
+      onTerminateSessionClick,
+      onTerminateStatementClick,
+    } = this.props;
     const session = this.props.session?.session;
     const showActionButtons = !!session && !sessionError;
     return (
@@ -150,6 +161,7 @@ export class SessionDetails extends React.Component<SessionDetailsProps, {}> {
                 <Button
                   disabled={session.active_queries?.length === 0}
                   onClick={() => {
+                    onTerminateStatementClick && onTerminateStatementClick();
                     if (session.active_queries?.length > 0) {
                       this.terminateQueryRef?.current?.showModalFor({
                         query_id: session.active_queries[0].id,
@@ -163,12 +175,13 @@ export class SessionDetails extends React.Component<SessionDetailsProps, {}> {
                   Cancel query
                 </Button>
                 <Button
-                  onClick={() =>
+                  onClick={() => {
+                    onTerminateSessionClick && onTerminateSessionClick();
                     this.terminateSessionRef?.current?.showModalFor({
                       session_id: session.id,
                       node_id: session.node_id.toString(),
-                    })
-                  }
+                    });
+                  }}
                   type="secondary"
                   size="small"
                 >
@@ -302,6 +315,9 @@ export class SessionDetails extends React.Component<SessionDetailsProps, {}> {
                     app: "",
                     search: "",
                   })}
+                  onClick={() =>
+                    this.props.onStatementClick && this.props.onStatementClick()
+                  }
                 >
                   View Statement Details
                 </Link>

--- a/packages/cluster-ui/src/sessions/sessionDetailsConnected.tsx
+++ b/packages/cluster-ui/src/sessions/sessionDetailsConnected.tsx
@@ -10,7 +10,7 @@
 
 import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
-import { AppState } from "src/store";
+import { analyticsActions, AppState } from "src/store";
 import { SessionDetails } from ".";
 import {
   actions as sessionsActions,
@@ -37,6 +37,28 @@ export const SessionDetailsPageConnected = withRouter(
       cancelQuery: terminateQueryActions.terminateQuery,
       refreshNodes: nodesActions.refresh,
       refreshNodesLiveness: nodesLivenessActions.refresh,
+      onTerminateSessionClick: () =>
+        analyticsActions.track({
+          name: "Session Actions Clicked",
+          page: "Sessions Details",
+          action: "Terminate Session",
+        }),
+      onTerminateStatementClick: () =>
+        analyticsActions.track({
+          name: "Session Actions Clicked",
+          page: "Sessions Details",
+          action: "Terminate Statement",
+        }),
+      onBackButtonClick: () =>
+        analyticsActions.track({
+          name: "Back Clicked",
+          page: "Sessions Details",
+        }),
+      onStatementClick: () =>
+        analyticsActions.track({
+          name: "Statement Clicked",
+          page: "Sessions Details",
+        }),
     },
   )(SessionDetails),
 );

--- a/packages/cluster-ui/src/sessions/sessionsPage.fixture.ts
+++ b/packages/cluster-ui/src/sessions/sessionsPage.fixture.ts
@@ -43,10 +43,12 @@ export const idleSession: SessionInfo = {
     last_active_query_anon: "SHOW database",
     alloc_bytes: Long.fromNumber(0),
     max_alloc_bytes: Long.fromNumber(10240),
+    active_queries: [],
+    toJSON: () => ({}),
   },
 };
 
-export const idleTransactionSession = {
+export const idleTransactionSession: SessionInfo = {
   session: {
     node_id: 1,
     username: "root",
@@ -78,6 +80,8 @@ export const idleTransactionSession = {
       num_auto_retries: 3,
     },
     last_active_query_anon: "SHOW database",
+    active_queries: [],
+    toJSON: () => ({}),
   },
 };
 
@@ -128,6 +132,7 @@ export const activeSession: SessionInfo = {
       num_auto_retries: 3,
     },
     last_active_query_anon: "SHOW database",
+    toJSON: () => ({}),
   },
 };
 

--- a/packages/cluster-ui/src/sessions/sessionsPage.tsx
+++ b/packages/cluster-ui/src/sessions/sessionsPage.tsx
@@ -58,6 +58,10 @@ interface OwnProps {
   cancelSession: (payload: ICancelSessionRequest) => void;
   cancelQuery: (payload: ICancelQueryRequest) => void;
   onPageChanged?: (newPage: number) => void;
+  onSortingChange?: (columnName: string, tableName: string) => void;
+  onSessionClick?: () => void;
+  onTerminateSessionClick?: () => void;
+  onTerminateStatementClick?: () => void;
 }
 
 export interface SessionsPageState {
@@ -123,6 +127,9 @@ export class SessionsPage extends React.Component<
   };
 
   changeSortSetting = (ss: SortSetting) => {
+    const { onSortingChange } = this.props;
+    onSortingChange && onSortingChange("Sessions", ss.columnTitle);
+
     this.setState({
       sortSetting: ss,
     });
@@ -182,6 +189,9 @@ export class SessionsPage extends React.Component<
             columns={makeSessionsColumns(
               this.terminateSessionRef,
               this.terminateQueryRef,
+              this.props.onSessionClick,
+              this.props.onTerminateStatementClick,
+              this.props.onTerminateSessionClick,
             )}
             renderNoResult={
               <EmptyTable

--- a/packages/cluster-ui/src/sessions/sessionsTable.tsx
+++ b/packages/cluster-ui/src/sessions/sessionsTable.tsx
@@ -20,8 +20,7 @@ import React from "react";
 import { Moment } from "moment";
 
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
-//import ISession = cockroach.server.serverpb.ISession;
-type ISession = any;
+type ISession = cockroach.server.serverpb.Session;
 
 import { TerminateSessionModalRef } from "./terminateSessionModal";
 import { TerminateQueryModalRef } from "./terminateQueryModal";
@@ -57,10 +56,12 @@ export function byteArrayToUuid(array: Uint8Array) {
   ].join("-");
 }
 
-const SessionLink = (props: { session: ISession }) => {
+const SessionLink = (props: { session: ISession; onClick?: () => void }) => {
+  const { session, onClick } = props;
+
   const base = `/session`;
-  const start = TimestampToMoment(props.session.start);
-  const sessionID = byteArrayToUuid(props.session.id);
+  const start = TimestampToMoment(session.start);
+  const sessionID = byteArrayToUuid(session.id);
 
   return (
     <div className={cx("sessionLink")}>
@@ -69,7 +70,7 @@ const SessionLink = (props: { session: ISession }) => {
         tableTitle
         title={<>Session started at {start.format(DATE_FORMAT)}</>}
       >
-        <Link to={`${base}/${encodeURIComponent(sessionID)}`}>
+        <Link onClick={onClick} to={`${base}/${encodeURIComponent(sessionID)}`}>
           {start.fromNow(true)}
         </Link>
       </Tooltip2>
@@ -96,13 +97,17 @@ const AgeLabel = (props: { start: Moment; thingName: string }) => {
 export function makeSessionsColumns(
   terminateSessionRef?: React.RefObject<TerminateSessionModalRef>,
   terminateQueryRef?: React.RefObject<TerminateQueryModalRef>,
+  onSessionClick?: () => void,
+  onTerminateSessionClick?: () => void,
+  onTerminateStatementClick?: () => void,
 ): ColumnDescriptor<SessionInfo>[] {
   return [
     {
       name: "1",
       title: SessionTableTitle.sessionAge,
       className: cx("cl-table__col-session-age"),
-      cell: session => SessionLink({ session: session.session }),
+      cell: session =>
+        SessionLink({ session: session.session, onClick: onSessionClick }),
       sort: session => TimestampToMoment(session.session.start).valueOf(),
     },
     {
@@ -194,6 +199,7 @@ export function makeSessionsColumns(
         ) => {
           switch (value) {
             case "terminateSession":
+              onTerminateSessionClick && onTerminateSessionClick();
               terminateSessionRef?.current?.showModalFor({
                 session_id: session.id,
                 node_id: session.node_id.toString(),
@@ -201,6 +207,7 @@ export function makeSessionsColumns(
               break;
             case "terminateStatement":
               if (session.active_queries?.length > 0) {
+                onTerminateStatementClick && onTerminateStatementClick();
                 terminateQueryRef?.current?.showModalFor({
                   query_id: session.active_queries[0].id,
                   node_id: session.node_id.toString(),

--- a/packages/cluster-ui/src/store/analytics/analytics.reducer.ts
+++ b/packages/cluster-ui/src/store/analytics/analytics.reducer.ts
@@ -1,7 +1,11 @@
 import { createAction } from "@reduxjs/toolkit";
 import { DOMAIN_NAME } from "../utils";
 
-type Page = "Statements" | "Statement Details";
+type Page =
+  | "Statements"
+  | "Statement Details"
+  | "Sessions"
+  | "Sessions Details";
 
 type SearchEvent = {
   name: "Keyword Searched";
@@ -37,6 +41,17 @@ type StatementClicked = {
   page: Page;
 };
 
+type SessionClicked = {
+  name: "Session Clicked";
+  page: Page;
+};
+
+type SessionActionsClicked = {
+  name: "Session Actions Clicked";
+  page: Page;
+  action: "Terminate Statement" | "Terminate Session";
+};
+
 type FilterEvent = {
   name: "Filter Clicked";
   page: Page;
@@ -51,7 +66,9 @@ type AnalyticsEvent =
   | TabChangedEvent
   | BackButtonClick
   | FilterEvent
-  | StatementClicked;
+  | StatementClicked
+  | SessionClicked
+  | SessionActionsClicked;
 
 const PREFIX = `${DOMAIN_NAME}/analytics`;
 


### PR DESCRIPTION
expose analytics events on sessions:
 - on table sorted
 - on session link clicked
 - on terminate session
 - on terminate statement
and sessions details page:
 - on back to sessions clicked
 - on terminate session
 - on terminate statement