### PR TITLE
Manual Publish

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/ui-components",
-  "version": "0.2.18-alpha.2",
+  "version": "0.2.18",
   "description": "UI Components is a reusable component library. It provides the core components for the Cockroach design system.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Manually publishing `@cockroachlabs/ui-components@0.2.18` after [publish failure](https://github.com/cockroachdb/ui/runs/2411506965?check_suite_focus=true)`

I don't know what's going on with the failed publishing, but this is a quick fix for now.