### PR TITLE
cluster-ui: fix typo on network tooltip

### DIFF
--- a/packages/cluster-ui/src/statementsTable/statementsTableContent.tsx
+++ b/packages/cluster-ui/src/statementsTable/statementsTableContent.tsx
@@ -258,7 +258,7 @@ export const StatementTableTitle = {
               data transferred over the network
             </Anchor>
             {
-              " (e.g., between regions and nodes) for statements with this fingerprint within the last hour or speicifed "
+              " (e.g., between regions and nodes) for statements with this fingerprint within the last hour or specified "
             }
             <Anchor href={statementsTimeInterval} target="_blank">
               time interval


### PR DESCRIPTION
Fixing typo on the Network tooltip on the Statements Page.

Closes: https://github.com/cockroachdb/cockroach/issues/64247

Release note (ui change): Fix typo on Network tooltip on Statements Page.