### PR TITLE
cluster-ui: return information about node regions to statement pages

### DIFF
--- a/packages/cluster-ui/src/statementDetails/statementDetails.fixture.ts
+++ b/packages/cluster-ui/src/statementDetails/statementDetails.fixture.ts
@@ -190,6 +190,12 @@ export const getStatementDetailsPropsFixture = (): StatementDetailsProps => ({
     "3": "127.0.0.1:55538 (n3)",
     "4": "127.0.0.1:55546 (n4)",
   },
+  nodeRegions: {
+    "1": "gcp-us-east1",
+    "2": "gcp-us-east1",
+    "3": "gcp-us-west1",
+    "4": "gcp-europe-west1",
+  },
   refreshStatements: noop,
   refreshStatementDiagnosticsRequests: noop,
   refreshNodes: noop,

--- a/packages/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/packages/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -133,6 +133,7 @@ export interface StatementDetailsStateProps {
   statement: SingleStatementStatistics;
   statementsError: Error | null;
   nodeNames: { [nodeId: string]: string };
+  nodeRegions: { [nodeId: string]: string };
   diagnosticsReports: cockroach.server.serverpb.IStatementDiagnosticsReport[];
   uiConfig?: UIConfigState["pages"]["statementDetails"];
 }

--- a/packages/cluster-ui/src/statementDetails/statementDetailsConnected.ts
+++ b/packages/cluster-ui/src/statementDetails/statementDetailsConnected.ts
@@ -12,7 +12,10 @@ import {
   selectStatement,
   selectStatementDetailsUiConfig,
 } from "./statementDetails.selectors";
-import { nodeDisplayNameByIDSelector } from "../store/nodes";
+import {
+  nodeDisplayNameByIDSelector,
+  nodeRegionsByIDSelector,
+} from "../store/nodes";
 import { actions as statementActions } from "src/store/statements";
 import {
   actions as statementDiagnosticsActions,
@@ -33,6 +36,7 @@ const mapStateToProps = (
     statement,
     statementsError: state.adminUI.statements.lastError,
     nodeNames: nodeDisplayNameByIDSelector(state),
+    nodeRegions: nodeRegionsByIDSelector(state),
     diagnosticsReports: selectDiagnosticsReportsByStatementFingerprint(
       state,
       statementFingerprint,

--- a/packages/cluster-ui/src/statementsPage/statementsPage.fixture.ts
+++ b/packages/cluster-ui/src/statementsPage/statementsPage.fixture.ts
@@ -240,6 +240,12 @@ const statementsPagePropsFixture: StatementsPageProps = {
     "params": {},
   },
   "databases": ["defaultdb","foo","system"],
+  "nodeRegions": {
+    "1": "gcp-us-east1",
+    "2": "gcp-us-east1",
+    "3": "gcp-us-west1",
+    "4": "gcp-europe-west1",
+  },
   "statements": [
     {
       "label": "SELECT IFNULL(a, b) FROM (SELECT (SELECT code FROM promo_codes WHERE code > $1 ORDER BY code LIMIT _) AS a, (SELECT code FROM promo_codes ORDER BY code LIMIT _) AS b)",

--- a/packages/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/packages/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -76,6 +76,7 @@ export interface StatementsPageStateProps {
   totalFingerprints: number;
   lastReset: string;
   columns: string[];
+  nodeRegions: { [key: string]: string };
 }
 
 export interface StatementsPageState {

--- a/packages/cluster-ui/src/statementsPage/statementsPageConnected.tsx
+++ b/packages/cluster-ui/src/statementsPage/statementsPageConnected.tsx
@@ -24,6 +24,7 @@ import {
   selectColumns,
 } from "./statementsPage.selectors";
 import { AggregateStatistics } from "../statementsTable";
+import { nodeRegionsByIDSelector } from "../store/nodes";
 
 export const ConnectedStatementsPage = withRouter(
   connect<
@@ -39,6 +40,7 @@ export const ConnectedStatementsPage = withRouter(
       totalFingerprints: selectTotalFingerprints(state),
       lastReset: selectLastReset(state),
       columns: selectColumns(state),
+      nodeRegions: nodeRegionsByIDSelector(state),
     }),
     (dispatch: Dispatch) => ({
       refreshStatements: () => dispatch(statementActions.refresh()),

--- a/packages/cluster-ui/src/store/nodes/nodes.selectors.ts
+++ b/packages/cluster-ui/src/store/nodes/nodes.selectors.ts
@@ -4,6 +4,8 @@ import { AppState } from "../reducers";
 import { getDisplayName } from "../../nodes";
 import { livenessStatusByNodeIDSelector } from "../liveness";
 import { accumulateMetrics } from "../../util";
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+type ILocality = cockroach.roachpb.ILocality;
 
 export const nodeStatusesSelector = (state: AppState) =>
   state.adminUI.nodes.data || [];
@@ -24,6 +26,27 @@ export const nodeDisplayNameByIDSelector = createSelector(
           ns,
           livenessStatusByNodeID[ns.desc.node_id],
         );
+      });
+    }
+    return result;
+  },
+);
+
+export function getRegionFromLocality(locality: ILocality): string {
+  for (let i = 0; i < locality.tiers.length; i++) {
+    if (locality.tiers[i].key === "region") return locality.tiers[i].value;
+  }
+  return "";
+}
+
+// nodeRegionsByIDSelector provides the region for each node.
+export const nodeRegionsByIDSelector = createSelector(
+  nodeStatusesSelector,
+  nodeStatuses => {
+    const result: { [key: string]: string } = {};
+    if (!_.isEmpty(nodeStatuses)) {
+      nodeStatuses.forEach(ns => {
+        result[ns.desc.node_id] = getRegionFromLocality(ns.desc.locality);
       });
     }
     return result;


### PR DESCRIPTION
Returning information from cache about which region each node is on.

Part of issue https://github.com/cockroachdb/cockroach/issues/59979
Dependency for PR (handles the backend changes) https://github.com/cockroachdb/cockroach/pull/64605

This will be followed by another PR with the changes on the ui visible to the user.

Release note: None