### PR TITLE
cluster-ui: adding information about node and region on statement details

### DIFF
--- a/packages/cluster-ui/package.json
+++ b/packages/cluster-ui/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.12.13",
-    "@cockroachlabs/crdb-protobuf-client": "^0.0.11",
+    "@cockroachlabs/crdb-protobuf-client": "^0.0.12",
     "@cockroachlabs/icons": "0.3.0",
     "@cockroachlabs/ui-components": "0.2.19-alpha.2",
     "@popperjs/core": "^2.4.0",

--- a/packages/cluster-ui/src/barCharts/barCharts.tsx
+++ b/packages/cluster-ui/src/barCharts/barCharts.tsx
@@ -1,9 +1,9 @@
 import * as protos from "@cockroachlabs/crdb-protobuf-client";
-import { stdDevLong } from "src/util";
+import { stdDevLong, longToInt } from "src/util";
 import { Duration, Bytes, Percentage } from "src/util/format";
 import classNames from "classnames/bind";
 import styles from "./barCharts.module.scss";
-import { bar, formatTwoPlaces, longToInt, approximify } from "./utils";
+import { bar, formatTwoPlaces, approximify } from "./utils";
 import { barChartFactory, BarChartOptions } from "./barChartFactory";
 import { AggregateStatistics } from "src/statementsTable/statementsTable";
 

--- a/packages/cluster-ui/src/barCharts/genericBarChart.tsx
+++ b/packages/cluster-ui/src/barCharts/genericBarChart.tsx
@@ -3,10 +3,9 @@ import classNames from "classnames/bind";
 import { scaleLinear } from "d3-scale";
 import { format as d3Format } from "d3-format";
 
-import { stdDevLong } from "src/util";
+import { stdDevLong, longToInt, NumericStat } from "src/util";
 import { Tooltip } from "@cockroachlabs/ui-components";
-import { NumericStat } from "../util";
-import { clamp, longToInt, normalizeClosedDomain } from "./utils";
+import { clamp, normalizeClosedDomain } from "./utils";
 import styles from "./barCharts.module.scss";
 
 const cx = classNames.bind(styles);

--- a/packages/cluster-ui/src/barCharts/numericStatLegend.tsx
+++ b/packages/cluster-ui/src/barCharts/numericStatLegend.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import classNames from "classnames/bind";
 import styles from "./barCharts.module.scss";
-import { longToInt } from "./utils";
+import { longToInt } from "../util";
 
 const cx = classNames.bind(styles);
 

--- a/packages/cluster-ui/src/barCharts/utils.ts
+++ b/packages/cluster-ui/src/barCharts/utils.ts
@@ -1,13 +1,8 @@
 import { format as d3Format } from "d3-format";
-import Long from "long";
-import { FixLong } from "src/util/fixLong";
 import * as protos from "@cockroachlabs/crdb-protobuf-client";
 
 type StatementStatistics = protos.cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
 type Transaction = protos.cockroach.server.serverpb.StatementsResponse.IExtendedCollectedTransactionStatistics;
-
-export const longToInt = (d: number | Long) =>
-  Long.fromValue(FixLong(d)).toInt();
 
 export const clamp = (i: number) => (i < 0 ? 0 : i);
 

--- a/packages/cluster-ui/src/statementDetails/statementDetails.fixture.ts
+++ b/packages/cluster-ui/src/statementDetails/statementDetails.fixture.ts
@@ -71,6 +71,7 @@ const statementStats: any = {
     nanos: 111613000,
   },
   database: "defaultdb",
+  nodes: [Long.fromInt(1), Long.fromInt(2)],
   sensitive_info: {
     last_err: "",
     most_recent_plan_description: {

--- a/packages/cluster-ui/src/statementsPage/statementsPage.fixture.ts
+++ b/packages/cluster-ui/src/statementsPage/statementsPage.fixture.ts
@@ -42,6 +42,7 @@ const statementStats: Required<IStatementStatistics> = {
   "first_attempt_count": Long.fromNumber(50000),
   "max_retries": Long.fromNumber(10),
   "sql_type": "DDL",
+  "nodes": [Long.fromNumber(1), Long.fromNumber(2)],
   "num_rows": {
     "mean": 1,
     "squared_diffs": 0,

--- a/packages/cluster-ui/src/statementsTable/statementsTable.tsx
+++ b/packages/cluster-ui/src/statementsTable/statementsTable.tsx
@@ -2,7 +2,12 @@ import React from "react";
 import classNames from "classnames/bind";
 import Long from "long";
 
-import { FixLong, StatementSummary, StatementStatistics } from "src/util";
+import {
+  FixLong,
+  longToInt,
+  StatementSummary,
+  StatementStatistics,
+} from "src/util";
 import {
   countBarChart,
   rowsReadBarChart,
@@ -28,7 +33,6 @@ type IStatementDiagnosticsReport = cockroach.server.serverpb.IStatementDiagnosti
 type ICollectedStatementStatistics = cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
 import styles from "./statementsTable.module.scss";
 const cx = classNames.bind(styles);
-const longToInt = (d: number | Long) => Number(FixLong(d));
 
 function makeCommonColumns(
   statements: AggregateStatistics[],

--- a/packages/cluster-ui/src/transactionsTable/transactionsBarCharts.ts
+++ b/packages/cluster-ui/src/transactionsTable/transactionsBarCharts.ts
@@ -1,15 +1,9 @@
 import * as protos from "@cockroachlabs/crdb-protobuf-client";
-import { stdDevLong } from "src/util";
-import { Duration, Bytes } from "src/util/format";
+import { stdDevLong, Duration, Bytes, longToInt } from "src/util";
 import classNames from "classnames/bind";
 import styles from "../barCharts/barCharts.module.scss";
 import { barChartFactory } from "src/barCharts/barChartFactory";
-import {
-  bar,
-  formatTwoPlaces,
-  longToInt,
-  approximify,
-} from "src/barCharts/utils";
+import { bar, approximify } from "src/barCharts/utils";
 
 type Transaction = protos.cockroach.server.serverpb.StatementsResponse.IExtendedCollectedTransactionStatistics;
 const cx = classNames.bind(styles);

--- a/packages/cluster-ui/src/transactionsTable/transactionsTable.tsx
+++ b/packages/cluster-ui/src/transactionsTable/transactionsTable.tsx
@@ -12,10 +12,9 @@ import {
   transactionsRetryBarChart,
 } from "./transactionsBarCharts";
 import { StatementTableTitle } from "../statementsTable/statementsTableContent";
-import { longToInt } from "./utils";
 import { tableClasses } from "./transactionsTableClasses";
 import { textCell } from "./transactionsCells";
-import { FixLong } from "src/util";
+import { FixLong, longToInt } from "src/util";
 import { SortSetting } from "../sortedtable";
 import {
   getStatementsById,

--- a/packages/cluster-ui/src/transactionsTable/utils.ts
+++ b/packages/cluster-ui/src/transactionsTable/utils.ts
@@ -1,7 +1,3 @@
-import { FixLong } from "src/util";
-
-export const longToInt = (value: number | Long) => Number(FixLong(value));
-
 export const limitText = (text: string, limit: number): string => {
   return text.length > limit ? text.slice(0, limit - 3).concat("...") : text;
 };

--- a/packages/cluster-ui/src/util/appStats/appStats.fixture.ts
+++ b/packages/cluster-ui/src/util/appStats/appStats.fixture.ts
@@ -92,6 +92,7 @@ export const statementsWithSameIdButDifferentNodeId: CollectedStatementStatistic
         seconds: Long.fromInt(1599670290),
         nanos: 111613000,
       },
+      nodes: [Long.fromInt(1), Long.fromInt(2)],
       exec_stats: {
         count: new Long(0),
         network_bytes: { mean: 0, squared_diffs: 0 },
@@ -199,6 +200,7 @@ export const statementsWithSameIdButDifferentNodeId: CollectedStatementStatistic
         seconds: Long.fromInt(1599670272),
         nanos: 111613000,
       },
+      nodes: [Long.fromInt(1), Long.fromInt(2)],
       exec_stats: {
         count: new Long(0),
         network_bytes: { mean: 0, squared_diffs: 0 },
@@ -309,6 +311,7 @@ export const statementsWithSameIdButDifferentNodeId: CollectedStatementStatistic
         seconds: Long.fromInt(1599670192),
         nanos: 111613000,
       },
+      nodes: [Long.fromInt(1), Long.fromInt(3)],
       exec_stats: {
         count: new Long(0),
         network_bytes: { mean: 0, squared_diffs: 0 },
@@ -413,6 +416,7 @@ export const statementsWithSameIdButDifferentNodeId: CollectedStatementStatistic
         seconds: Long.fromInt(1599670299),
         nanos: 111613000,
       },
+      nodes: [Long.fromInt(1)],
       exec_stats: {
         count: new Long(0),
         network_bytes: { mean: 0, squared_diffs: 0 },
@@ -517,6 +521,7 @@ export const statementsWithSameIdButDifferentNodeId: CollectedStatementStatistic
         seconds: Long.fromInt(1599670242),
         nanos: 111613000,
       },
+      nodes: [Long.fromInt(1), Long.fromInt(2), Long.fromInt(4)],
       exec_stats: {
         count: new Long(0),
         network_bytes: { mean: 0, squared_diffs: 0 },
@@ -627,6 +632,7 @@ export const statementsWithSameIdButDifferentNodeId: CollectedStatementStatistic
         seconds: Long.fromInt(1599650292),
         nanos: 111613000,
       },
+      nodes: [Long.fromInt(1), Long.fromInt(2)],
       exec_stats: {
         count: new Long(0),
         network_bytes: { mean: 0, squared_diffs: 0 },
@@ -737,6 +743,7 @@ export const statementsWithSameIdButDifferentNodeId: CollectedStatementStatistic
         seconds: Long.fromInt(1599670282),
         nanos: 111613000,
       },
+      nodes: [Long.fromInt(1), Long.fromInt(2)],
       exec_stats: {
         count: new Long(0),
         network_bytes: { mean: 0, squared_diffs: 0 },
@@ -850,6 +857,7 @@ export const statementsWithSameIdButDifferentNodeId: CollectedStatementStatistic
         seconds: Long.fromInt(1599670257),
         nanos: 111613000,
       },
+      nodes: [Long.fromInt(1), Long.fromInt(2)],
       exec_stats: {
         count: new Long(0),
         network_bytes: { mean: 0, squared_diffs: 0 },
@@ -957,6 +965,7 @@ export const statementsWithSameIdButDifferentNodeId: CollectedStatementStatistic
         seconds: Long.fromInt(1599670279),
         nanos: 111613000,
       },
+      nodes: [Long.fromInt(1), Long.fromInt(2)],
       exec_stats: {
         count: new Long(0),
         network_bytes: { mean: 0, squared_diffs: 0 },

--- a/packages/cluster-ui/src/util/appStats/appStats.spec.ts
+++ b/packages/cluster-ui/src/util/appStats/appStats.spec.ts
@@ -204,6 +204,7 @@ function randomStats(
       seconds: Long.fromInt(1599670292),
       nanos: 111613000,
     },
+    nodes: [Long.fromInt(1), Long.fromInt(3), Long.fromInt(4)],
   };
 }
 

--- a/packages/cluster-ui/src/util/appStats/appStats.ts
+++ b/packages/cluster-ui/src/util/appStats/appStats.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import _ from "lodash";
 import * as protos from "@cockroachlabs/crdb-protobuf-client";
-import { FixLong } from "src/util/fixLong";
+import { FixLong, uniqueLong } from "src/util";
 
 export type StatementStatistics = protos.cockroach.sql.IStatementStatistics;
 export type ExecStats = protos.cockroach.sql.IExecStats;
@@ -151,6 +151,7 @@ export function addStatementStats(
       a.last_exec_timestamp.seconds > b.last_exec_timestamp.seconds
         ? a.last_exec_timestamp
         : b.last_exec_timestamp,
+    nodes: uniqueLong([...a.nodes, ...b.nodes]),
   };
 }
 

--- a/packages/cluster-ui/src/util/arrays.ts
+++ b/packages/cluster-ui/src/util/arrays.ts
@@ -1,0 +1,13 @@
+import Long from "long";
+import { longToInt } from "./fixLong";
+
+// Remove duplicates and return an array with unique elements.
+export const unique = <T>(a: T[]): T[] => [...new Set([...a])];
+
+// Remove duplicates of an array of Long, returning an array with
+// unique elements. Since Long is an object, `Set` cannot identify
+// unique elements, so the array needs to be converted before
+// creating the Set and converted back to be returned.
+export const uniqueLong = (a: Long[]): Long[] => {
+  return unique(a.map(longToInt)).map(n => Long.fromInt(n));
+};

--- a/packages/cluster-ui/src/util/fixLong.ts
+++ b/packages/cluster-ui/src/util/fixLong.ts
@@ -9,3 +9,5 @@ export function FixLong(value: Long | number): Long {
   }
   return value as Long;
 }
+
+export const longToInt = (value: number | Long) => Number(FixLong(value));

--- a/packages/cluster-ui/src/util/index.ts
+++ b/packages/cluster-ui/src/util/index.ts
@@ -1,4 +1,5 @@
 export * from "./appStats";
+export * from "./arrays";
 export * from "./constants";
 export * from "./convert";
 export * from "./dataFromServer";

--- a/packages/cluster-ui/src/util/totalWorkload.ts
+++ b/packages/cluster-ui/src/util/totalWorkload.ts
@@ -1,6 +1,6 @@
 import * as protos from "@cockroachlabs/crdb-protobuf-client";
-import { longToInt } from "src/barCharts/utils";
 import { AggregateStatistics } from "src/statementsTable";
+import { longToInt } from "./fixLong";
 
 type Statement = protos.cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
 type statementType = AggregateStatistics | Statement;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2288,7 +2288,7 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@cockroachlabs/crdb-protobuf-client@^0.0.11":
+"@cockroachlabs/crdb-protobuf-client@^0.0.12":
   version "0.0.11"
   resolved "https://registry.yarnpkg.com/@cockroachlabs/crdb-protobuf-client/-/crdb-protobuf-client-0.0.11.tgz#02454d0800317bd0bea5487469009ed2ab8ad04a"
   integrity sha512-ggW3HpjL1nD/YfJjO60K3tDXvAeuLn2VPCWYZS7O9C3puI/EKSaDduxPU6GcK8NglGqx9arvqYqdRJubxggahA==


### PR DESCRIPTION
Add information about which node and region a statement was executed on.

<img width="530" alt="Screen Shot 2021-05-06 at 6 10 48 PM" src="https://user-images.githubusercontent.com/1017486/117371806-8125d600-ae96-11eb-8d83-162e900c8d83.png">

Resolves: https://github.com/cockroachdb/cockroach/issues/59979

Release note (ui change): Display on Statement Details information about
nodes and regions a statement was executed on.