### PR TITLE
cluster-ui: adding information about node and region on stmt/transaction pages

### DIFF
--- a/packages/cluster-ui/src/barCharts/utils.ts
+++ b/packages/cluster-ui/src/barCharts/utils.ts
@@ -1,5 +1,6 @@
 import { format as d3Format } from "d3-format";
 import * as protos from "@cockroachlabs/crdb-protobuf-client";
+import { TransactionInfo } from "../transactionsTable";
 
 type StatementStatistics = protos.cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
 type Transaction = protos.cockroach.server.serverpb.StatementsResponse.IExtendedCollectedTransactionStatistics;
@@ -10,7 +11,7 @@ export const formatTwoPlaces = d3Format(".2f");
 
 export function bar(
   name: string,
-  value: (d: StatementStatistics | Transaction) => number,
+  value: (d: StatementStatistics | Transaction | TransactionInfo) => number,
 ) {
   return { name, value };
 }

--- a/packages/cluster-ui/src/queryFilter/filter.module.scss
+++ b/packages/cluster-ui/src/queryFilter/filter.module.scss
@@ -56,7 +56,7 @@ $dropdown-hover-color: darken($colors--background, 2.5%);
       }
 
       &__margin-top {
-        margin-top: 27px;
+        margin-top: 15px;
       }
     }
 

--- a/packages/cluster-ui/src/queryFilter/filter.tsx
+++ b/packages/cluster-ui/src/queryFilter/filter.tsx
@@ -23,9 +23,13 @@ interface QueryFilter {
   activeFilters: number;
   filters: Filters;
   dbNames?: string[];
+  regions?: string[];
+  nodes?: string[];
   showDB?: boolean;
   showSqlType?: boolean;
   showScan?: boolean;
+  showRegions?: boolean;
+  showNodes?: boolean;
 }
 interface FilterState {
   hide: boolean;
@@ -45,6 +49,8 @@ export interface Filters {
   sqlType?: string;
   fullScan?: boolean;
   distributed?: boolean;
+  regions?: string;
+  nodes?: string;
 }
 
 const timeUnit = [
@@ -59,6 +65,8 @@ export const defaultFilters: Filters = {
   fullScan: false,
   sqlType: "",
   database: "",
+  regions: "",
+  nodes: "",
 };
 
 /**
@@ -101,6 +109,8 @@ export const inactiveFiltersState: Filters = {
   fullScan: false,
   sqlType: "",
   database: "",
+  regions: "",
+  nodes: "",
 };
 
 export const calculateActiveFilters = (filters: Filters) => {
@@ -213,10 +223,14 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
     const {
       appNames,
       dbNames,
+      regions,
+      nodes,
       activeFilters,
       showDB,
       showSqlType,
       showScan,
+      showRegions,
+      showNodes,
     } = this.props;
     const dropdownArea = hide ? hidden : dropdown;
     const customStyles = {
@@ -254,7 +268,6 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
           isSelected: this.isOptionSelected(db, filters.database),
         }))
       : [];
-
     const databaseValue = databasesOptions.filter(option => {
       return filters.database.split(",").includes(option.label);
     });
@@ -267,6 +280,52 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
           field="database"
           parent={this}
           value={databaseValue}
+        />
+      </div>
+    );
+
+    const regionsOptions = showRegions
+      ? regions.map(region => ({
+          label: region,
+          value: region,
+          isSelected: this.isOptionSelected(region, filters.regions),
+        }))
+      : [];
+    const regionsValue = regionsOptions.filter(option =>
+      filters.regions.split(",").includes(option.label),
+    );
+    const regionsFilter = (
+      <div>
+        <div className={filterLabel.margin}>Region</div>
+        <MultiSelectCheckbox
+          options={regionsOptions}
+          placeholder="All"
+          field="regions"
+          parent={this}
+          value={regionsValue}
+        />
+      </div>
+    );
+
+    const nodesOptions = showNodes
+      ? nodes.map(node => ({
+          label: node,
+          value: node,
+          isSelected: this.isOptionSelected(node, filters.nodes),
+        }))
+      : [];
+    const nodesValue = nodesOptions.filter(option => {
+      return filters.nodes.split(",").includes(option.label);
+    });
+    const nodesFilter = (
+      <div>
+        <div className={filterLabel.margin}>Node</div>
+        <MultiSelectCheckbox
+          options={nodesOptions}
+          placeholder="All"
+          field="nodes"
+          parent={this}
+          value={nodesValue}
         />
       </div>
     );
@@ -297,7 +356,6 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
     const sqlTypeValue = sqlTypes.filter(option => {
       return filters.sqlType.split(",").includes(option.label);
     });
-
     const sqlTypeFilter = (
       <div>
         <div className={filterLabel.margin}>Statement Type</div>
@@ -310,6 +368,7 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
         />
       </div>
     );
+
     const fullScanFilter = (
       <div className={filterLabel.margin}>
         <input
@@ -344,6 +403,8 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
             />
             {showDB ? dbFilter : ""}
             {showSqlType ? sqlTypeFilter : ""}
+            {showRegions ? regionsFilter : ""}
+            {showNodes ? nodesFilter : ""}
             <div className={filterLabel.margin}>
               Query fingerprint runs longer than
             </div>

--- a/packages/cluster-ui/src/sortedtable/sortedtable.module.scss
+++ b/packages/cluster-ui/src/sortedtable/sortedtable.module.scss
@@ -97,6 +97,10 @@
 
 }
 
+.break-line {
+    white-space:pre-wrap !important;
+}
+
 .cl-table-container {
   padding: 18px 24px;
 }

--- a/packages/cluster-ui/src/sortedtable/sortedtable.tsx
+++ b/packages/cluster-ui/src/sortedtable/sortedtable.tsx
@@ -11,6 +11,7 @@ import classNames from "classnames/bind";
 import { TableSpinner } from "./tableSpinner";
 import { TableHead } from "./tableHead";
 import { TableRow } from "./tableRow";
+import { Tooltip } from "@cockroachlabs/ui-components";
 
 export interface ISortedTablePagination {
   current: number;
@@ -369,4 +370,31 @@ export class SortedTable<T> extends React.Component<
       </div>
     );
   }
+}
+
+/**
+ * Creates an element limited by the max length and
+ * with a tooltip with one listed element per line.
+ * E.g. `value1, value2, value3` with maxLength 10 will display
+ * `value1, va...` on the table and
+ * `value1
+ * value2
+ * value3`  on the tooltip.
+ * @param value a string with elements separated by `, `.
+ * @param maxLength the max length to which it should display value
+ * and hide the remaining.
+ */
+export function longListWithTooltip(value: string, maxLength: number) {
+  const summary =
+    value.length > maxLength ? value.slice(0, maxLength) + "..." : value;
+  return (
+    <Tooltip
+      placement="bottom"
+      content={
+        <pre className={cx("break-line")}>{value.split(", ").join("\r\n")}</pre>
+      }
+    >
+      <div className="cl-table-link__tooltip-hover-area">{summary}</div>
+    </Tooltip>
+  );
 }

--- a/packages/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/packages/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -39,6 +39,7 @@ import {
 } from "src/barCharts";
 import {
   AggregateStatistics,
+  populateRegionNodeForStatements,
   makeNodesColumns,
   StatementsSortedTable,
 } from "src/statementsTable";
@@ -448,9 +449,10 @@ export class StatementDetails extends React.Component<
 
     const statsByNode = this.props.statement.byNode;
     const totalWorkload = calculateTotalWorkload(statsByNode);
-    const nodes = stats.nodes
-      ? stats.nodes.sort().map(node => node.toString())
-      : [];
+    populateRegionNodeForStatements(statsByNode, nodeRegions);
+    const nodes: string[] = unique(
+      stats.nodes.map(node => node.toString()),
+    ).sort();
     const regions = unique(
       stats.nodes.map(node => nodeRegions[node.toString()]),
     ).sort();
@@ -808,6 +810,7 @@ export class StatementDetails extends React.Component<
                 statsByNode,
                 this.props.nodeNames,
                 totalWorkload,
+                nodeRegions,
               )}
               sortSetting={this.state.sortSetting}
               onChangeSortSetting={this.changeSortSetting}

--- a/packages/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/packages/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -18,9 +18,16 @@ import {
   getTimeValueInSeconds,
 } from "../queryFilter";
 
-import { appAttr, getMatchParamByName, calculateTotalWorkload } from "src/util";
+import {
+  appAttr,
+  getMatchParamByName,
+  calculateTotalWorkload,
+  unique,
+  containAny,
+} from "src/util";
 import {
   AggregateStatistics,
+  populateRegionNodeForStatements,
   makeStatementsColumns,
   statementColumnLabels,
   StatementsSortedTable,
@@ -239,6 +246,8 @@ export class StatementsPage extends React.Component<
       timeUnit: filters.timeUnit,
       sqlType: filters.sqlType,
       database: filters.database,
+      regions: filters.regions,
+      nodes: filters.nodes,
     });
     this.selectApp(filters.app);
   };
@@ -264,13 +273,15 @@ export class StatementsPage extends React.Component<
       timeUnit: undefined,
       sqlType: undefined,
       database: undefined,
+      regions: undefined,
+      nodes: undefined,
     });
     this.selectApp("");
   };
 
   filteredStatementsData = () => {
     const { search, filters } = this.state;
-    const { statements } = this.props;
+    const { statements, nodeRegions } = this.props;
     const timeValue = getTimeValueInSeconds(filters);
     const sqlTypes =
       filters.sqlType.length > 0
@@ -282,7 +293,15 @@ export class StatementsPage extends React.Component<
         : [];
     const databases =
       filters.database.length > 0 ? filters.database.split(",") : [];
+    const regions =
+      filters.regions.length > 0 ? filters.regions.split(",") : [];
+    const nodes = filters.nodes.length > 0 ? filters.nodes.split(",") : [];
 
+    // Return statements filtered by the values selected on the filter and
+    // the search text. A statement must match all selected filters to be
+    // displayed on the table.
+    // Current filters: search text, database, fullScan, service latency,
+    // SQL Type, nodes and regions.
     return statements
       .filter(
         statement =>
@@ -306,6 +325,29 @@ export class StatementsPage extends React.Component<
       .filter(
         statement =>
           sqlTypes.length == 0 || sqlTypes.includes(statement.stats.sql_type),
+      )
+      .filter(
+        // The statement must contain at least one value from the selected nodes
+        // list if the list is not empty.
+        statement =>
+          regions.length == 0 ||
+          containAny(
+            statement.stats.nodes.map(
+              node => nodeRegions[node.toString()],
+              regions,
+            ),
+            regions,
+          ),
+      )
+      .filter(
+        // The statement must contain at least one value from the selected regions
+        // list if the list is not empty.
+        statement =>
+          nodes.length == 0 ||
+          containAny(
+            statement.stats.nodes.map(node => "n" + node),
+            nodes,
+          ),
       );
   };
 
@@ -321,6 +363,7 @@ export class StatementsPage extends React.Component<
       resetSQLStats,
       columns: userSelectedColumnsToShow,
       onColumnsChange,
+      nodeRegions,
     } = this.props;
     const appAttrValue = getMatchParamByName(match, appAttr);
     const selectedApp = appAttrValue || "";
@@ -330,17 +373,31 @@ export class StatementsPage extends React.Component<
     const totalWorkload = calculateTotalWorkload(data);
     const totalCount = data.length;
     const isEmptySearchResults = statements?.length > 0 && search?.length > 0;
+    const nodes = Object.keys(nodeRegions)
+      .map(n => Number(n))
+      .sort();
+    const regions = unique(
+      nodes.map(node => nodeRegions[node.toString()]),
+    ).sort();
+    populateRegionNodeForStatements(statements, nodeRegions);
 
     // Creates a list of all possible columns
     const columns = makeStatementsColumns(
       statements,
       selectedApp,
       totalWorkload,
+      nodeRegions,
       search,
       this.activateDiagnosticsRef,
       onDiagnosticsReportDownload,
       onStatementClick,
     );
+
+    // If it's multi-region, we want to show the Regions/Nodes column by default
+    // and hide otherwise.
+    if (regions.length > 1) {
+      columns.filter(c => c.name === "regionNodes")[0].showByDefault = true;
+    }
 
     const isColumnSelected = (c: ColumnDescriptor<AggregateStatistics>) => {
       return (
@@ -382,11 +439,15 @@ export class StatementsPage extends React.Component<
               onSubmitFilters={this.onSubmitFilters}
               appNames={appOptions}
               dbNames={databases}
+              regions={regions}
+              nodes={nodes.map(n => "n" + n)}
               activeFilters={activeFilters}
               filters={filters}
               showDB={true}
               showSqlType={true}
               showScan={true}
+              showRegions={regions.length > 1}
+              showNodes={nodes.length > 1}
             />
           </PageConfigItem>
         </PageConfig>

--- a/packages/cluster-ui/src/statementsTable/statementsTable.stories.tsx
+++ b/packages/cluster-ui/src/statementsTable/statementsTable.stories.tsx
@@ -20,6 +20,7 @@ storiesOf("StatementsSortedTable", module)
         statements,
         "(internal)",
         calculateTotalWorkload(statements),
+        { "1": "gcp-europe-west1", "2": "gcp-us-east1", "3": "gcp-us-west1" },
       )}
       sortSetting={{
         ascending: false,

--- a/packages/cluster-ui/src/statementsTable/statementsTable.tsx
+++ b/packages/cluster-ui/src/statementsTable/statementsTable.tsx
@@ -20,7 +20,11 @@ import {
   workloadPctBarChart,
 } from "src/barCharts";
 import { ActivateDiagnosticsModalRef } from "src/statementsDiagnostics";
-import { ColumnDescriptor, SortedTable } from "src/sortedtable";
+import {
+  ColumnDescriptor,
+  longListWithTooltip,
+  SortedTable,
+} from "src/sortedtable";
 
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import {
@@ -37,6 +41,7 @@ const cx = classNames.bind(styles);
 function makeCommonColumns(
   statements: AggregateStatistics[],
   totalWorkload: number,
+  nodeRegions: { [nodeId: string]: string },
 ): ColumnDescriptor<AggregateStatistics>[] {
   const defaultBarChartOptions = {
     classes: {
@@ -82,7 +87,7 @@ function makeCommonColumns(
       title: StatementTableTitle.database,
       className: cx("statements-table__col-database"),
       cell: (stmt: AggregateStatistics) => stmt.database,
-      sort: (stmt: AggregateStatistics) => FixLong(Number(stmt.database)),
+      sort: (stmt: AggregateStatistics) => stmt.database,
       showByDefault: false,
     },
     {
@@ -148,6 +153,16 @@ function makeCommonColumns(
         (stmt.stats.service_lat.mean * longToInt(stmt.stats.count)) /
         totalWorkload,
     },
+    {
+      name: "regionNodes",
+      title: StatementTableTitle.regionNodes,
+      className: cx("statements-table__col-regions"),
+      cell: (stmt: AggregateStatistics) => {
+        return longListWithTooltip(stmt.regionNodes.sort().join(", "), 50);
+      },
+      sort: (stmt: AggregateStatistics) => stmt.regionNodes.sort().join(", "),
+      showByDefault: false,
+    },
   ];
   return columns;
 }
@@ -164,6 +179,7 @@ export interface AggregateStatistics {
   diagnosticsReports?: cockroach.server.serverpb.IStatementDiagnosticsReport[];
   // totalWorkload is the sum of service latency of all statements listed on the table.
   totalWorkload?: Long;
+  regionNodes?: string[];
 }
 
 export class StatementsSortedTable extends SortedTable<AggregateStatistics> {}
@@ -192,6 +208,7 @@ export function makeStatementsColumns(
   selectedApp: string,
   // totalWorkload is the sum of service latency of all statements listed on the table.
   totalWorkload: number,
+  nodeRegions: { [nodeId: string]: string },
   search?: string,
   activateDiagnosticsRef?: React.RefObject<ActivateDiagnosticsModalRef>,
   onDiagnosticsDownload?: (report: IStatementDiagnosticsReport) => void,
@@ -211,7 +228,7 @@ export function makeStatementsColumns(
       alwaysShow: true,
     },
   ];
-  columns.push(...makeCommonColumns(statements, totalWorkload));
+  columns.push(...makeCommonColumns(statements, totalWorkload, nodeRegions));
 
   if (activateDiagnosticsRef) {
     const diagnosticsColumn: ColumnDescriptor<AggregateStatistics> = {
@@ -241,6 +258,7 @@ export function makeNodesColumns(
   statements: AggregateStatistics[],
   nodeNames: NodeNames,
   totalWorkload: number,
+  nodeRegions: { [nodeId: string]: string },
 ): ColumnDescriptor<AggregateStatistics>[] {
   const original: ColumnDescriptor<AggregateStatistics>[] = [
     {
@@ -250,5 +268,50 @@ export function makeNodesColumns(
     },
   ];
 
-  return original.concat(makeCommonColumns(statements, totalWorkload));
+  return original.concat(
+    makeCommonColumns(statements, totalWorkload, nodeRegions),
+  );
+}
+
+/**
+ * For each statement, generate the list of regions and nodes it was
+ * executed on. Each node is assigned to only one region and a region can
+ * have multiple nodes.
+ * E.g. of one element of the list: `gcp-us-east1 (n1, n2, n3)`
+ * @param statements: list of statements containing details about which
+ * node it was executed on.
+ * @param nodeRegions: object with keys being the node id and the value
+ * which region it belongs to.
+ */
+export function populateRegionNodeForStatements(
+  statements: AggregateStatistics[],
+  nodeRegions: { [p: string]: string },
+) {
+  statements.forEach(stmt => {
+    const regions: { [region: string]: Set<number> } = {};
+    // For each region, populate a list of all nodes where the statement was executed.
+    // E.g. {"gcp-us-east1" : [1,3,4]}
+    stmt.stats.nodes.forEach(node => {
+      if (Object.keys(regions).includes(nodeRegions[node.toString()])) {
+        regions[nodeRegions[node.toString()]].add(longToInt(node));
+      } else {
+        regions[nodeRegions[node.toString()]] = new Set([longToInt(node)]);
+      }
+    });
+    // Create a list nodes/regions where a statement was executed on, with
+    // format: region (node1,node2)
+    const regionNodes: string[] = [];
+    Object.keys(regions).forEach(region => {
+      regionNodes.push(
+        region +
+          " (" +
+          Array.from(regions[region])
+            .sort()
+            .map(n => "n" + n)
+            .toString() +
+          ")",
+      );
+    });
+    stmt.regionNodes = regionNodes;
+  });
 }

--- a/packages/cluster-ui/src/statementsTable/statementsTableContent.module.scss
+++ b/packages/cluster-ui/src/statementsTable/statementsTableContent.module.scss
@@ -64,3 +64,10 @@
     }
   }
 }
+
+.node-link {
+  display: flex;
+  font-weight: $font-weight--bold;
+  line-height: $line-height--medium;
+  white-space: nowrap;
+}

--- a/packages/cluster-ui/src/statementsTable/statementsTableContent.tsx
+++ b/packages/cluster-ui/src/statementsTable/statementsTableContent.tsx
@@ -49,6 +49,7 @@ export const statementColumnLabels = {
   networkBytes: "Network",
   retries: "Retries",
   workloadPct: "% of All Runtime",
+  regionNodes: "Regions/Nodes",
   diagnostics: "Diagnostics",
 };
 
@@ -81,15 +82,6 @@ export const StatementTableTitle: StatementTableTitleType = {
       {statementColumnLabels.statements}
     </Tooltip>
   ),
-  database: (
-    <Tooltip
-      placement="bottom"
-      style="tableTitle"
-      content={<p>Database on which the statement was executed.</p>}
-    >
-      Database
-    </Tooltip>
-  ),
   executionCount: (
     <Tooltip
       placement="bottom"
@@ -118,6 +110,15 @@ export const StatementTableTitle: StatementTableTitleType = {
       Execution Count
     </Tooltip>
   ),
+  database: (
+    <Tooltip
+      placement="bottom"
+      style="tableTitle"
+      content={<p>Database on which the statement was executed.</p>}
+    >
+      {statementColumnLabels.database}
+    </Tooltip>
+  ),
   rowsRead: (
     <Tooltip
       placement="bottom"
@@ -144,7 +145,7 @@ export const StatementTableTitle: StatementTableTitleType = {
         </>
       }
     >
-      Rows Read
+      {statementColumnLabels.rowsRead}
     </Tooltip>
   ),
   bytesRead: (
@@ -173,7 +174,7 @@ export const StatementTableTitle: StatementTableTitleType = {
         </>
       }
     >
-      Bytes Read
+      {statementColumnLabels.bytesRead}
     </Tooltip>
   ),
   statementTime: (
@@ -198,7 +199,7 @@ export const StatementTableTitle: StatementTableTitleType = {
         </>
       }
     >
-      Statement Time
+      {statementColumnLabels.statementTime}
     </Tooltip>
   ),
   transactionTime: (
@@ -223,7 +224,7 @@ export const StatementTableTitle: StatementTableTitleType = {
         </>
       }
     >
-      Transaction Time
+      {statementColumnLabels.transactionTime}
     </Tooltip>
   ),
   contention: (
@@ -250,7 +251,7 @@ export const StatementTableTitle: StatementTableTitleType = {
         </>
       }
     >
-      Contention
+      {statementColumnLabels.contention}
     </Tooltip>
   ),
   maxMemUsage: (
@@ -275,7 +276,7 @@ export const StatementTableTitle: StatementTableTitleType = {
         </>
       }
     >
-      Max Memory
+      {statementColumnLabels.maxMemUsage}
     </Tooltip>
   ),
   networkBytes: (
@@ -308,7 +309,7 @@ export const StatementTableTitle: StatementTableTitleType = {
         </>
       }
     >
-      Network
+      {statementColumnLabels.networkBytes}
     </Tooltip>
   ),
   retries: (
@@ -329,7 +330,7 @@ export const StatementTableTitle: StatementTableTitleType = {
         </>
       }
     >
-      Retries
+      {statementColumnLabels.retries}
     </Tooltip>
   ),
   workloadPct: (
@@ -344,7 +345,16 @@ export const StatementTableTitle: StatementTableTitleType = {
         </p>
       }
     >
-      % of All Runtime
+      {statementColumnLabels.workloadPct}
+    </Tooltip>
+  ),
+  regionNodes: (
+    <Tooltip
+      placement="bottom"
+      style="tableTitle"
+      content={<p>Regions/Nodes in which the statement was executed.</p>}
+    >
+      {statementColumnLabels.regionNodes}
     </Tooltip>
   ),
   diagnostics: (
@@ -366,7 +376,7 @@ export const StatementTableTitle: StatementTableTitleType = {
         </>
       }
     >
-      Diagnostics
+      {statementColumnLabels.diagnostics}
     </Tooltip>
   ),
 };
@@ -524,10 +534,10 @@ export const StatementLink = (props: StatementLinkProps) => {
   );
 };
 
-export const NodeLink = (props: { nodeId: string; nodeNames: NodeNames }) => (
+export const NodeLink = (props: { nodeId: string; nodeNames?: NodeNames }) => (
   <Link to={`/node/${props.nodeId}`}>
     <div className={cx("node-name-tooltip__info-icon")}>
-      {props.nodeNames[props.nodeId]}
+      {props.nodeNames ? props.nodeNames[props.nodeId] : "N" + props.nodeId}
     </div>
   </Link>
 );

--- a/packages/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/packages/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -13,7 +13,10 @@ import { Pagination } from "../pagination";
 import { TableStatistics } from "../tableStatistics";
 import { baseHeadingClasses } from "../transactionsPage/transactionsPageClasses";
 import { Button } from "../button";
-import { collectStatementsText } from "src/transactionsPage/utils";
+import {
+  collectStatementsText,
+  generateRegionNode,
+} from "src/transactionsPage/utils";
 import { tableClasses } from "../transactionsTable/transactionsTableClasses";
 import { SqlBox } from "../sql";
 import { aggregateStatements } from "../transactionsPage/utils";
@@ -33,7 +36,10 @@ import { Col, Row } from "antd";
 import { Text, Heading } from "@cockroachlabs/ui-components";
 import { formatTwoPlaces } from "../barCharts";
 import { ArrowLeft } from "@cockroachlabs/icons";
-import { makeStatementsColumns } from "src/statementsTable/statementsTable";
+import {
+  populateRegionNodeForStatements,
+  makeStatementsColumns,
+} from "src/statementsTable/statementsTable";
 
 const { containerClass } = tableClasses;
 const cx = classNames.bind(statementsStyles);
@@ -96,6 +102,7 @@ export class TransactionDetails extends React.Component<
       handleDetails,
       error,
       resetSQLStats,
+      nodeRegions,
     } = this.props;
     return (
       <div>
@@ -120,6 +127,7 @@ export class TransactionDetails extends React.Component<
             const statementsSummary = collectStatementsText(statements);
             const aggregatedStatements = aggregateStatements(statements);
             const totalWorkload = calculateTotalWorkload(statements);
+            populateRegionNodeForStatements(aggregatedStatements, nodeRegions);
             const duration = (v: number) => Duration(v * 1e9);
             return (
               <React.Fragment>
@@ -232,6 +240,7 @@ export class TransactionDetails extends React.Component<
                         aggregatedStatements,
                         "",
                         totalWorkload,
+                        nodeRegions,
                       )}
                       className={cx("statements-table")}
                       sortSetting={sortSetting}

--- a/packages/cluster-ui/src/transactionsPage/transactions.fixture.ts
+++ b/packages/cluster-ui/src/transactionsPage/transactions.fixture.ts
@@ -48,6 +48,7 @@ export const data: cockroach.server.serverpb.IStatementsResponse = {
       },
       stats: {
         count: Long.fromInt(557),
+        nodes: [Long.fromNumber(1), Long.fromNumber(2)],
         first_attempt_count: Long.fromInt(557),
         max_retries: Long.fromInt(0),
         legacy_last_err: "",
@@ -125,6 +126,7 @@ export const data: cockroach.server.serverpb.IStatementsResponse = {
       },
       stats: {
         count: Long.fromInt(70),
+        nodes: [Long.fromNumber(1), Long.fromNumber(3)],
         first_attempt_count: Long.fromInt(70),
         max_retries: Long.fromInt(0),
         legacy_last_err: "",
@@ -189,6 +191,7 @@ export const data: cockroach.server.serverpb.IStatementsResponse = {
       },
       stats: {
         count: Long.fromInt(1),
+        nodes: [Long.fromNumber(1), Long.fromNumber(3)],
         first_attempt_count: Long.fromInt(1),
         max_retries: Long.fromInt(0),
         legacy_last_err: "",
@@ -244,6 +247,7 @@ export const data: cockroach.server.serverpb.IStatementsResponse = {
       },
       stats: {
         count: Long.fromInt(280),
+        nodes: [Long.fromNumber(3), Long.fromNumber(4)],
         first_attempt_count: Long.fromInt(280),
         max_retries: Long.fromInt(0),
         legacy_last_err: "",
@@ -340,6 +344,7 @@ export const data: cockroach.server.serverpb.IStatementsResponse = {
       },
       stats: {
         count: Long.fromInt(1),
+        nodes: [Long.fromNumber(2), Long.fromNumber(4)],
         first_attempt_count: Long.fromInt(1),
         max_retries: Long.fromInt(0),
         legacy_last_err: "",
@@ -389,6 +394,7 @@ export const data: cockroach.server.serverpb.IStatementsResponse = {
       },
       stats: {
         count: Long.fromInt(1),
+        nodes: [Long.fromNumber(1)],
         first_attempt_count: Long.fromInt(1),
         max_retries: Long.fromInt(0),
         legacy_last_err: "",
@@ -427,6 +433,7 @@ export const data: cockroach.server.serverpb.IStatementsResponse = {
       },
       stats: {
         count: Long.fromInt(1),
+        nodes: [Long.fromNumber(3), Long.fromNumber(4)],
         first_attempt_count: Long.fromInt(1),
         max_retries: Long.fromInt(0),
         legacy_last_err: "",
@@ -464,6 +471,94 @@ export const data: cockroach.server.serverpb.IStatementsResponse = {
       key: {
         key_data: {
           query:
+            "WITH current_meta AS (SELECT version, num_records, num_spans, total_bytes FROM system.protected_ts_meta UNION ALL SELECT _ AS version, _ AS num_records, _ AS num_spans, _ AS total_bytes ORDER BY version DESC LIMIT _) SELECT version, num_records, num_spans, total_bytes FROM current_meta",
+          app: "$ internal-protectedts-GetMetadata",
+          distSQL: false,
+          failed: false,
+          opt: true,
+          implicit_txn: false,
+          vec: false,
+        },
+        node_id: 5,
+      },
+      stats: {
+        count: Long.fromInt(24),
+        nodes: [Long.fromNumber(2), Long.fromNumber(3)],
+        first_attempt_count: Long.fromInt(24),
+        max_retries: Long.fromInt(0),
+        legacy_last_err: "",
+        num_rows: { mean: 0, squared_diffs: 0 },
+        parse_lat: { mean: 0.0010775, squared_diffs: 0.000022485897999999995 },
+        plan_lat: {
+          mean: 0.029394708333333335,
+          squared_diffs: 0.1030786466649583,
+        },
+        run_lat: {
+          mean: 0.005224291666666666,
+          squared_diffs: 0.0025294570249583337,
+        },
+        service_lat: {
+          mean: 0.035700833333333334,
+          squared_diffs: 0.13060311153333334,
+        },
+        overhead_lat: {
+          mean: 0.000004333333333333095,
+          squared_diffs: 1.3933333333305632e-10,
+        },
+        legacy_last_err_redacted: "",
+        sensitive_info: {
+          last_err: "",
+          most_recent_plan_description: {
+            name: "render",
+            children: [
+              {
+                name: "limit",
+                attrs: [{ key: "count", value: "_" }],
+                children: [
+                  {
+                    name: "sort",
+                    attrs: [{ key: "order", value: "-version" }],
+                    children: [
+                      {
+                        name: "union all",
+                        children: [
+                          {
+                            name: "scan",
+                            attrs: [
+                              { key: "missing stats", value: "" },
+                              {
+                                key: "table",
+                                value: "protected_ts_meta@primary",
+                              },
+                              { key: "spans", value: "FULL SCAN" },
+                            ],
+                          },
+                          {
+                            name: "values",
+                            attrs: [{ key: "size", value: "1 column, 1 row" }],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          most_recent_plan_timestamp: {
+            seconds: Long.fromInt(1599670094),
+            nanos: 152349000,
+          },
+        },
+        bytes_read: { mean: 0, squared_diffs: 0 },
+        rows_read: { mean: 0, squared_diffs: 0 },
+      },
+      id: Long.fromInt(107),
+    },
+    {
+      key: {
+        key_data: {
+          query:
             "WITH deleted_sessions AS (DELETE FROM sqlliveness WHERE expiration < $1 RETURNING session_id) SELECT count(*) FROM deleted_sessions",
           app: "$ internal-delete-sessions",
           distSQL: false,
@@ -476,6 +571,7 @@ export const data: cockroach.server.serverpb.IStatementsResponse = {
       },
       stats: {
         count: Long.fromInt(141),
+        nodes: [Long.fromNumber(1), Long.fromNumber(2), Long.fromNumber(3)],
         first_attempt_count: Long.fromInt(141),
         max_retries: Long.fromInt(0),
         legacy_last_err: "",
@@ -587,6 +683,12 @@ export const data: cockroach.server.serverpb.IStatementsResponse = {
       },
       stats: {
         count: Long.fromInt(1),
+        nodes: [
+          Long.fromNumber(1),
+          Long.fromNumber(2),
+          Long.fromNumber(3),
+          Long.fromNumber(4),
+        ],
         first_attempt_count: Long.fromInt(1),
         max_retries: Long.fromInt(0),
         legacy_last_err: "",
@@ -624,93 +726,6 @@ export const data: cockroach.server.serverpb.IStatementsResponse = {
         rows_read: { mean: 0, squared_diffs: 0 },
       },
       id: Long.fromInt(109),
-    },
-    {
-      key: {
-        key_data: {
-          query:
-            "WITH current_meta AS (SELECT version, num_records, num_spans, total_bytes FROM system.protected_ts_meta UNION ALL SELECT _ AS version, _ AS num_records, _ AS num_spans, _ AS total_bytes ORDER BY version DESC LIMIT _) SELECT version, num_records, num_spans, total_bytes FROM current_meta",
-          app: "$ internal-protectedts-GetMetadata",
-          distSQL: false,
-          failed: false,
-          opt: true,
-          implicit_txn: false,
-          vec: false,
-        },
-        node_id: 5,
-      },
-      stats: {
-        count: Long.fromInt(24),
-        first_attempt_count: Long.fromInt(24),
-        max_retries: Long.fromInt(0),
-        legacy_last_err: "",
-        num_rows: { mean: 0, squared_diffs: 0 },
-        parse_lat: { mean: 0.0010775, squared_diffs: 0.000022485897999999995 },
-        plan_lat: {
-          mean: 0.029394708333333335,
-          squared_diffs: 0.1030786466649583,
-        },
-        run_lat: {
-          mean: 0.005224291666666666,
-          squared_diffs: 0.0025294570249583337,
-        },
-        service_lat: {
-          mean: 0.035700833333333334,
-          squared_diffs: 0.13060311153333334,
-        },
-        overhead_lat: {
-          mean: 0.000004333333333333095,
-          squared_diffs: 1.3933333333305632e-10,
-        },
-        legacy_last_err_redacted: "",
-        sensitive_info: {
-          last_err: "",
-          most_recent_plan_description: {
-            name: "render",
-            children: [
-              {
-                name: "limit",
-                attrs: [{ key: "count", value: "_" }],
-                children: [
-                  {
-                    name: "sort",
-                    attrs: [{ key: "order", value: "-version" }],
-                    children: [
-                      {
-                        name: "union all",
-                        children: [
-                          {
-                            name: "scan",
-                            attrs: [
-                              { key: "missing stats", value: "" },
-                              {
-                                key: "table",
-                                value: "protected_ts_meta@primary",
-                              },
-                              { key: "spans", value: "FULL SCAN" },
-                            ],
-                          },
-                          {
-                            name: "values",
-                            attrs: [{ key: "size", value: "1 column, 1 row" }],
-                          },
-                        ],
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-          most_recent_plan_timestamp: {
-            seconds: Long.fromInt(1599670094),
-            nanos: 152349000,
-          },
-        },
-        bytes_read: { mean: 0, squared_diffs: 0 },
-        rows_read: { mean: 0, squared_diffs: 0 },
-      },
-      id: Long.fromInt(107),
     },
   ],
   last_reset: { seconds: Long.fromInt(1599667572), nanos: 688635000 },

--- a/packages/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/packages/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -3,7 +3,7 @@ import * as protos from "@cockroachlabs/crdb-protobuf-client";
 import classNames from "classnames/bind";
 import styles from "../statementsPage/statementsPage.module.scss";
 import { RouteComponentProps } from "react-router-dom";
-import { TransactionsTable } from "../transactionsTable";
+import { TransactionInfo, TransactionsTable } from "../transactionsTable";
 import { TransactionDetails } from "../transactionDetails";
 import { ISortedTablePagination, SortSetting } from "../sortedtable";
 import { Pagination } from "../pagination";
@@ -12,7 +12,11 @@ import {
   baseHeadingClasses,
   statisticsClasses,
 } from "./transactionsPageClasses";
-import { aggregateAcrossNodeIDs, getTrxAppFilterOptions } from "./utils";
+import {
+  aggregateAcrossNodeIDs,
+  generateRegionNode,
+  getTrxAppFilterOptions,
+} from "./utils";
 import {
   searchTransactionsData,
   filterTransactions,
@@ -20,7 +24,7 @@ import {
 } from "./utils";
 import { forIn } from "lodash";
 import Long from "long";
-import { aggregateStatementStats, getSearchParams } from "src/util";
+import { aggregateStatementStats, getSearchParams, unique } from "src/util";
 import { EmptyTransactionsPlaceholder } from "./emptyTransactionsPlaceholder";
 import { Loading } from "../loading";
 import { PageConfig, PageConfigItem } from "../pageConfig";
@@ -153,6 +157,8 @@ export class TransactionsPage extends React.Component<
       app: filters.app,
       timeNumber: filters.timeNumber,
       timeUnit: filters.timeUnit,
+      regions: filters.regions,
+      nodes: filters.nodes,
     });
   };
 
@@ -167,6 +173,8 @@ export class TransactionsPage extends React.Component<
       app: undefined,
       timeNumber: undefined,
       timeUnit: undefined,
+      regions: undefined,
+      nodes: undefined,
     });
   };
 
@@ -191,13 +199,19 @@ export class TransactionsPage extends React.Component<
           loading={!this.props?.data}
           error={this.props?.error}
           render={() => {
-            const { data, resetSQLStats } = this.props;
+            const { data, resetSQLStats, nodeRegions } = this.props;
             const { pagination, search, filters } = this.state;
             const { statements, internal_app_name_prefix } = data;
             const appNames = getTrxAppFilterOptions(
               data.transactions,
               internal_app_name_prefix,
             );
+            const nodes = Object.keys(nodeRegions)
+              .map(n => Number(n))
+              .sort();
+            const regions = unique(
+              nodes.map(node => nodeRegions[node.toString()]),
+            ).sort();
             // We apply the search filters and app name filters prior to aggregating across Node IDs
             // in order to match what's done on the Statements Page.
             //
@@ -210,11 +224,17 @@ export class TransactionsPage extends React.Component<
               searchTransactionsData(search, data.transactions, statements),
               filters,
               internal_app_name_prefix,
+              statements,
+              nodeRegions,
             );
-            const transactionsToDisplay = aggregateAcrossNodeIDs(
+            const transactionsToDisplay: TransactionInfo[] = aggregateAcrossNodeIDs(
               filteredTransactions,
               statements,
-            );
+            ).map(t => ({
+              stats_data: t.stats_data,
+              node_id: t.node_id,
+              regionNodes: generateRegionNode(t, statements, nodeRegions),
+            }));
             const { current, pageSize } = pagination;
             const hasData = data.transactions?.length > 0;
             const isUsedFilter = search?.length > 0;
@@ -233,8 +253,12 @@ export class TransactionsPage extends React.Component<
                     <Filter
                       onSubmitFilters={this.onSubmitFilters}
                       appNames={appNames}
+                      regions={regions}
+                      nodes={nodes.map(n => "n" + n)}
                       activeFilters={activeFilters}
                       filters={filters}
+                      showRegions={regions.length > 1}
+                      showNodes={nodes.length > 1}
                     />
                   </PageConfigItem>
                 </PageConfig>
@@ -252,6 +276,7 @@ export class TransactionsPage extends React.Component<
                   <TransactionsTable
                     transactions={transactionsToDisplay}
                     statements={statements}
+                    nodeRegions={nodeRegions}
                     sortSetting={this.state.sortSetting}
                     onChangeSortSetting={this.onChangeSortSetting}
                     handleDetails={this.handleDetails}

--- a/packages/cluster-ui/src/transactionsPage/utils.spec.ts
+++ b/packages/cluster-ui/src/transactionsPage/utils.spec.ts
@@ -1,7 +1,7 @@
 import { assert } from "chai";
 import { filterTransactions, getStatementsById } from "./utils";
 import { Filters } from "../queryFilter/filter";
-import { data } from "./transactions.fixture";
+import { data, nodeRegions } from "./transactions.fixture";
 import Long from "long";
 import * as protos from "@cockroachlabs/crdb-protobuf-client";
 
@@ -31,9 +31,17 @@ describe("Filter transactions", () => {
       app: "All",
       timeNumber: "0",
       timeUnit: "seconds",
+      nodes: "",
+      regions: "",
     };
     assert.equal(
-      filterTransactions(txData, filter, "$ internal").transactions.length,
+      filterTransactions(
+        txData,
+        filter,
+        "$ internal",
+        data.statements,
+        nodeRegions,
+      ).transactions.length,
       11,
     );
   });
@@ -43,9 +51,17 @@ describe("Filter transactions", () => {
       app: "$ TEST",
       timeNumber: "0",
       timeUnit: "seconds",
+      nodes: "",
+      regions: "",
     };
     assert.equal(
-      filterTransactions(txData, filter, "$ internal").transactions.length,
+      filterTransactions(
+        txData,
+        filter,
+        "$ internal",
+        data.statements,
+        nodeRegions,
+      ).transactions.length,
       3,
     );
   });
@@ -55,9 +71,17 @@ describe("Filter transactions", () => {
       app: "$ TEST EXACT",
       timeNumber: "0",
       timeUnit: "seconds",
+      nodes: "",
+      regions: "",
     };
     assert.equal(
-      filterTransactions(txData, filter, "$ internal").transactions.length,
+      filterTransactions(
+        txData,
+        filter,
+        "$ internal",
+        data.statements,
+        nodeRegions,
+      ).transactions.length,
       1,
     );
   });
@@ -67,9 +91,17 @@ describe("Filter transactions", () => {
       app: data.internal_app_name_prefix,
       timeNumber: "0",
       timeUnit: "seconds",
+      nodes: "",
+      regions: "",
     };
     assert.equal(
-      filterTransactions(txData, filter, "$ internal").transactions.length,
+      filterTransactions(
+        txData,
+        filter,
+        "$ internal",
+        data.statements,
+        nodeRegions,
+      ).transactions.length,
       7,
     );
   });
@@ -79,10 +111,98 @@ describe("Filter transactions", () => {
       app: "All",
       timeNumber: "40",
       timeUnit: "miliseconds",
+      nodes: "",
+      regions: "",
     };
     assert.equal(
-      filterTransactions(txData, filter, "$ internal").transactions.length,
+      filterTransactions(
+        txData,
+        filter,
+        "$ internal",
+        data.statements,
+        nodeRegions,
+      ).transactions.length,
       8,
+    );
+  });
+
+  it("filters by one node", () => {
+    const filter: Filters = {
+      app: "All",
+      timeNumber: "0",
+      timeUnit: "seconds",
+      nodes: "n1",
+      regions: "",
+    };
+    assert.equal(
+      filterTransactions(
+        txData,
+        filter,
+        "$ internal",
+        data.statements,
+        nodeRegions,
+      ).transactions.length,
+      6,
+    );
+  });
+
+  it("filters by multiple nodes", () => {
+    const filter: Filters = {
+      app: "All",
+      timeNumber: "0",
+      timeUnit: "seconds",
+      nodes: "n2,n4",
+      regions: "",
+    };
+    assert.equal(
+      filterTransactions(
+        txData,
+        filter,
+        "$ internal",
+        data.statements,
+        nodeRegions,
+      ).transactions.length,
+      8,
+    );
+  });
+
+  it("filters by one region", () => {
+    const filter: Filters = {
+      app: "All",
+      timeNumber: "0",
+      timeUnit: "seconds",
+      nodes: "",
+      regions: "gcp-europe-west1",
+    };
+    assert.equal(
+      filterTransactions(
+        txData,
+        filter,
+        "$ internal",
+        data.statements,
+        nodeRegions,
+      ).transactions.length,
+      4,
+    );
+  });
+
+  it("filters by multiple regions", () => {
+    const filter: Filters = {
+      app: "All",
+      timeNumber: "0",
+      timeUnit: "seconds",
+      nodes: "",
+      regions: "gcp-us-west1,gcp-europe-west1",
+    };
+    assert.equal(
+      filterTransactions(
+        txData,
+        filter,
+        "$ internal",
+        data.statements,
+        nodeRegions,
+      ).transactions.length,
+      9,
     );
   });
 });

--- a/packages/cluster-ui/src/transactionsPage/utils.ts
+++ b/packages/cluster-ui/src/transactionsPage/utils.ts
@@ -1,9 +1,21 @@
 import * as protos from "@cockroachlabs/crdb-protobuf-client";
-import { Filters, SelectOptions, getTimeValueInSeconds } from "../queryFilter";
+import {
+  Filters,
+  SelectOptions,
+  getTimeValueInSeconds,
+  calculateActiveFilters,
+} from "../queryFilter";
 import { AggregateStatistics } from "../statementsTable";
 import Long from "long";
 import _ from "lodash";
-import { addExecStats, aggregateNumericStats, FixLong } from "../util";
+import {
+  addExecStats,
+  aggregateNumericStats,
+  containAny,
+  FixLong,
+  longToInt,
+  unique,
+} from "../util";
 
 type Statement = protos.cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
 type TransactionStats = protos.cockroach.sql.ITransactionStatistics;
@@ -69,6 +81,8 @@ export const filterTransactions = (
   data: Transaction[],
   filters: Filters,
   internalAppNamePrefix: string,
+  statements: Statement[],
+  nodeRegions: { [key: string]: string },
 ): { transactions: Transaction[]; activeFilters: number } => {
   if (!filters)
     return {
@@ -76,29 +90,102 @@ export const filterTransactions = (
       activeFilters: 0,
     };
   const timeValue = getTimeValueInSeconds(filters);
-  const filtersStatus = [
-    timeValue && timeValue !== "empty",
-    filters.app !== "All",
-  ];
-  const activeFilters = filtersStatus.filter(f => f).length;
+  const regions = filters.regions.length > 0 ? filters.regions.split(",") : [];
+  const nodes = filters.nodes.length > 0 ? filters.nodes.split(",") : [];
 
-  const filteredTransactions = data.filter((t: Transaction) => {
-    const matchAppNameExactly = t.stats_data.app === filters.app;
-    const filterIsSetToAll = filters.app === "All";
-    const filterIsInternalMatchByPrefix =
-      filters.app === internalAppNamePrefix &&
-      t.stats_data.app.includes(filters.app);
-    const validateTransaction = [
-      matchAppNameExactly || filterIsSetToAll || filterIsInternalMatchByPrefix,
-      t.stats_data.stats.service_lat.mean >= timeValue || timeValue === "empty",
-    ];
-    return validateTransaction.every(f => f);
-  });
+  const activeFilters = calculateActiveFilters(filters);
+
+  // Return transactions filtered by the values selected on the filter. A
+  // transaction must match all selected filters.
+  // Current filters: app, service latency, nodes and regions.
+  const filteredTransactions = data
+    .filter(
+      (t: Transaction) =>
+        filters.app === "All" ||
+        t.stats_data.app === filters.app ||
+        (filters.app === internalAppNamePrefix &&
+          t.stats_data.app.includes(filters.app)),
+    )
+    .filter(
+      (t: Transaction) =>
+        t.stats_data.stats.service_lat.mean >= timeValue ||
+        timeValue === "empty",
+    )
+    .filter((t: Transaction) => {
+      // The transaction must contain at least one value of the nodes
+      // and regions list (if the list is not empty).
+      if (regions.length == 0 && nodes.length == 0) return true;
+      let foundRegion: boolean = regions.length == 0;
+      let foundNode: boolean = nodes.length == 0;
+
+      getStatementsById(t.stats_data.statement_ids, statements).some(stmt => {
+        stmt.stats.nodes.some(node => {
+          if (foundRegion || regions.includes(nodeRegions[node.toString()])) {
+            foundRegion = true;
+          }
+          if (foundNode || nodes.includes("n" + node)) {
+            foundNode = true;
+          }
+          if (foundNode && foundRegion) return true;
+        });
+      });
+
+      return foundRegion && foundNode;
+    });
 
   return {
     transactions: filteredTransactions,
     activeFilters,
   };
+};
+
+/**
+ * For each transaction, generate the list of regions and nodes all
+ * its statements were executed on.
+ * E.g. of one element of the list: `gcp-us-east1 (n1, n2, n3)`
+ * @param transaction: list of transactions.
+ * @param statements: list of all statements collected.
+ * @param nodeRegions: object with keys being the node id and the value
+ * which region it belongs to.
+ */
+export const generateRegionNode = (
+  transaction: Transaction,
+  statements: Statement[],
+  nodeRegions: { [p: string]: string },
+): string[] => {
+  const regions: { [region: string]: Set<number> } = {};
+  // Get the list of statements that were executed on the transaction. Combine all
+  // nodes and regions of all the statements to a single list of `region: nodes`
+  // for the transaction.
+  // E.g. {"gcp-us-east1" : [1,3,4]}
+  getStatementsById(transaction.stats_data.statement_ids, statements).forEach(
+    stmt => {
+      stmt.stats.nodes.forEach(n => {
+        const node = n.toString();
+        if (Object.keys(regions).includes(nodeRegions[node])) {
+          regions[nodeRegions[node]].add(longToInt(n));
+        } else {
+          regions[nodeRegions[node]] = new Set([longToInt(n)]);
+        }
+      });
+    },
+  );
+
+  // Create a list nodes/regions where a transaction was executed on, with
+  // format: region (node1,node2)
+  const regionNodes: string[] = [];
+  Object.keys(regions).forEach(region => {
+    regionNodes.push(
+      region +
+        " (" +
+        Array.from(regions[region])
+          .sort()
+          .map(n => "n" + n)
+          .toString() +
+        ")",
+    );
+  });
+  return regionNodes;
 };
 
 type TransactionWithFingerprint = Transaction & { fingerprint: string };

--- a/packages/cluster-ui/src/util/arrays.ts
+++ b/packages/cluster-ui/src/util/arrays.ts
@@ -11,3 +11,8 @@ export const unique = <T>(a: T[]): T[] => [...new Set([...a])];
 export const uniqueLong = (a: Long[]): Long[] => {
   return unique(a.map(longToInt)).map(n => Long.fromInt(n));
 };
+
+// Check if array `a` contains any element of array `b`.
+export const containAny = (a: string[], b: string[]): boolean => {
+  return a.some(item => b.includes(item));
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2289,9 +2289,9 @@
     minimist "^1.2.0"
 
 "@cockroachlabs/crdb-protobuf-client@^0.0.12":
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/@cockroachlabs/crdb-protobuf-client/-/crdb-protobuf-client-0.0.11.tgz#02454d0800317bd0bea5487469009ed2ab8ad04a"
-  integrity sha512-ggW3HpjL1nD/YfJjO60K3tDXvAeuLn2VPCWYZS7O9C3puI/EKSaDduxPU6GcK8NglGqx9arvqYqdRJubxggahA==
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/@cockroachlabs/crdb-protobuf-client/-/crdb-protobuf-client-0.0.12.tgz#c8f054db04fb04cef7cd08788000ee93a02cbe98"
+  integrity sha512-yQP+62rzPAquyTrexeRkds5FIBvyXGsetewCVt39easUyiXBZnB8oEMKCJlP0z+/elirIWfFOuFxPOvSNEwWzw==
 
 "@cockroachlabs/icons@0.3.0":
   version "0.3.0"


### PR DESCRIPTION
Display information about which Regions/Nodes a statement was executed and
a filter option for region and another for nodes.
Both new filters will only be displayed if there is more than one value.

**Values on the table:**
<img width="345" alt="Screen Shot 2021-05-13 at 6 30 56 PM" src="https://user-images.githubusercontent.com/1017486/118195666-a62bc300-b419-11eb-86b7-465f629c596f.png">

**Filter:**
<img width="312" alt="Screen Shot 2021-05-13 at 6 31 40 PM" src="https://user-images.githubusercontent.com/1017486/118195697-b2b01b80-b419-11eb-9121-2861eb6019d2.png">

**Columns selector on statement page:**
<img width="315" alt="Screen Shot 2021-05-13 at 6 31 16 PM" src="https://user-images.githubusercontent.com/1017486/118195725-be034700-b419-11eb-96c6-7852172d1399.png">


Release note (ui change): Display on Statement and Transaction pages information
about nodes and regions a statement was executed on.