### PR TITLE
cluster-ui: fix sort on tables

### DIFF
--- a/packages/cluster-ui/src/sessions/sessionsPage.tsx
+++ b/packages/cluster-ui/src/sessions/sessionsPage.tsx
@@ -82,8 +82,9 @@ export class SessionsPage extends React.Component<
     super(props);
     const defaultState = {
       sortSetting: {
-        sortKey: 2, // Sort by Statement Age column as default option.
+        // Sort by Statement Age column as default option.
         ascending: false,
+        columnTitle: "statementAge",
       },
       pagination: {
         pageSize: 20,
@@ -100,13 +101,13 @@ export class SessionsPage extends React.Component<
   getStateFromHistory = (): Partial<SessionsPageState> => {
     const { history } = this.props;
     const searchParams = new URLSearchParams(history.location.search);
-    const sortKey = searchParams.get("sortKey") || undefined;
     const ascending = searchParams.get("ascending") || undefined;
+    const columnTitle = searchParams.get("columnTitle") || undefined;
 
     return {
       sortSetting: {
-        sortKey: sortKey,
-        ascending: Boolean(ascending),
+        ascending: ascending === "true",
+        columnTitle: columnTitle,
       },
     };
   };
@@ -135,8 +136,8 @@ export class SessionsPage extends React.Component<
     });
 
     this.syncHistory({
-      sortKey: ss.sortKey,
-      ascending: Boolean(ss.ascending).toString(),
+      ascending: ss.ascending.toString(),
+      columnTitle: ss.columnTitle,
     });
   };
 

--- a/packages/cluster-ui/src/sortedtable/sortedtable.spec.tsx
+++ b/packages/cluster-ui/src/sortedtable/sortedtable.spec.tsx
@@ -93,7 +93,6 @@ describe("<SortedTable>", function() {
       .simulate("click");
     assert.isTrue(spy.calledOnce);
     assert.deepEqual(spy.getCall(0).args[0], {
-      sortKey: 0,
       ascending: false,
       columnTitle: "first",
     } as SortSetting);
@@ -130,10 +129,16 @@ describe("<SortedTable>", function() {
       });
     };
     assertMatches(data);
-    wrapper = makeTable(data, { sortKey: 0, ascending: true });
+    wrapper = makeTable(data, {
+      ascending: true,
+      columnTitle: "first",
+    });
     assertMatches(_.sortBy(data, r => r.name));
     wrapper.setProps({
-      uiSortSetting: { sortKey: 1, ascending: true } as SortSetting,
+      uiSortSetting: {
+        ascending: true,
+        columnTitle: "second",
+      } as SortSetting,
     });
     assertMatches(_.sortBy(data, r => r.value));
   });
@@ -237,10 +242,15 @@ describe("<SortedTable>", function() {
       "first row column at seconds page match",
     );
 
-    wrapper = makeTable(data, { sortKey: 0, ascending: true }, undefined, {
-      current: 1,
-      pageSize: 2,
-    });
+    wrapper = makeTable(
+      data,
+      { ascending: true, columnTitle: "first" },
+      undefined,
+      {
+        current: 1,
+        pageSize: 2,
+      },
+    );
     rows = wrapper.find("tbody");
     assert.equal(
       rows
@@ -252,10 +262,15 @@ describe("<SortedTable>", function() {
       "second row column at first page match",
     );
 
-    wrapper = makeTable(data, { sortKey: 0, ascending: true }, undefined, {
-      current: 2,
-      pageSize: 2,
-    });
+    wrapper = makeTable(
+      data,
+      { ascending: true, columnTitle: "first" },
+      undefined,
+      {
+        current: 2,
+        pageSize: 2,
+      },
+    );
     rows = wrapper.find("tbody");
     assert.equal(
       rows

--- a/packages/cluster-ui/src/sortedtable/sortedtable.tsx
+++ b/packages/cluster-ui/src/sortedtable/sortedtable.tsx
@@ -122,7 +122,7 @@ export interface SortableColumn {
   // Unique key that identifies this column from others, for the purpose of
   // indicating sort order. If not provided, the column is not considered
   // sortable.
-  sortKey?: any;
+  columnTitle?: any;
   // className is a classname to apply to the td elements
   className?: string;
   titleAlign?: "left" | "right" | "center";
@@ -132,12 +132,11 @@ export interface SortableColumn {
 
 /**
  * SortSetting is the structure that SortableTable uses to indicate its current
- * sort preference to higher-level components. It contains a sortKey (taken from
+ * sort preference to higher-level components. It contains a columnTitle (taken from
  * one of the currently displayed columns) and a boolean indicating that the
  * sort should be ascending, rather than descending.
  */
 export interface SortSetting {
-  sortKey: any;
   ascending: boolean;
   columnTitle?: string;
 }
@@ -171,8 +170,8 @@ export class SortedTable<T> extends React.Component<
     rowClass: (_obj: any) => "",
     columns: [],
     sortSetting: {
-      sortKey: null,
       ascending: false,
+      columnTitle: null,
     },
     onChangeSortSetting: _ss => {},
   };
@@ -205,7 +204,9 @@ export class SortedTable<T> extends React.Component<
       if (!sortSetting) {
         return this.paginatedData();
       }
-      const sortColumn = columns[sortSetting.sortKey];
+      const sortColumn = columns.filter(
+        c => c.name === sortSetting.columnTitle,
+      )[0];
       if (!sortColumn || !sortColumn.sort) {
         return this.paginatedData();
       }
@@ -240,7 +241,7 @@ export class SortedTable<T> extends React.Component<
             name: cd.name,
             title: cd.title,
             cell: index => cd.cell(sorted[index]),
-            sortKey: cd.sort ? ii : undefined,
+            columnTitle: cd.sort ? cd.name : undefined,
             rollup: rollups[ii],
             className: cd.className,
             titleAlign: cd.titleAlign,

--- a/packages/cluster-ui/src/sortedtable/tableHead/tableHead.tsx
+++ b/packages/cluster-ui/src/sortedtable/tableHead/tableHead.tsx
@@ -25,20 +25,20 @@ export const TableHead: React.FC<TableHeadProps> = ({
   const cellContentWrapper = cx("inner-content-wrapper");
   const arrowsClass = cx("sortable__actions");
 
-  function handleSort(thSortKey: any, picked: boolean, columnTitle?: string) {
-    // If the sort key is different than the previous key, initial sort
-    // descending. If the same sort key is clicked multiple times consecutively,
+  function handleSort(picked: boolean, columnTitle: string) {
+    // If the columnTitle is different than the previous value, initial sort
+    // descending. If the same columnTitle is clicked multiple times consecutively,
     // first change to ascending, then remove the sort key.
     const ASCENDING = true;
     const DESCENDING = false;
 
     const direction = picked ? ASCENDING : DESCENDING;
-    const sortElementKey = picked && sortSetting.ascending ? null : thSortKey;
+    const sortElementColumnTitle =
+      picked && sortSetting.ascending ? null : columnTitle;
 
     onChangeSortSetting({
-      sortKey: sortElementKey,
       ascending: direction,
-      columnTitle,
+      columnTitle: sortElementColumnTitle,
     });
   }
 
@@ -47,12 +47,10 @@ export const TableHead: React.FC<TableHeadProps> = ({
       <tr className={trClass}>
         {expandableConfig && <th className={thClass} />}
         {columns.map((c: SortableColumn, idx: number) => {
-          const sortable = c.sortKey !== (null || undefined);
-          const picked = c.sortKey === sortSetting.sortKey;
+          const sortable = c.columnTitle !== (null || undefined);
+          const picked = c.name === sortSetting.columnTitle;
           const style = { textAlign: c.titleAlign };
-          const cellAction = sortable
-            ? () => handleSort(c.sortKey, picked, c.name)
-            : null;
+          const cellAction = sortable ? () => handleSort(picked, c.name) : null;
           const cellClasses = cx(
             "head-wrapper__cell",
             "sorted__cell",

--- a/packages/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/packages/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -294,8 +294,9 @@ export class StatementDetails extends React.Component<
     const searchParams = new URLSearchParams(props.history.location.search);
     this.state = {
       sortSetting: {
-        sortKey: 5, // Latency
+        // Latency
         ascending: false,
+        columnTitle: "statementTime",
       },
       currentTab: searchParams.get("tab") || "overview",
     };

--- a/packages/cluster-ui/src/statementsPage/statementsPage.spec.tsx
+++ b/packages/cluster-ui/src/statementsPage/statementsPage.spec.tsx
@@ -26,7 +26,10 @@ describe("StatementsPage", () => {
       > = rootWrapper.find(StatementsPage).first();
       const statementsPageInstance = statementsPageWrapper.instance();
 
-      assert.equal(statementsPageInstance.state.sortSetting.sortKey, 1);
+      assert.equal(
+        statementsPageInstance.state.sortSetting.columnTitle,
+        "executionCount",
+      );
       assert.equal(statementsPageInstance.state.sortSetting.ascending, false);
     });
   });

--- a/packages/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/packages/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -104,8 +104,8 @@ export class StatementsPage extends React.Component<
     const defaultState = {
       sortSetting: {
         // Sort by Execution Count column as default option.
-        sortKey: 1,
         ascending: false,
+        columnTitle: "executionCount",
       },
       pagination: {
         pageSize: 20,
@@ -124,14 +124,14 @@ export class StatementsPage extends React.Component<
   getStateFromHistory = (): Partial<StatementsPageState> => {
     const { history } = this.props;
     const searchParams = new URLSearchParams(history.location.search);
-    const sortKey = searchParams.get("sortKey") || undefined;
     const ascending = searchParams.get("ascending") || undefined;
+    const columnTitle = searchParams.get("columnTitle") || undefined;
     const searchQuery = searchParams.get("q") || undefined;
 
     return {
       sortSetting: {
-        sortKey,
-        ascending: Boolean(ascending),
+        ascending: ascending === "true",
+        columnTitle,
       },
       search: searchQuery,
     };
@@ -159,8 +159,8 @@ export class StatementsPage extends React.Component<
     });
 
     this.syncHistory({
-      sortKey: ss.sortKey,
-      ascending: Boolean(ss.ascending).toString(),
+      ascending: ss.ascending.toString(),
+      columnTitle: ss.columnTitle,
     });
     if (this.props.onSortingChange) {
       this.props.onSortingChange("Statements", ss.columnTitle, ss.ascending);

--- a/packages/cluster-ui/src/statementsTable/statementsTable.stories.tsx
+++ b/packages/cluster-ui/src/statementsTable/statementsTable.stories.tsx
@@ -23,7 +23,7 @@ storiesOf("StatementsSortedTable", module)
       )}
       sortSetting={{
         ascending: false,
-        sortKey: 3,
+        columnTitle: "rowsRead",
       }}
       pagination={{
         pageSize: 20,

--- a/packages/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/packages/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -69,8 +69,8 @@ export class TransactionDetails extends React.Component<
   state: TState = {
     sortSetting: {
       // Sort by statement latency as default column.
-      sortKey: 4,
       ascending: false,
+      columnTitle: "statementTime",
     },
     pagination: {
       pageSize: 10,

--- a/packages/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/packages/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -60,12 +60,14 @@ export class TransactionsPage extends React.Component<
 > {
   trxSearchParams = getSearchParams(this.props.history.location.search);
   filters = getFiltersFromQueryString(this.props.history.location.search);
-
   state: TState = {
     sortSetting: {
       // Sort by Execution Count column as default option.
-      sortKey: 1,
-      ascending: false,
+      ascending: this.trxSearchParams("ascending", false).toString() === "true",
+      columnTitle: this.trxSearchParams(
+        "columnTitle",
+        "execution count",
+      ).toString(),
     },
     pagination: {
       pageSize: this.props.pageSize || 20,
@@ -105,8 +107,8 @@ export class TransactionsPage extends React.Component<
       sortSetting: ss,
     });
     this.syncHistory({
-      sortKey: ss.sortKey,
-      ascending: Boolean(ss.ascending).toString(),
+      ascending: ss.ascending.toString(),
+      columnTitle: ss.columnTitle,
     });
   };
 

--- a/packages/cluster-ui/src/util/appStats/appStats.ts
+++ b/packages/cluster-ui/src/util/appStats/appStats.ts
@@ -219,7 +219,7 @@ export function combineStatementStats(
 
 export const getSearchParams = (searchParams: string) => {
   const sp = new URLSearchParams(searchParams);
-  return (key: string, defaultValue?: string | boolean) =>
+  return (key: string, defaultValue?: string | boolean | number) =>
     sp.get(key) || defaultValue;
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2289,9 +2289,9 @@
     minimist "^1.2.0"
 
 "@cockroachlabs/crdb-protobuf-client@^0.0.12":
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/@cockroachlabs/crdb-protobuf-client/-/crdb-protobuf-client-0.0.11.tgz#02454d0800317bd0bea5487469009ed2ab8ad04a"
-  integrity sha512-ggW3HpjL1nD/YfJjO60K3tDXvAeuLn2VPCWYZS7O9C3puI/EKSaDduxPU6GcK8NglGqx9arvqYqdRJubxggahA==
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/@cockroachlabs/crdb-protobuf-client/-/crdb-protobuf-client-0.0.12.tgz#c8f054db04fb04cef7cd08788000ee93a02cbe98"
+  integrity sha512-yQP+62rzPAquyTrexeRkds5FIBvyXGsetewCVt39easUyiXBZnB8oEMKCJlP0z+/elirIWfFOuFxPOvSNEwWzw==
 
 "@cockroachlabs/icons@0.3.0":
   version "0.3.0"


### PR DESCRIPTION
Sort on tables of Statement, Transaction and Sessions page were
not using the right value from the url regarding sorting. It was
using the right sortKey, but always doing ascending. Fix done so
it uses the right value for the boolean.

Since the sortKet might be different for different users on Statement
Page (difference on columns being displayed), use the name of the
columns, instead of the key.

Fixes: https://github.com/cockroachdb/cockroach/issues/65085

Release note (bug fix): Sort on tables are now picking up the
correct value from the url.
