### PR TITLE
cluster-ui: Increasing version to align release branches

### DIFF
--- a/packages/cluster-ui/package.json
+++ b/packages/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "0.2.15",
+  "version": "0.2.43",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# CLUSTER-UI // Version alignment

This package has become misaligned with the dependent API in CRDB. After
cutting a release branch (`release-21.1`) API changes continued on
master as the next version of CRDB, but the version of cluster-ui
continued along the same minor version. By increasing the version of
0.2.x, we are aligning the minor version back to the appropriate version
  of the database.

This means that 0.2.43 is an ancestor of 0.2.15, and that intermediate
versions will become the next minor version (0.3.0). This will be
documented via markdown in this repository and those intermediate
versions will be deprecated in the npm registry.

