### PR TITLE
cluster-ui: fix styling for statements filter component

### DIFF
--- a/packages/cluster-ui/src/queryFilter/filterClasses.ts
+++ b/packages/cluster-ui/src/queryFilter/filterClasses.ts
@@ -1,5 +1,7 @@
 import classNames from "classnames/bind";
 import styles from "./filter.module.scss";
+import "react-select/dist/react-select.css";
+import "./select.scss";
 
 const cx = classNames.bind(styles);
 

--- a/packages/cluster-ui/src/queryFilter/select.scss
+++ b/packages/cluster-ui/src/queryFilter/select.scss
@@ -1,0 +1,108 @@
+@import "../core/index.module";
+
+.Select.is-focused {
+  &:not(.is-open) {
+    .Select-control {
+      box-shadow: none;
+      border: none;
+    }
+  }
+}
+
+.Select.is-focused {
+  &:not(.is-open) {
+    .Select-control {
+      box-shadow: none;
+      border: none;
+    }
+  }
+}
+
+.Select-value, .Select-placeholder {
+  line-height: inherit !important;
+  height: auto !important;
+  position: relative !important;
+  white-space: nowrap !important;
+  max-width: 250px !important;
+  padding: 0 0 0 3px !important;
+}
+
+.Select-control {
+  line-height: inherit !important;
+  height: auto !important;
+  border-width: 0 !important;
+  background-color: transparent !important;
+  width: auto !important;
+
+  &:hover {
+    box-shadow: none;
+  }
+}
+
+.Select-input {
+  line-height: inherit !important;
+  height: auto !important;
+  position: absolute !important;
+  top: 0 !important;
+}
+
+.Select-input > input {
+  padding: 0 !important;
+}
+
+.Select-menu-outer {
+  width: auto !important;
+  border: none !important;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2) !important;
+  max-height: 200px;
+  font-family: $font-family--base;
+  font-size: 14px;
+  text-transform: none;
+  letter-spacing: 0;
+  border-radius: 4px !important;
+  padding: 0 0;
+}
+
+.Select-menu, .Select-menu-outer {
+  max-height: 350px;
+}
+
+.Select-value-label {
+  display: block !important;
+  cursor: pointer;
+}
+
+.Select-arrow {
+  border-top-color: #242a35 !important;
+}
+
+.Select {
+  display: block;
+  width: 100%;
+}
+
+.dropdown--side-arrows {
+  .Select {
+    padding: 12px 24px !important;
+  }
+
+  .Select-arrow-zone {
+    display: none;
+  }
+}
+
+Select {
+  display: flex;
+  justify-content: space-between;
+}
+
+.Select-value-label {
+  margin-right: 10px;
+  font-family: $font-family--base font-weight 600 font-size 14px;
+  line-height: 24px;
+  color: $colors--neutral-7 text-transform initial;
+
+  &__sufix {
+    color: $colors--secondary-text;
+  }
+}


### PR DESCRIPTION
Filter component is based on `react-select` package and has been moved
form cockroachdb repository initially. But except component related
styles, this component relied on global styles defined in `cockroachdb/cockroach/pkg/ui/styl/shame.styl`
 file and wasn't moved with component.
 Current fix imports default `react-select` component styles and
 overridden styles as well.

<img width="656" alt="Screen Shot 2021-05-21 at 5 59 03 PM" src="https://user-images.githubusercontent.com/3106437/119158783-4065b980-ba5f-11eb-8a9b-8336bdf4fd86.png">

<img width="744" alt="Screen Shot 2021-05-21 at 5 43 47 PM" src="https://user-images.githubusercontent.com/3106437/119158774-3f348c80-ba5f-11eb-8a12-70b77d0adee7.png">