### PR TITLE
exclude svgr/cli package from been updated by renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -7,7 +7,7 @@
   extends: ["config:base"],
   // We currently only use renovate for JavaScript dependencies.
   enabledManagers: ["npm"],
-  ignoreDeps: [],
+  ignoreDeps: ["@svgr/cli"],
   ignorePaths: [],
   schedule: ["on Friday"],
   packageRules: [


### PR DESCRIPTION
@cockroachlabs/icons package depends on `@svgr/cli` package
to build icons and it works well with at most 5.3.0 version.
Other latest versions cause build failures and looks like
some incompatible change was introduced in minor versions.

Recently, we had the same issue and the version was
downgraded back to 5.3.0 in following commit 03eaecbe4ca725e93427fdfc3ae4bb2e15958a93

This change extends renovate configuration to avoid upgrading
version for @svgr/cli package.

Also this change should resolve build failures in some of existing renovate PRs
