### PR TITLE
ui-components: fix tooltip scroll

### DIFF
--- a/packages/ui-components/src/Tooltip/Tooltip.tsx
+++ b/packages/ui-components/src/Tooltip/Tooltip.tsx
@@ -60,7 +60,7 @@ export const Tooltip: FunctionComponent<TooltipProps> = ({
 
   useEffect(() => {
     const onScroll = () => {
-      popperElement.removeAttribute("data-show");
+      popperElement?.removeAttribute("data-show");
     };
     document.addEventListener("scroll", onScroll, true);
     return () => document.removeEventListener("scroll", onScroll);


### PR DESCRIPTION
Tooltip is causing an scroll error. This commit makes
sure that popperElement exists before removing elements from it

