### PR TITLE
ui-components: demonstrate inline Tooltip bug

### DIFF
--- a/packages/storybook-ui-components/stories/Tooltip.stories.tsx
+++ b/packages/storybook-ui-components/stories/Tooltip.stories.tsx
@@ -132,7 +132,7 @@ export const Example = () => {
   );
 };
 
-export const Demo = () => (
+export const PlainString = () => (
   <StoryContainer>
     <div
       style={{
@@ -171,5 +171,30 @@ export const Demo = () => (
         hover me
       </Tooltip>
     </div>
+  </StoryContainer>
+);
+
+export const Inline = () => (
+  <StoryContainer>
+      <div style={{padding: "5px"}}>
+          <Tooltip
+            content={text(
+              "Text",
+              "should be centered around inline element",
+            )}
+          >
+            <span style={{ backgroundColor: "yellow", padding: "5px" }}>I'm an inline element</span>
+          </Tooltip>
+      </div>
+      <div style={{padding: "5px"}}>
+          <Tooltip
+            content={text(
+              "Text",
+              "should be centered around block element",
+            )}
+          >
+            <div style={{ backgroundColor: "yellow", padding: "5px" }}>I'm a block element</div>
+          </Tooltip>
+      </div>
   </StoryContainer>
 );


### PR DESCRIPTION
Add story to demonstrate the https://github.com/cockroachdb/ui/issues/395 bug with using the Tooltip on inline elements

<img width="605" alt="image" src="https://user-images.githubusercontent.com/91907326/138921011-c4876d18-5875-4b97-b54e-06f24265a29d.png">