### PR TITLE
design-tokens: export stylus tokens

### DIFF
--- a/packages/design-tokens/README.md
+++ b/packages/design-tokens/README.md
@@ -32,6 +32,19 @@ npm run build
 }
 ```
 
+### Stylus
+
+`tokens.styl` contains exported token values as Stylus variables.
+
+```stylus
+@require "~@cockroachlabs/design-tokens/dist/web/tokens"
+
+.example
+  color $color-intent-success-4
+  background-color $color-intent-success-1
+  border-radius 3px
+```
+
 ### JavaScript
 
 `tokens.js` contains exported token values as JavaScript constants.

--- a/packages/design-tokens/config.json
+++ b/packages/design-tokens/config.json
@@ -11,6 +11,16 @@
         }
       ]
     },
+    "stylus": {
+      "transformGroup": "css",
+      "buildPath": "dist/web/",
+      "files": [
+        {
+          "destination": "tokens.styl",
+          "format": "stylus/variables"
+        }
+      ]
+    },
     "js": {
       "transformGroup": "js",
       "buildPath": "dist/web/",

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/design-tokens",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Design tokens for Cockroach Labs.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Export stylus tokens for use in db console
Motivated by https://github.com/cockroachdb/cockroach/issues/72674