### PR TITLE
design-tokens: Added a prepublishOnly script

### DIFF
--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "build": "style-dictionary build",
     "clean": "style-dictionary clean",
+    "prepublishOnly": "npm run clean && npm run build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "license": "MIT",


### PR DESCRIPTION
Added a prepublishOnly script to ensure that tokens are built on package
publish.