### PR TITLE
ui-components: address export warnings during build

### DIFF
--- a/packages/ui-components/src/Input/index.ts
+++ b/packages/ui-components/src/Input/index.ts
@@ -1,9 +1,5 @@
 export * from "./Field";
 export * from "./EmailPasswordInput";
 export * from "./CheckboxInput";
-export {
-  SingleLineTextInput as TextInput,
-  TextInputProps,
-  NumberInput,
-  NumberProps,
-} from "./TextTypeInput";
+export { SingleLineTextInput as TextInput, NumberInput } from "./TextTypeInput";
+export type { TextInputProps, NumberProps } from "./TextTypeInput";


### PR DESCRIPTION
The types in `Input/index.ts` are not exported separately to address
the below warnings.

```
WARNING in ./src/Input/index.ts 4:0-109
export 'TextInputProps' (reexported as 'TextInputProps') was not found
in './TextTypeInput' (possible exports: BaseTextInput,
MultilineTextInput, NumberInput, SingleLineTextInput)
 @ ./src/index.ts 4:0-25 4:0-25

WARNING in ./src/Input/index.ts 4:0-109
export 'NumberProps' (reexported as 'NumberProps') was not found in
'./TextTypeInput' (possible exports: BaseTextInput, MultilineTextInput,
NumberInput, SingleLineTextInput)
 @ ./src/index.ts 4:0-25 4:0-25
```