### PR TITLE
eslint-config, ui-components: add stricter rules to eslint config

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -41,6 +41,43 @@ module.exports = {
           { allow: ["arrowFunctions"] },
         ],
         "@typescript-eslint/no-unused-vars": "error",
+        "eqeqeq": ["error", "always", {"null": "ignore"}],
+        "@typescript-eslint/no-non-null-assertion": "error",
+        "@typescript-eslint/no-explicit-any": "error",
+        "@typescript-eslint/naming-convention": [
+          "error",
+          // matches the default config from @typescript-eslint/eslint-plugin@2
+          // as best as possible
+          {
+            "selector": "default",
+            "format": ["camelCase"],
+            "leadingUnderscore": "allow",
+            "trailingUnderscore": "allow"
+          },
+          {
+            "selector": "variable",
+            "format": ["camelCase", "UPPER_CASE", "PascalCase"],
+            "leadingUnderscore": "allow",
+            "trailingUnderscore": "allow"
+          },
+          {
+            "selector": "function",
+            "format": ["camelCase", "UPPER_CASE", "PascalCase"],
+            "leadingUnderscore": "allow",
+            "trailingUnderscore": "allow"
+          },
+          {"selector": "property",
+            "format": null
+          },
+          {
+            "selector": "enumMember",
+            "format": ["UPPER_CASE", "PascalCase"]
+          },
+          {
+            "selector": "typeLike",
+            "format": ["PascalCase"]
+          }
+        ]
       },
     },
   ],

--- a/packages/ui-components/src/Input/Field.tsx
+++ b/packages/ui-components/src/Input/Field.tsx
@@ -78,6 +78,7 @@ const InputField = ({
   validate,
   validateFields,
   name,
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   InputFieldComponent,
   ...inputProps
 }: InternalFieldProps) => {


### PR DESCRIPTION
We have been adding stricter rules to the eslint config in the
managed-service repo. Now that the eslint version has been updated, we
can update the rules as well.

There was one naming rule violation in the ui-components package that
is now ignored because the we are passing a component in as a prop. The
casing is correct.

I moved everything below https://github.com/cockroachlabs/managed-service/blob/master/console/.eslintrc.json#L6.
