### PR TITLE
Add ExpandableText component to ui-components

### DIFF
--- a/packages/storybook-ui-components/stories/ExpandableText.stories.tsx
+++ b/packages/storybook-ui-components/stories/ExpandableText.stories.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { storiesOf } from "@storybook/react";
+
+import { ExpandableText } from "@cockroachlabs/ui-components";
+
+const divWidth = "200px";
+const fourLinetext =
+  "Very very very very very very very very very very very very very very very very very very very long text.";
+
+storiesOf("ExpandableText", module)
+  .add("Default", () => (
+    <div style={{ width: divWidth }}>
+      <ExpandableText text={fourLinetext} />
+    </div>
+  ))
+  .add("2 lines", () => (
+    <div style={{ width: divWidth }}>
+      <ExpandableText text={fourLinetext} maxLine={2} />
+    </div>
+  ))
+  .add("Text does not exceed lines", () => (
+    <div style={{ width: divWidth }}>
+      <ExpandableText text={fourLinetext} maxLine={5} />
+    </div>
+  ));

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -30,6 +30,7 @@
     "@cockroachlabs/icons": "^0.5.2",
     "@popperjs/core": "^2.9.2",
     "npm-run-all": "^4.1.5",
+    "react-lines-ellipsis": "^0.15.0",
     "react-popper": "^2.2.5"
   },
   "devDependencies": {
@@ -49,6 +50,7 @@
     "@types/lodash": "4.14.181",
     "@types/node": "16.11.26",
     "@types/react": "17.0.43",
+    "@types/react-lines-ellipsis": "0.15.1",
     "@typescript-eslint/eslint-plugin": "5.18.0",
     "@typescript-eslint/parser": "5.18.0",
     "babel-loader": "8.2.4",

--- a/packages/ui-components/src/ExpandableText/ExpandableText.module.scss
+++ b/packages/ui-components/src/ExpandableText/ExpandableText.module.scss
@@ -1,0 +1,10 @@
+@import "../styles/tokens.scss";
+
+.anchor {
+  color: $color-font-link-base;
+  fill: $color-font-link-base;
+  &:hover {
+    color: $color-font-link-hover;
+    fill: $color-font-link-hover;
+  }
+}

--- a/packages/ui-components/src/ExpandableText/ExpandableText.tsx
+++ b/packages/ui-components/src/ExpandableText/ExpandableText.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useState } from "react";
+import styles from "./ExpandableText.module.scss";
+import classNames from "classnames/bind";
+import LinesEllipsis from "react-lines-ellipsis";
+
+interface ExpandableTextProps {
+  text: string;
+  maxLine: number;
+}
+
+const cx = classNames.bind(styles);
+
+export function ExpandableText({
+  text,
+  maxLine,
+}: ExpandableTextProps): React.ReactElement {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  useEffect(() => {
+    // When the text changes, reset to the default of isExpanded=false.
+    // This is needed in case the text changes without re-mounting the component.
+    setIsExpanded(false);
+  }, [text]);
+
+  return (
+    <>
+      {!isExpanded && (
+        <LinesEllipsis
+          text={text}
+          maxLine={maxLine}
+          /**
+           * The type definition for the ellipsis prop (https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-lines-ellipsis/index.d.ts#L14)
+           * does not match the component behavior or the docs (https://github.com/xiaody/react-lines-ellipsis#propsellipsis-node),
+           * which says that ellipsis takes type Node.
+           */
+          ellipsis={
+            (
+              <>
+                {"… "}
+                <a
+                  className={cx("crl-anchor")}
+                  onClick={() => {
+                    setIsExpanded(true);
+                  }}
+                >
+                  Show More
+                </a>
+              </>
+            ) as unknown as string
+          }
+        />
+      )}
+      {isExpanded && (
+        <div>
+          {text}{" "}
+          <a className={cx("anchor")} onClick={() => setIsExpanded(false)}>
+            Show Less
+          </a>
+        </div>
+      )}
+    </>
+  );
+}
+
+export default ExpandableText;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2788,11 +2788,12 @@
     minimist "^1.2.0"
 
 "@cockroachlabs/ui-components@link:packages/ui-components":
-  version "0.3.5-alpha.2"
+  version "0.3.5-alpha.3"
   dependencies:
     "@cockroachlabs/icons" "^0.5.2"
     "@popperjs/core" "^2.9.2"
     npm-run-all "^4.1.5"
+    react-lines-ellipsis "^0.15.0"
     react-popper "^2.2.5"
 
 "@discoveryjs/json-ext@^0.5.0":
@@ -5239,6 +5240,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
   integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
 
+"@types/lodash@*":
+  version "4.14.182"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.182.tgz#05301a4d5e62963227eaafe0ce04dd77c54ea5c2"
+  integrity sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==
+
 "@types/lodash@4.14.181":
   version "4.14.181"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.181.tgz#d1d3740c379fda17ab175165ba04e2d03389385d"
@@ -5344,6 +5350,14 @@
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.13.tgz#a3323b974ee4280070982b3112351bb1952a7809"
   integrity sha512-wEP+B8hzvy6ORDv1QBhcQia4j6ea4SFIBttHYpXKPFZRviBvknq0FRh3VrIxeXUmsPkwuXVZrVGG7KUVONmXCQ==
   dependencies:
+    "@types/react" "*"
+
+"@types/react-lines-ellipsis@0.15.1":
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/@types/react-lines-ellipsis/-/react-lines-ellipsis-0.15.1.tgz#7bc47dbe12e7fe16de2ecb33134b270fbb88802a"
+  integrity sha512-j0lZ5UyO1ShIs2Fk2OfvmUBc1s5gUP3/5n6pHnRCVKLvSfensCBJVqXNa1Tzlcgf6BE31wfEfmn22QrSlnSBnw==
+  dependencies:
+    "@types/lodash" "*"
     "@types/react" "*"
 
 "@types/react-syntax-highlighter@11.0.5":
@@ -14275,6 +14289,11 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-lines-ellipsis@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/react-lines-ellipsis/-/react-lines-ellipsis-0.15.0.tgz#07ecc8095f7d598e676ee662c637bd373f3552f4"
+  integrity sha512-8kWpEmu7ijmB6Gz5t+eSjNux2SpVXZBsmfeFE8LjMS7tU3H8ai475CyNc0dH0RDTwt4Esr7c06Xq4SB7Gpl9yQ==
 
 react-popper-tooltip@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
This commit adds an ExpandableText component to ui-components.

<!--
  Please add a title to your Pull Request with the package the changes
  occured in.
-->
# ui-components // Add ExpandableText component

Collapsed:
<img width="214" alt="image" src="https://user-images.githubusercontent.com/91907326/171226111-15484ab7-0281-412d-8f5a-c19e2579f6a2.png">

Expanded:
<img width="209" alt="image" src="https://user-images.githubusercontent.com/91907326/171226143-22cbb41a-fa15-4732-98a7-a84911d0b0d6.png">

Does not exceed length:
<img width="213" alt="image" src="https://user-images.githubusercontent.com/91907326/171226187-38d669d3-01f7-4008-9ad6-b9af0b4623c0.png">

<!--
  Please describe your changes by describing motivation, linking to issues,
  and adding screenshots or gifs to illustrate your changes for reviewers
 -->
This component was added for https://github.com/cockroachdb/cockroach/pull/81180#issuecomment-1134899951, for the Job details error table.
It is being added in this repo per [this conclusion](https://cockroachlabs.slack.com/archives/C3T5LG9R8/p1645029579140249?thread_ts=1644965483.606339&cid=C3T5LG9R8):

> So, tl;dr for using db-console/cluster-ui components in managed-service:
> - For components (e.g. SQL Activity pages) that are specific to a database version and its APIs, they should live in cluster-ui and be imported in managed-service using componentFactory. This does a dynamic import that allows cluster-ui to be bundled separately from the main managed-service bundle
> - For generic components (e.g. Tooltips, SqlBox) that are not tied to a specific database version, they should ideally be moved to https://github.com/cockroachdb/ui. This allows them to be shared across db-console, cluster-ui, and managed-service
>   - As a fallback alternative, the code for these components can be duplicated in the managed-service repo, at the cost of code duplication

#### Checklist
- [x] I have written or updated test for the changes I made
- [ ] I have updated the README of the package I'm working in to reflect my changes
- [x] I have added or updated Storybook if appropriate for my changes

