### PR TITLE
design-tokens: add color tokens with branding names

### DIFF
--- a/packages/design-tokens/tokens/color/core.json
+++ b/packages/design-tokens/tokens/color/core.json
@@ -56,5 +56,15 @@
         "5": { "value": "#99000f" }
       }
     }
+  },
+  "brand": {
+    "dark-blue": { "value": "#0037a5" },
+    "iridescent-blue": { "value": "#00fced" },
+    "action-blue": { "value": "#0055ff" },
+    "light-blue": { "value": "#c2d5ff" },
+    "deep-purple": { "value": "#190f33" },
+    "action-purple": { "value": "#b921f1" },
+    "light-purple": { "value": "#f7d6ff" },
+    "electric-purple": { "value": "#6933ff" }
   }
 }


### PR DESCRIPTION
This PR adds a series of colors that are defined in our internal
branding documents. Currently, they're not under the standard format of
`ColorBase<Name><number>` as I felt that naming them under the
design-system format caused a lot of headaches in going back and forth
deciding colors.

These tokens are intended to be used in things like Graphics, and more
visual use cases. Naming them by the color name is intended to speed up
visual work by not needing to reference an external hex + branding doc
using the `tokens.js` file. I'm not super tied to it, and if we'd rather
have the same number naming under a "brand" nest I'd be happy with that
as well.

Some of these tokens are duplicates, of existing design system ones
above. Some of them are new to the `ui` repository. The final exported
output of variable names looks like:

```
export const BrandDarkBlue = "#0037a5";
export const BrandIridescentBlue = "#00fced";
export const BrandActionBlue = "#0055ff";
export const BrandLightBlue = "#c2d5ff";
export const BrandDeepPurple = "#190f33";
export const BrandActionPurple = "#b921f1";
export const BrandLightPurple = "#f7d6ff";
export const BrandElectricPurple = "#6933ff";
```

Release note: None

<!--
  Please add a title to your Pull Request with the package the changes
  occured in.
-->
# PACKAGE // TITLE

<!--
  Please describe your changes by describing motivation, linking to issues,
  and adding screenshots or gifs to illustrate your changes for reviewers
 -->

#### Checklist
- [x] I have written or updated test for the changes I made
- [x] I have updated the README of the package I'm working in to reflect my changes
- [x] I have added or updated Storybook if appropriate for my changes

