### PR TITLE
UI Components: Added `debug` prop to Badge

### DIFF
--- a/packages/ui-components/src/Badge/Badge.tsx
+++ b/packages/ui-components/src/Badge/Badge.tsx
@@ -11,6 +11,7 @@ export type BadgeIntent = "neutral" | "success" | "warning" | "danger" | "info";
 interface OwnBadgeProps {
   intent?: BadgeIntent;
   transformCase?: BadgeCase;
+  debug?: boolean;
 }
 type NativeDivProps = Omit<
   React.HTMLAttributes<HTMLDivElement>,
@@ -24,6 +25,7 @@ const cx = classNames.bind(styles);
 export const Badge: FunctionComponent<BadgeProps> = ({
   intent = "neutral",
   transformCase = "uppercase",
+  debug = false,
   children,
   className,
   ...props
@@ -37,6 +39,12 @@ export const Badge: FunctionComponent<BadgeProps> = ({
   if (children !== undefined) {
     return (
       <div className={classnames} {...props}>
+        {debug && (
+          <pre>
+            intent :: {intent}
+            transformCase :: {transformCase}
+          </pre>
+        )}
         {children}
       </div>
     );


### PR DESCRIPTION
# UI Components // Added debug prop to Badge

Added a boolean prop to Badge that when set to true will render the value of props to a `<pre>` tag inside the Badge.


**What I'm really doing is making a change to a component to test the automated publishing flow
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @cockroachlabs/ui-components@0.3.12-canary.482.53981b4.0
  # or 
  yarn add @cockroachlabs/ui-components@0.3.12-canary.482.53981b4.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
