### PR TITLE
[CC-6325]ui-components: remove timeout from tooltip

### DIFF
--- a/packages/ui-components/src/Tooltip/Tooltip.tsx
+++ b/packages/ui-components/src/Tooltip/Tooltip.tsx
@@ -29,7 +29,6 @@ export interface TooltipProps {
   style?: TooltipStyle;
   content: ReactElement | string;
   visible?: boolean;
-  timeout?: number;
 }
 
 export const Tooltip: FunctionComponent<TooltipProps> = ({
@@ -38,7 +37,6 @@ export const Tooltip: FunctionComponent<TooltipProps> = ({
   children,
   content,
   visible = false,
-  timeout = 500,
 }) => {
   const [referenceElement, setReferenceElement] = useState(null);
   const [popperElement, setPopperElement] = useState(null);
@@ -81,21 +79,14 @@ export const Tooltip: FunctionComponent<TooltipProps> = ({
     );
   });
 
-  const timers: Array<ReturnType<typeof setTimeout>> = [];
   return (
     <div
       ref={setReferenceElement}
       onMouseOver={() => {
-        const t = setTimeout(() => {
-          popperElement.setAttribute("data-show", "");
-        }, timeout);
-        timers.push(t);
+        popperElement.setAttribute("data-show", "");
       }}
       onMouseLeave={() => {
-        timers.forEach((t: ReturnType<typeof setTimeout>) => {
-          clearTimeout(t);
-          popperElement.removeAttribute("data-show");
-        });
+        popperElement.removeAttribute("data-show");
       }}
     >
       {wrappedChildren}


### PR DESCRIPTION
The timeout from the Tooltip component was causing the component to stick for longer than it should.
This commit removes the timeout, until a better solution is made.

Part Of https://cockroachlabs.atlassian.net/browse/CC-6325

Before
https://www.loom.com/share/3f645bba0419429f9b92d946d0538e54

After
https://www.loom.com/share/3ec548eb22624cd8b0fe543cc7d3d7b1