### PR TITLE
ui-components: Fixing type compatibility in InlineAlerts

### DIFF
--- a/packages/ui-components/src/InlineAlert/InlineAlert.tsx
+++ b/packages/ui-components/src/InlineAlert/InlineAlert.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from "react";
 import classNames from "classnames/bind";
 
 import styles from "./InlineAlert.module.scss";
-import { Icon } from "../Icon/Icon";
+import { Icon, IconFill } from "../Icon/Icon";
 import { Text } from "../Typography";
 
 const cx = classNames.bind(styles);
@@ -49,7 +49,11 @@ export const InlineAlert: React.FC<InlineAlertProps> = ({
   return (
     <div className={cx("root", `intent-${intent}`, className)}>
       <div className={cx("icon-container")}>
-        <Icon iconName={iconName} size="default" fill={intent} />
+        <Icon
+          iconName={iconName}
+          size="default"
+          fill={String(intent) as IconFill}
+        />
       </div>
       <div className={cx("container")}>
         {title && (


### PR DESCRIPTION
The intent prop (of type InlineAlertIntent) was being passed directly to
the Icon component's fill prop (of type IconFill). InlineAlertIntent is
compatible as a subset of IconFill (which is a union of IconIntent and
some string types), but are clearly different types and not
interchangable.

The fix is to cast the InlineAlertIntent to a string and then pass the
string cast as an IconFill.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @cockroachlabs/ui-components@0.4.2-canary.499.3859477258.0
  # or 
  yarn add @cockroachlabs/ui-components@0.4.2-canary.499.3859477258.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
