### PR TITLE
ui: fix icon alignment on inline alert

### DIFF
--- a/packages/ui-components/src/InlineAlert/InlineAlert.module.scss
+++ b/packages/ui-components/src/InlineAlert/InlineAlert.module.scss
@@ -16,11 +16,12 @@
 }
 
 .title {
-  margin-bottom: crl-gutters(0.5);
+  margin-bottom: 0px;
 }
 
 .icon-container {
   padding: 0 crl-gutters(2);
+  display: flex;
 }
 
 .intent-info {


### PR DESCRIPTION
This commit fixes the alignment of the icon
on the inlineAlert component.

Before
<img width="1519" alt="Screenshot 2023-02-15 at 5 49 54 PM" src="https://user-images.githubusercontent.com/1017486/219210308-e22aba4e-eb8c-4e8e-8abb-ca8098960178.png">
<img width="235" alt="Screenshot 2023-02-15 at 5 55 18 PM" src="https://user-images.githubusercontent.com/1017486/219211143-2f46e864-b3d9-4816-ba03-75166b9be2f8.png">
<img width="205" alt="Screenshot 2023-02-15 at 6 02 23 PM" src="https://user-images.githubusercontent.com/1017486/219211233-6e5bf42a-b577-49cf-a164-d90a82ede9b0.png">


After
<img width="1516" alt="Screenshot 2023-02-15 at 5 50 03 PM" src="https://user-images.githubusercontent.com/1017486/219210403-97de5b44-e1e0-4ae6-84b4-708fa0160092.png">
<img width="337" alt="Screenshot 2023-02-15 at 5 54 57 PM" src="https://user-images.githubusercontent.com/1017486/219210625-96416c1c-8fcf-4cd5-b7bd-4b5f6e44dc35.png">
<img width="360" alt="Screenshot 2023-02-15 at 5 51 34 PM" src="https://user-images.githubusercontent.com/1017486/219210910-2235f1ce-8713-4a15-93d2-78fbe9055c0a.png">

Epic: None
Release note: None