### PR TITLE
Remove `-v` from release command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create Release
-        env: #Tokens generated under github account: https://github.com/nathanstilwell
+        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "init": "yarn install && yarn lerna run build",
     "start": "lerna run start --parallel",
-    "release": "auto shipit -v"
+    "release": "auto shipit"
   },
   "resolutions": {},
   "workspaces": [


### PR DESCRIPTION
Releasing seems pretty stable, so we can reduce the noise in the logs

