### PR TITLE
ui-components: Remove margin from Icon

### DIFF
--- a/packages/ui-components/src/Icon/Icon.module.scss
+++ b/packages/ui-components/src/Icon/Icon.module.scss
@@ -2,7 +2,6 @@
 
 .icon {
   fill: $color-core-neutral-7;
-  margin: auto;
 
   &:disabled {
     pointer-events: none;


### PR DESCRIPTION
Having a default `margin` is causing far more trouble than it's worth. Something with the way that CSS modules are composed, doesn't allow internal Icon styles to be overridden easily. We're better off having implementors add their own margins.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @cockroachlabs/ui-components@0.6.5-canary.513.4493441166.0
  # or 
  yarn add @cockroachlabs/ui-components@0.6.5-canary.513.4493441166.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
