### PR TITLE
eslint-config: warn console.log statements when committed

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -13,6 +13,7 @@ module.exports = {
     es6: true,
   },
   rules: {
+    "no-console": ["warn", { allow: ["warn", "error"] }],
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "error",
     "prettier/prettier": [


### PR DESCRIPTION
We're seeing a decent amount of PR reviews comment on stray console.logs. We can just stop that at the source with an eslint configuration.

Setting this to `warn` to not prevent or halt any builds upstream if DBConsole has any console.logs in the repo. IIRC we cleared it for cloud a bit ago.

Release note: None
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @cockroachlabs/eslint-config@1.0.6-canary.516.4597826625.0
  npm install @cockroachlabs/ui-components@0.7.1-canary.516.4597826625.0
  # or 
  yarn add @cockroachlabs/eslint-config@1.0.6-canary.516.4597826625.0
  yarn add @cockroachlabs/ui-components@0.7.1-canary.516.4597826625.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
