### PR TITLE
tokens: introduce blue-gray tokens to design system

### DIFF
--- a/packages/design-tokens/tokens/color/core.json
+++ b/packages/design-tokens/tokens/color/core.json
@@ -54,6 +54,13 @@
         "3": { "value": "#ff3b4e" },
         "4": { "value": "#c32534" },
         "5": { "value": "#99000f" }
+      },
+      "blue-gray": {
+        "1": { "value": "#828391" },
+        "2": { "value": "#696b7b" },
+        "3": { "value": "#56586a" },
+        "4": { "value": "#3b3e53" },
+        "5": { "value": "#131522" }
       }
     }
   },
@@ -65,6 +72,7 @@
     "deep-purple": { "value": "#190f33" },
     "action-purple": { "value": "#b921f1" },
     "light-purple": { "value": "#f7d6ff" },
-    "electric-purple": { "value": "#6933ff" }
+    "electric-purple": { "value": "#6933ff" },
+    "electric-teal": { "value": "#58ffd2" }
   }
 }


### PR DESCRIPTION
Introduces a few new color tokens to the design system for use in Onboarding on Cockroach Cloud. Also introduces a teal used for highlighting text and icons.

Release note: None

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @cockroachlabs/design-tokens@0.4.12-canary.520.5126452973.0
  npm install @cockroachlabs/ui-components@0.7.2-canary.520.5126452973.0
  # or 
  yarn add @cockroachlabs/design-tokens@0.4.12-canary.520.5126452973.0
  yarn add @cockroachlabs/ui-components@0.7.2-canary.520.5126452973.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
