### PR TITLE
ui-components, icons: bump package version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,17 +12,17 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci') && !github.event.pull_request.head.repo.fork }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v3
         with:
           version: 8.6
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 16
           cache: "pnpm"
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
           cache: "pnpm"
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "root",
   "private": true,
   "devDependencies": {
-    "auto": "11.0.4",
+    "auto": "11.1.6",
     "lerna": "^7.2.0"
   },
   "scripts": {

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/icons",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "description": "Icons for Cockroach UI exported as React Components",
   "files": [
     "dist/"

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -176,6 +176,7 @@ import India from "./components/India";
 import Indonesia from "./components/Indonesia";
 import Ireland from "./components/Ireland";
 import Israel from "./components/Israel";
+import Italy from "./components/Italy";
 import Japan from "./components/Japan";
 import Korea from "./components/Korea";
 import Netherlands from "./components/Netherlands";
@@ -332,6 +333,7 @@ const Flags = {
   Indonesia,
   Ireland,
   Israel,
+  Italy,
   Japan,
   Korea,
   Netherlands,
@@ -465,6 +467,7 @@ export {
   India,
   Ireland,
   Israel,
+  Italy,
   Japan,
   Korea,
   Netherlands,

--- a/packages/icons/svg/preserveFill/italy.svg
+++ b/packages/icons/svg/preserveFill/italy.svg
@@ -1,0 +1,10 @@
+<svg width="28" height="20" viewBox="0 0 28 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="0.25" y="0.25" width="27.5" height="19.5" rx="1.75" fill="white" stroke="#F5F5F5" stroke-width="0.5"/>
+<mask id="mask0_11035_21713" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="28" height="20">
+<rect x="0.25" y="0.25" width="27.5" height="19.5" rx="1.75" fill="white" stroke="white" stroke-width="0.5"/>
+</mask>
+<g mask="url(#mask0_11035_21713)">
+<rect x="18.6667" width="9.33333" height="20" fill="#E43D4C"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M0 20H9.33333V0H0V20Z" fill="#1BB65D"/>
+</g>
+</svg>

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/ui-components",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "description": "UI Components is a reusable component library. It provides the core components for the Cockroach design system.",
   "repository": {
     "type": "git",

--- a/packages/ui-components/src/Icon/Flag.tsx
+++ b/packages/ui-components/src/Icon/Flag.tsx
@@ -50,6 +50,7 @@ export const flagNameCountryCodeMap: Array<{
   { code: "idn", flag: "Indonesia" },
   { code: "irl", flag: "Ireland" },
   { code: "isr", flag: "Israel" },
+  { code: "ita", flag: "Italy" },
   { code: "jpn", flag: "Japan" },
   { code: "kor", flag: "Korea" },
   { code: "nld", flag: "Netherlands" },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ importers:
   .:
     devDependencies:
       auto:
-        specifier: 11.0.4
-        version: 11.0.4(@types/node@16.18.14)(typescript@5.2.2)
+        specifier: 11.1.6
+        version: 11.1.6(@types/node@16.18.14)(typescript@5.2.2)
       lerna:
         specifier: ^7.2.0
         version: 7.2.0
@@ -275,7 +275,7 @@ importers:
         version: 1.58.3
       ts-jest:
         specifier: 29.1.1
-        version: 29.1.1(@babel/core@7.22.5)(jest@29.4.3)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.21.0)(jest@29.4.3)(typescript@5.2.2)
       typescript:
         specifier: 5.x
         version: 5.2.2
@@ -298,13 +298,13 @@ packages:
       '@jridgewell/trace-mapping': 0.3.17
     dev: true
 
-  /@auto-it/bot-list@11.0.4:
-    resolution: {integrity: sha512-f3w9UZ655MLiELUQP28K9Gceptf2vvKdKVRzh2b2ST+PG/srmoxCnHgE/TO9afW7NiuUA1h+hQVyIb0eQ9VSfQ==}
+  /@auto-it/bot-list@11.1.6:
+    resolution: {integrity: sha512-3Qdphiw9JlzYX15moLZSaP+jNuM3UAFDHTgIpsfnfIQwQDNSjZhM4rwxqsAY/r1mJAyxt16c6wbqisi7KNFD/A==}
     engines: {node: '>=10.x'}
     dev: true
 
-  /@auto-it/core@11.0.4(@types/node@16.18.14)(typescript@5.2.2):
-    resolution: {integrity: sha512-oYIByeGeuiM0MhWibbj3Y4Vj8p5Kt1n4g0hKL7Zu7oFlKmAjsZlwbH4z0wEjVTdK2+Eqg2/I1Dj/GgkiSriXgg==}
+  /@auto-it/core@11.1.6(@types/node@16.18.14)(typescript@5.2.2):
+    resolution: {integrity: sha512-bxiUXJVyRYs7Bf4DH/JLT5pdR14RYSpoX0eBw0ilkU9qNqylTCbThuKofM7Bqn7jaQF2PDUoC72c8xCkqvHGQg==}
     peerDependencies:
       '@types/node': '*'
       typescript: '>=2.7'
@@ -312,7 +312,7 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@auto-it/bot-list': 11.0.4
+      '@auto-it/bot-list': 11.1.6
       '@endemolshinegroup/cosmiconfig-typescript-loader': 3.0.2(cosmiconfig@7.0.0)(typescript@5.2.2)
       '@octokit/core': 3.6.0
       '@octokit/plugin-enterprise-compatibility': 1.3.0
@@ -361,11 +361,11 @@ packages:
       - supports-color
     dev: true
 
-  /@auto-it/npm@11.0.4(@types/node@16.18.14)(typescript@5.2.2):
-    resolution: {integrity: sha512-7sKGswdhQZ0/EryFhMU8DZV/hKZSZTOhJnNTXBtCGRk7oLjRHjt6XVOWCMOMOCNO/wVn5k5r52DbhAy5V4i0GQ==}
+  /@auto-it/npm@11.1.6(@types/node@16.18.14)(typescript@5.2.2):
+    resolution: {integrity: sha512-eFWzR+6N1lMSXi32BunnlIdXIFikX6mieaFLmPk9VNM4vOXqsfkc7BQ0xhsZRsn5sxSR/XBwlQXoExAHybjs3g==}
     dependencies:
-      '@auto-it/core': 11.0.4(@types/node@16.18.14)(typescript@5.2.2)
-      '@auto-it/package-json-utils': 11.0.4
+      '@auto-it/core': 11.1.6(@types/node@16.18.14)(typescript@5.2.2)
+      '@auto-it/package-json-utils': 11.1.6
       await-to-js: 3.0.0
       endent: 2.1.0
       env-ci: 5.5.0
@@ -387,19 +387,19 @@ packages:
       - typescript
     dev: true
 
-  /@auto-it/package-json-utils@11.0.4:
-    resolution: {integrity: sha512-Y84CW2QSL1TXkc4cVajODhRFFixDhOGX4JBS/ic3TgeJ94h6QH0Q8so+FxzPwBDWGXmUdLsj8fY/A3n0X09lqA==}
+  /@auto-it/package-json-utils@11.1.6:
+    resolution: {integrity: sha512-RSXmO+KegaEY7uw1vt8iXL9FShiinFigKNFuIWM9oLSaSHJfeQ2ZD291i9nV+tz86bPGySBb5ktdJ3uo2pAZ+Q==}
     engines: {node: '>=10.x'}
     dependencies:
       parse-author: 2.0.0
       parse-github-url: 1.0.2
     dev: true
 
-  /@auto-it/released@11.0.4(@types/node@16.18.14)(typescript@5.2.2):
-    resolution: {integrity: sha512-BfzCr+rJvONgw5EtsmTfoPtjm7C6Yo+vKDiXtI82EctLfUuADV/wCE/zj5e1nACsELpqhqWfgLySvDu1n6bn6g==}
+  /@auto-it/released@11.1.6(@types/node@16.18.14)(typescript@5.2.2):
+    resolution: {integrity: sha512-RHTSjq5fAQxkhcC84aWItotyPGH67o+bzSxzr9H4mzvP8OrIxj7Jsfmk8wT4rjgupCTl9fu8DiGoCGjcQpCdCw==}
     dependencies:
-      '@auto-it/bot-list': 11.0.4
-      '@auto-it/core': 11.0.4(@types/node@16.18.14)(typescript@5.2.2)
+      '@auto-it/bot-list': 11.1.6
+      '@auto-it/core': 11.1.6(@types/node@16.18.14)(typescript@5.2.2)
       deepmerge: 4.2.2
       fp-ts: 2.12.3
       io-ts: 2.2.19(fp-ts@2.12.3)
@@ -413,10 +413,10 @@ packages:
       - typescript
     dev: true
 
-  /@auto-it/version-file@11.0.4(@types/node@16.18.14)(typescript@5.2.2):
-    resolution: {integrity: sha512-esKwslQPsPjFC96m0lI/MJI12OFjH92KXtVaQEguGIIXAhs7iop9+y5vLXjOtgNOFVBvk/FKTFItq2mV587aiA==}
+  /@auto-it/version-file@11.1.6(@types/node@16.18.14)(typescript@5.2.2):
+    resolution: {integrity: sha512-iDAK0IrCYFPDgkX4DGB97VFbiFEfxN+IMW1NiF+Qk7Kd3SX2899vwuFxyVvGwovX7ssuCi/4tSTrvx6PLhH6zw==}
     dependencies:
-      '@auto-it/core': 11.0.4(@types/node@16.18.14)(typescript@5.2.2)
+      '@auto-it/core': 11.1.6(@types/node@16.18.14)(typescript@5.2.2)
       fp-ts: 2.12.3
       io-ts: 2.2.19(fp-ts@2.12.3)
       semver: 7.5.4
@@ -9264,15 +9264,15 @@ packages:
     engines: {node: '>=0.8'}
     dev: true
 
-  /auto@11.0.4(@types/node@16.18.14)(typescript@5.2.2):
-    resolution: {integrity: sha512-jDe95fpOHZXRDe0HJMH1FvTrU0f3rXbee0eqNIAR2mB9EcdiWQTj1aF56R/xPyGLxF9y3WXzu38DgiIX9sjoDg==}
+  /auto@11.1.6(@types/node@16.18.14)(typescript@5.2.2):
+    resolution: {integrity: sha512-GKeZbFWPp7V9d+yWuFvaffVNyLSGFpR/+SrzXt29YKhg8axx5bKQKzbBN0eSzX5DLmhBwS81tWXS+SYpECil9Q==}
     engines: {node: '>=10.x'}
     hasBin: true
     dependencies:
-      '@auto-it/core': 11.0.4(@types/node@16.18.14)(typescript@5.2.2)
-      '@auto-it/npm': 11.0.4(@types/node@16.18.14)(typescript@5.2.2)
-      '@auto-it/released': 11.0.4(@types/node@16.18.14)(typescript@5.2.2)
-      '@auto-it/version-file': 11.0.4(@types/node@16.18.14)(typescript@5.2.2)
+      '@auto-it/core': 11.1.6(@types/node@16.18.14)(typescript@5.2.2)
+      '@auto-it/npm': 11.1.6(@types/node@16.18.14)(typescript@5.2.2)
+      '@auto-it/released': 11.1.6(@types/node@16.18.14)(typescript@5.2.2)
+      '@auto-it/version-file': 11.1.6(@types/node@16.18.14)(typescript@5.2.2)
       await-to-js: 3.0.0
       chalk: 4.1.2
       command-line-application: 0.10.1
@@ -17479,7 +17479,7 @@ packages:
     engines: {node: '>=6.10'}
     dev: true
 
-  /ts-jest@29.1.1(@babel/core@7.22.5)(jest@29.4.3)(typescript@5.2.2):
+  /ts-jest@29.1.1(@babel/core@7.21.0)(jest@29.4.3)(typescript@5.2.2):
     resolution: {integrity: sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -17500,7 +17500,7 @@ packages:
       esbuild:
         optional: true
     dependencies:
-      '@babel/core': 7.22.5
+      '@babel/core': 7.21.0
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       jest: 29.4.3(@types/node@16.18.14)


### PR DESCRIPTION
Bumping the version to release new flag additions.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @cockroachlabs/icons@0.7.13-canary.548.8653412450.0
  npm install @cockroachlabs/ui-components@0.7.14-canary.548.8653412450.0
  # or 
  yarn add @cockroachlabs/icons@0.7.13-canary.548.8653412450.0
  yarn add @cockroachlabs/ui-components@0.7.14-canary.548.8653412450.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
